### PR TITLE
Add automatic logo downloading, created Title class, other minor changes from dev branch

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ regex = "*"
 num2words = "*"
 pyyaml = "*"
 requests = "*"
+titlecase = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "54cd308fa6e6d23ee64414a566b32572c8995012595022d1c492aa0691f618b9"
+            "sha256": "9812e04f8861b3cba2b2c791b6b248bcb7f4b94af8945782d171dfcf8bb8efd2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -179,6 +179,14 @@
             ],
             "index": "pypi",
             "version": "==2.27.1"
+        },
+        "titlecase": {
+            "hashes": [
+                "sha256:037be1a542634d5582735c949f3b247bfc878a4f21c76957ae42167a398c9dce",
+                "sha256:9a1595ed9b88f3ce4362a7602ee63cf074e10ac80d1256b32ea1ec5ffa265fa0"
+            ],
+            "index": "pypi",
+            "version": "==2.3"
         },
         "urllib3": {
             "hashes": [

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 
+from titlecase import titlecase
+
 from modules.ImageMaker import ImageMaker
 
 class CardType(ImageMaker):
@@ -13,7 +15,7 @@ class CardType(ImageMaker):
     CardTypes need to use every argument of these methods. For example, the
     StandardTitleCard utilizes most all customizations for a title card (i.e.
     custom fonts, colors, sizing, season titles, etc.), while a
-    StarWarsTitleCard doesn't use anything except the episode number and title.
+    StarWarsTitleCard doesn't use anything except the episode title and number.
     """
 
     """Default case for all episode text"""
@@ -23,7 +25,7 @@ class CardType(ImageMaker):
     CASE_FUNCTION_MAP = {
         'upper': str.upper,
         'lower': str.lower,
-        'title': str.title,
+        'title': titlecase,
     }
 
     """Standard size for a title card"""

--- a/modules/GenreMaker.py
+++ b/modules/GenreMaker.py
@@ -43,8 +43,8 @@ class GenreMaker(ImageMaker):
 
     def __resize_source(self) -> Path:
         """
-        Resize the source file for this card into the necessary
-        dimensions (946x1446).
+        Resize the source file for this card into the necessary dimensions
+        (946x1446).
         
         :returns:   Path to the created image.
         """
@@ -64,9 +64,9 @@ class GenreMaker(ImageMaker):
 
     def __add_gradient(self, resized_source: Path) -> Path:
         """
-        Adds a gradient.
+        Add the static gradient image to the given resized image.
         
-        :param      resized_source:  The resized source
+        :param      resized_source: Path to the image to add a gradient to.
         
         :returns:   Path to the created image.
         """
@@ -86,9 +86,9 @@ class GenreMaker(ImageMaker):
 
     def __add_text_and_border(self, source_with_gradient: Path) -> Path:
         """
-        Adds a text and border.
+        Add the genre text and the white border to the given image.
         
-        :param      source_with_gradient:   The source image with gradient
+        :param      source_with_gradient:   The source image with the gradient
                                             applied.
         
         :returns:   Path to the created image.
@@ -114,13 +114,14 @@ class GenreMaker(ImageMaker):
         
     def create(self) -> None:
         """
-        Create the genre card. This WILL overwrite the existing file if it already
-        exists. Errors and returns if the image source does not exist.
+        Create the genre card. This WILL overwrite the existing file if it 
+        already exists. Errors and returns if the image source does not exist.
         """
 
         # If the source file doesn't exist, exit
         if not self.source.exists():
-            error(f'Cannot create genre card, "{self.source.resolve()}" does not exist.')
+            error(f'Cannot create genre card, "{self.source.resolve()}" does '
+                  f'not exist.')
             return None
         
         # Resize source to fit in contrained space
@@ -133,5 +134,8 @@ class GenreMaker(ImageMaker):
         output = self.__add_text_and_border(source_with_gradient)
 
         # Delete intermediate files
-        self.image_magick.delete_intermediate_images(resized_source, source_with_gradient)
+        self.image_magick.delete_intermediate_images(
+            resized_source,
+            source_with_gradient
+        )
 

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -20,8 +20,8 @@ class ImageMagickInterface:
 
     def __init__(self, docker_id: str=None) -> None:
         """
-        Constructs a new instance. If docker_id is None/0/False, then
-        commands will not use a docker container.
+        Constructs a new instance. If docker_id is None/0/False, then commands
+        will not use a docker container.
         
         :param      docker_id:  The docker ID for sending requests to
                                 ImageMagick.
@@ -62,24 +62,25 @@ class ImageMagickInterface:
 
     def run_get_stdout(self, command: str, *args: tuple, **kwargs: dict) -> str:
         """
-        Wrapper for `run()`, but return the byte-decoded stdout immediately.
+        Wrapper for run(), but return the byte-decoded stdout.
         
-        :param      command:    The command being executed.
-        :param      args:       The arguments to pass to `subprocess.run()`.
-        :param      kwargs:     The keywords arguments to pass to `subprocess.run()`.
+        :param      command:            The command being executed.
+        :param      args and kwargs:    Generalized arguments to pass to
+                                        `subprocess.run()`.
 
         :returns:   The decoded stdout output of the executed command.
         """
 
-        return self.run(command, capture_output=True, *args, **kwargs).stdout.decode()
+        return self.run(
+            command, capture_output=True, *args, **kwargs
+        ).stdout.decode()
 
 
     def delete_intermediate_images(self, *paths: tuple) -> None:
         """
-        Delete all the provided files.
+        Delete all the provided intermediate files.
         
-        :param      paths:  Any number of files to delete. Must be
-                            Path objects.
+        :param      paths:  Any number of files to delete. Must be Path objects.
         """
 
         # Delete (unlink) each image, don't raise FileNotFoundError if DNE

--- a/modules/ImageMaker.py
+++ b/modules/ImageMaker.py
@@ -37,5 +37,4 @@ class ImageMaker(ABC):
         This method should delete any intermediate files, and should make
         ImageMagick calls through the parent class' ImageMagickInterface object.
         """
-
-        pass
+        raise NotImplementedError(f'All ImageMaker objects must implement this')

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -24,6 +24,7 @@ class PlexInterface:
                                     if the host device is untrusted.
         """
 
+        # Store base url and parameters to use for most requests
         url = url + ('' if url.endswith('/') else '/')
         self.base_url = url + 'library/'
         self.base_params = {'X-Plex-Token': x_plex_token}
@@ -35,7 +36,9 @@ class PlexInterface:
 
     def parse_plex_library(self) -> None:
         """
-        Parse the associated plex library 
+        Parse the associated plex library. This queries Plex to get a list of
+        all libraries, and then stores the content of that library for future
+        reference.
         """
         
         url = self.base_url + 'sections'
@@ -102,7 +105,7 @@ class PlexInterface:
         :param      full_title: The full title of the content to refresh.
         """
 
-        # Match based on the stripped full title
+        # Do matching on the a-z 0-9 title only
         match_title = Show.strip_specials(full_title)
 
         # Invalid library - error and exit

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -44,6 +44,7 @@ class PreferenceParser:
         self.create_summaries = False
         self.summary_background_color = ShowSummary.BACKGROUND_COLOR
         self.logo_filename = ShowSummary.LOGO_FILENAME
+        self.summary_minimum_episode_count = 1
         self.use_plex = False
         self.plex_url = None
         self.plex_token = 'NA'
@@ -117,6 +118,14 @@ class PreferenceParser:
 
         if self.__is_specified('archive', 'summary', 'logo_filename'):
             self.logo_filename = self.__yaml['archive']['summary']['logo_filename']
+
+        if self.__is_specified('archive', 'summary', 'minimum_episodes'):
+            value = self.__yaml['archive']['summary']['minimum_episodes']
+            try:
+                self.summary_minimum_episode_count = int(value)
+            except ValueError:
+                error(f'Summary minimum episode count "{value}" is invalid')
+                self.valid = False
 
         if self.__is_specified('plex', 'url'):
             self.plex_url = self.__yaml['plex']['url']

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -9,9 +9,8 @@ from modules.TMDbInterface import TMDbInterface
 
 class PreferenceParser:
     """
-    This class describes a preference parser that reads a given preference
-    YAML file and parses it into individual attributes such as whether to use Plex,
-    the TMDb API key, etc.
+    This class describes a preference parser that reads a given preference YAML
+    file and parses it into individual attributes.
     """
 
     def __init__(self, file: Path) -> None:
@@ -36,7 +35,7 @@ class PreferenceParser:
             exit(1)
         self.source_directory = Path(self.__yaml['options']['source'])
 
-        ## Setup default values that can be overwritten by YAML
+        # Setup default values that can be overwritten by YAML
         self.series_files = []
         self.card_type = 'standard'
         self.archive_directory = None
@@ -57,7 +56,7 @@ class PreferenceParser:
         self.tmdb_minimum_resolution = {'width': 0, 'height': 0}
         self.imagemagick_docker_id = None
 
-        # Modify object attributes based off YAML
+        # Modify object attributes based off YAML, assume valid to start
         self.valid = True
         self.__parse_yaml()
 
@@ -67,33 +66,35 @@ class PreferenceParser:
         Determines whether the given attribute/sub-attribute has been manually 
         specified in the show's YAML.
         
-        :param      attribute:      The attribute to check for.
-        :param      sub_attribute:  The sub attribute to check for. Necessary if
-                                    the given attribute has attributes of its own.
+        :param      attributes: Any number of attributes to check for. Each
+                                subsequent argument is checked for as a sub-
+                                attribute of the prior one.
         
-        :returns:   True if specified, False otherwise.
+        :returns:   True if ALL attributes are specified, False otherwise.
         """
 
-        current_level = self.__yaml
+        current = self.__yaml
         for attribute in attributes:
-            # If this level isn't even a dictionary, or the attribute doesn't exist
-            if not isinstance(current_level, dict) or attribute not in current_level:
+            # If this level isn't even a dictionary or the attribute DNE - False
+            if not isinstance(current, dict) or attribute not in current:
                 return False
 
-            if current_level[attribute] == None:
+            # If this level has sub-attributes, but is blank (None) - False
+            if current[attribute] == None:
                 return False
 
             # Move to the next level
-            current_level = current_level[attribute]
+            current = current[attribute]
 
+        # All given attributes have been checked without exit, must be specified
         return True
 
 
     def __parse_yaml(self) -> None:
         """
-        Parse the raw YAML dictionary into object attributes. This also
-        errors to the user if any provided values are overtly invalid (i.e.
-        missing where necessary, fails type conversion).
+        Parse the raw YAML dictionary into object attributes. This also errors
+        to the user if any provided values are overtly invalid (i.e. missing
+        where necessary, fails type conversion).
         """
 
         if self.__is_specified('options', 'series'):
@@ -160,7 +161,7 @@ class PreferenceParser:
                 width, height = map(int, self.__yaml['tmdb']['minimum_resolution'].split('x'))
                 self.tmdb_minimum_resolution = {'width': width, 'height': height}
             except:
-                error(f'Invalid TMDb minimum resolution - specify as WIDTHxHEIGHT')
+                error(f'Invalid minimum resolution - specify as WIDTHxHEIGHT')
                 self.valid = False
 
         if self.__is_specified('imagemagick', 'docker_id'):

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -235,6 +235,8 @@ class Profile:
             remove_regex = format_string.replace('{abs_number}', full_regex)
         elif '{episode_number}' in format_string:
             remove_regex = format_string.replace('{episode_number}', full_regex)
+        else:
+            return title_text
 
         # Find match of above regex, if exists, delete that text
         # Perform match on the case-ified episode text

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -240,14 +240,13 @@ class Profile:
         # Perform match on the case-ified episode text
         text_to_remove = match(remove_regex, title_text, IGNORECASE)
 
-        if text_to_remove:
-            info(f'Removed episode number format text "'
-                 f'{text_to_remove.group()}" from episode title', 1)
-            new_text = title_text.replace(text_to_remove.group(), '')
-            if new_text == '':
-                return title_text
+        # If there's no match, return the original title
+        if not text_to_remove:
+            return title_text
 
-        return title_text
+        info(f'Removed episode number format text "{text_to_remove.group()}" '
+             f'from episode title', 1)
+        return title_text.replace(text_to_remove.group(), '')
 
 
     def convert_title(self, title_text: str) -> str:

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -55,7 +55,7 @@ class Show:
         self.preferences = global_preferences.pp
         
         # Parse arguments given by the creator of this object
-        self.name = name
+        self.name = str(name)
         self.__yaml = yaml_dict
         self.__library_map = library_map
 

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -70,14 +70,14 @@ class ShowSummary(ImageMaker):
         # Warn if this show has no episodes to work with
         episode_count = len(available_episodes)
         if episode_count == 0:
-            warn(f'Cannot create ShowSummary for {self.show.full_name} - '
-                 f'has no episodes', 1)
+            return None
 
+        # Skip if the number of available episodes is below the minimum
         minimum = self.preferences.summary_minimum_episode_count
         if episode_count < minimum:
             info(f'Skipping ShowSummary for {self.show.full_name} - has '
                  f'{episode_count} episodes, minimum setting is {minimum}', 1)
-            return
+            return None
 
         # Get a random subset of images to create the summary with
         # Sort that subset my season/episode number so the montage appears chronological
@@ -254,13 +254,13 @@ class ShowSummary(ImageMaker):
         # Select images for montaging
         self.__select_images()
 
-        # If the summary already exists, or there are no title cards to montage
-        if self.output.exists() or len(self.inputs) == 0:
+        # If there are no title cards to montage
+        if len(self.inputs) == 0:
             return
 
         # Exit if a logo does not exist
         if not self.logo.exists():
-            warn('Cannot create ShowSummary; no logo found', 1)
+            warn('Cannot create ShowSummary - no logo found', 1)
             return
 
         # Create montage of title cards
@@ -277,7 +277,6 @@ class ShowSummary(ImageMaker):
 
         # Add created by tag - summary is completed
         self._add_created_by(montage_and_logo)
-        
         info(f'Created ImageSummary', 1)
 
         # Delete temporary files

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -70,8 +70,14 @@ class ShowSummary(ImageMaker):
         # Warn if this show has no episodes to work with
         episode_count = len(available_episodes)
         if episode_count == 0:
-            warn(f'Cannot create Show Summary for {self.show.full_name} - '
+            warn(f'Cannot create ShowSummary for {self.show.full_name} - '
                  f'has no episodes', 1)
+
+        minimum = self.preferences.summary_minimum_episode_count
+        if episode_count < minimum:
+            info(f'Skipping ShowSummary for {self.show.full_name} - has '
+                 f'{episode_count} episodes, minimum setting is {minimum}', 1)
+            return
 
         # Get a random subset of images to create the summary with
         # Sort that subset my season/episode number so the montage appears chronological

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -14,19 +14,17 @@ class SonarrInterface(WebInterface):
     """
 
     """Datetime format string for airDateUtc field in Sonarr API requests"""
-    AIRDATE_FORMAT: str = '%Y-%m-%dT%H:%M:%SZ'
+    __AIRDATE_FORMAT: str = '%Y-%m-%dT%H:%M:%SZ'
 
     """Path to the map of sonarr titles to ID's"""
     __ID_MAP: Path = Path(__file__).parent / '.objects' / 'sonarr_id_map.pkl'
 
     def __init__(self, url: str, api_key: str) -> None:
         """
-        Constructs a new instance.
+        Constructs a new instance of an interface to Sonarr.
         
         :param      url:        The base url of Sonarr.
-
-        :param      api_key:    The api key for requesting data to/from
-                                Sonarr.
+        :param      api_key:    The api key for requesting data to/from Sonarr.
         """
 
         # Initialize parent WebInterface 
@@ -53,11 +51,11 @@ class SonarrInterface(WebInterface):
 
     def __add_id_to_map(self, full_title: str, id_: int) -> None:
         """
-        Adds an identifier to map.
+        Add the given ID to the object's map. Also write this updated map object
+        to the file.
         
-        :param      title:  The title
-
-        :param      id_:    The identifier
+        :param      full_title: The full title of the entry to map.
+        :param      id_:        The ID of the entry to store.
         """
 
         self.__id_map[full_title] = int(id_)
@@ -172,10 +170,8 @@ class SonarrInterface(WebInterface):
 
     def _get_episode_title_for_id(self, series_id: int, season: int,
                                   episode: int) -> str:
-
         """
-        Gets the episode title for a given series ID and season/episode
-        number.
+        Gets the episode title for a given series ID and season/episode number.
         
         :param      series_id:  The series identifier
         
@@ -209,10 +205,10 @@ class SonarrInterface(WebInterface):
         Gets all episode data for identifier. Only returns episodes that have
         aired already.
         
-        :param      series_id:  The series identifier
+        :param      series_id:  The series identifier.
         
-        :returns:   All episode data for the given series id. Only entries
-                    that have ALREADY aired are returned.
+        :returns:   All episode data for the given series id. Only entries that
+                    have ALREADY aired (or do not air) are returned.
         """
 
         # Construct GET arguments
@@ -231,7 +227,7 @@ class SonarrInterface(WebInterface):
                 # Verify this episode has already aired, skip if not
                 air_datetime = datetime.strptime(
                     episode['airDateUtc'],
-                    self.AIRDATE_FORMAT
+                    self.__AIRDATE_FORMAT
                 )
                 if air_datetime > datetime.now():
                     continue
@@ -263,11 +259,8 @@ class SonarrInterface(WebInterface):
         Gets the episode title of the requested entry.
         
         :param      title:      The title of the requested series.
-
         :param      year:       The year of the requested series.
-
         :param      season:     The season number of the entry.
-
         :param      episode:    The episode number of the entry.
         
         :returns:   The episode title.
@@ -286,7 +279,6 @@ class SonarrInterface(WebInterface):
         Only episodes that have already aired are returned.
         
         :param      title:  The title of the series.
-
         :param      year:   The year of the series.
         
         :returns:   List of dictionaries of episode data.
@@ -301,6 +293,7 @@ class SonarrInterface(WebInterface):
         return self._get_all_episode_data_for_id(series_id)
 
 
+    #TODO immplement
     # def get_episode_filename(self, title: str, year: int, season_number: int,
     #                          episode_number: int) -> str:
 
@@ -354,16 +347,13 @@ class SonarrInterface(WebInterface):
     #     return None
 
 
-
     @staticmethod
     def manually_specify_id(title: str, year: int, id_: int) -> None:
         """
-        Manually set the Sonarr ID for the given full title.
+        Manually override the Sonarr ID for the given full title.
 
         :param      title:  The title of the series.
-
         :param      year:   The year of the series.
-
         :param      id_:    The Sonarr ID for this series.
         """
 

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -19,13 +19,13 @@ class StandardTitleCard(CardType):
         2. Add the title text (either one or two lines) to the image. Using the
            provided text line(s), font, and color.
         3. Create the output file's necessary parent folders.
-        4. If no season text is required, add just the episode count and skip to 8.
-        5. If season text is required, query ImageMagick's to get the end width of
-           the season and episode text.
-        6. Create a transparent image of only the provided season and episode text
-           of the dimensions computed in 5.
-        7. Place the intermediate transparent text image on top of the image with
-           title text.
+        4. If no season text is required, add just the episode count and go to 8.
+        5. If season text is required, query ImageMagick's to get the end width
+           of the season and episode text.
+        6. Create a transparent image of only the provided season and episode
+           text of the dimensions computed in 5.
+        7. Place the intermediate transparent text image on top of the image
+           with title text.
         8. The resulting title card file is placed at the provided output path. 
         9. Delete all intermediate files created above.
     """
@@ -67,7 +67,6 @@ class StandardTitleCard(CardType):
                  title_bottom_line: str, season_text: str, episode_text: str,
                  font: str, font_size: float, title_color: str,
                  hide_season: bool, *args: tuple, **kwargs: dict) -> None:
-
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
@@ -153,7 +152,7 @@ class StandardTitleCard(CardType):
         return [
             f'-fill black',
             f'-stroke black',
-            f'-strokewidth 3', #3, euphoria is 0.5, the wire is 1, punisher 1.5
+            f'-strokewidth 3', #def:3, euphoria:0.5, the wire:1, punisher:1.5
         ]
 
 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -10,8 +10,8 @@ from modules.WebInterface import WebInterface
 class TMDbInterface(WebInterface):
     """
     This class defines an interface to TheMovieDatabase (TMDb). Once initialized 
-    with a valid API key, the primary purpose of this class is to automatically 
-    gather source images of episodes.
+    with a valid API key, the primary purpose of this class is to gather 
+    images for title cards, or logos for summaries.
     """
 
     """Base URL for sending API requests to TheMovieDB"""
@@ -30,7 +30,7 @@ class TMDbInterface(WebInterface):
         """
         Constructs a new instance of an interface to TheMovieDB.
         
-        :param      api_key:    The api key used to communicate with TMDB.
+        :param      api_key:    The api key to communicate with TMDb.
         """
 
         # Initialize parent WebInterface 
@@ -59,7 +59,8 @@ class TMDbInterface(WebInterface):
         self.__api_key = api_key
 
 
-    def __update_blacklist(self, title: str, year: int, season: int, episode: int) -> None:
+    def __update_blacklist(self, title: str, year: int, season: int,
+                           episode: int) -> None:
         """
         Adds the given entry to the blacklist; indicating that this exact entry
         shouldn't be queried to TheMovieDB (to prevent unnecessary queries).
@@ -95,7 +96,8 @@ class TMDbInterface(WebInterface):
             dump(self.__blacklist, file_handle, HIGHEST_PROTOCOL)
 
 
-    def __is_blacklisted(self, title: str, year: int, season: int, episode: int) -> bool:
+    def __is_blacklisted(self, title: str, year: int, season: int,
+                         episode: int) -> bool:
         """
         Determines if the specified entry is in the blacklist (i.e. should
         not bother querying TMDb.
@@ -150,17 +152,18 @@ class TMDbInterface(WebInterface):
 
 
     @staticmethod
-    def manually_download_season(api_key: str, title: str, year: int, season: int,
-                                 episode_count: int, directory: Path) -> None:
+    def manually_download_season(api_key: str, title: str, year: int,
+                                 season: int, episode_count: int,
+                                 directory: Path) -> None:
         """
-        Download episodes 1-episode_count of the requested season for the given show.
-        They will be named as s{season}e{episode}.jpg.
+        Download episodes 1-episode_count of the requested season for the given
+        show. They will be named as s{season}e{episode}.jpg.
         
         :param      api_key:        The api key for sending requsts to TMDb.
 
         :param      title:          The title of the requested show.
 
-        :param      year:           The year of the requested show (for matching).
+        :param      year:           The year of the requested show.
 
         :param      season:         The season to download.
 
@@ -174,17 +177,17 @@ class TMDbInterface(WebInterface):
         dbi = TMDbInterface(api_key)
 
         for episode in range(1, episode_count+1):
-            image_url = dbi.get_title_card_source_image(title, year, season, episode)
+            image_url=dbi.get_title_card_source_image(title,year,season,episode)
 
+            # If a valid URL was returned, download it
             if image_url:
-                dbi.download_image(image_url, directory / f's{season}e{episode}.jpg')
+                filename = f's{season}e{episode}.jpg'
+                dbi.download_image(image_url, directory / filename)
 
 
     @staticmethod
     def delete_blacklist() -> None:
-        """
-        Delete the blacklist file referenced by this class.
-        """
+        """Delete the blacklist file referenced by this class."""
 
         TMDbInterface.__BLACKLIST.unlink(missing_ok=True)
         info(f'Deleted blacklist file "{TMDbInterface.__BLACKLIST.resolve()}"')
@@ -192,8 +195,8 @@ class TMDbInterface(WebInterface):
 
     def __get_tv_id(self, title: str, year: int) -> int:
         """
-        Get the internal TMDb ID for the provided series. Search is done
-        by name and the start air year.
+        Get the internal TMDb ID for the provided series. Matching is done by
+        name and the start air year.
 
         The first result is returned every time.
         
@@ -210,7 +213,8 @@ class TMDbInterface(WebInterface):
 
         # Base params are api_key and the query (title)
         url = f'{self.API_BASE_URL}search/tv/'
-        params = {'api_key': self.__api_key, 'query': title, 'first_air_date_year': year}
+        params = {'api_key': self.__api_key, 'query': title,
+                  'first_air_date_year': year}
 
         # Query TheMovieDB
         results = self._get(url=url, params=params)
@@ -229,17 +233,16 @@ class TMDbInterface(WebInterface):
 
     def __determine_best_image(self, images: list) -> dict:
         """
-        Determines the best image, returning it's contents from within
-        the database return JSON.
+        Determines the best image, returning it's contents from within the
+        database return JSON.
         
-        :param      images: The results from the database. Each entry
-                            is a new image to be considered.
+        :param      images: The results from the database. Each entry is a new
+                            image to be considered.
         
-        :returns:   The "best" image for title card creation. This is
-                    determined using the images' aspect ratios, and 
-                    dimensions. Priority given to largest image. None is
-                    returned if no images passed the minimum dimension
-                    requirements in preferences.
+        :returns:   The "best" image for title card creation. This is determined
+                    using the images' dimensions. Priority given to largest
+                    image. None is returned if no images passed the minimum
+                    dimension requirements in preferences.
         """
 
         # Pick the best image based on image dimensions, and then vote average
@@ -251,7 +254,7 @@ class TMDbInterface(WebInterface):
             if not self.preferences.meets_minimum_resolution(width, height):
                 continue
 
-            # If the image has valid dimensions, get pixel count and vote average
+            # If the image has valid dimensions,get pixel count and vote average
             valid_image = True
             pixels = height * width
             score = int(image['vote_average'])
@@ -261,7 +264,7 @@ class TMDbInterface(WebInterface):
                 best_image = {'index': index, 'pixels': pixels, 'score': score}
             elif pixels == best_image['pixels']:
                 if score > best_image['score']:
-                    best_image = {'index': index, 'pixels': pixels, 'score': score}
+                    best_image = {'index':index, 'pixels':pixels, 'score':score}
 
         return images[best_image['index']] if valid_image else None
 
@@ -269,8 +272,8 @@ class TMDbInterface(WebInterface):
     def get_title_card_source_image(self, title: str, year: int, season: int,
                                     episode: int, abs_number: int=None) -> str:
         """
-        Get the best source image for the requested entry. The URL of this
-        image is returned.
+        Get the best source image for the requested entry. The URL of this image
+        is returned.
         
         :param      title:      The title of the requested series.
 
@@ -282,8 +285,8 @@ class TMDbInterface(WebInterface):
 
         :param      abs_number: The absolute episode number of the entry.
         
-        :returns:   URL to the 'best' source image for the requested
-                    entry. None if no images are available.
+        :returns:   URL to the 'best' source image for the requested entry. None
+                    if no images are available.
         """
 
         # Don't query the database if this episode is in the blacklist
@@ -314,24 +317,77 @@ class TMDbInterface(WebInterface):
 
         # If 'stills' wasn't in return JSON, episode wasn't found
         if 'stills' not in results:
-            warn(f'TMDb has no matching episode for "{title} ({year})" Season {season}, Episode {episode}', 2)
+            warn(f'TMDb has no matching episode for "{title} ({year})" Season '
+                 f'{season}, Episode {episode}', 2)
             self.__update_blacklist(title, year, season, episode)
             return None
 
-        # If 'stills' is in JSON, but is an empty list, then database has no images
+        # If 'stills' is in JSON, but is empty, then TMDb has no images
         if len(results['stills']) == 0:
-            warn(f'TMDb has no images for "{title} ({year})" Season {season}, Episode {episode}', 2)
+            warn(f'TMDb has no images for "{title} ({year})" Season {season}, '
+                 f'Episode {episode}', 2)
             self.__update_blacklist(title, year, season, episode)
             return None
 
         # Get the best image, None is returned if requirements weren't met
         best_image = self.__determine_best_image(results['stills'])
         if not best_image:
-            warn(f'TMDb images for "{title} ({year})" Season {season}, Episode {episode} '
-                 f'do not meet dimensional requirements.', 2)
+            warn(f'TMDb images for "{title} ({year})" Season {season}, Episode '
+                 f'{episode} do not meet dimensional requirements.', 2)
+            self.__update_blacklist(title, year, season, episode)
             return None
         
         return f'https://image.tmdb.org/t/p/original{best_image["file_path"]}'
+
+
+    def get_series_logo(self, title: str, year: int) -> str:
+        """
+        Get the 'best' logo for the given series.
+        
+        :param      title:  The title of the requested series.
+
+        :param      year:   The year of the requested series.
+        
+        :returns:   URL to the 'best' logo for the given series, and None if no
+                    images are available.
+        """
+
+        # Get the TV id for the provided series+year
+        tv_id = self.__get_tv_id(title, year)
+
+        # GET params
+        url = f'{self.API_BASE_URL}tv/{tv_id}/images'
+        params = {'api_key': self.__api_key}
+
+        # Make the GET request
+        results = self._get(url=url, params=params)
+
+        # If there are no logos, warn and exit
+        if len(results['logos']) == 0:
+            warn(f'TMDb has no logos for "{title} ({year})"', 1)
+            return None
+
+        # Pick the best image based on image dimensions
+        best = results['logos'][0]
+        valid_image = False
+        for index, image in enumerate(results['logos']):
+            # Skip SVG images (for now!)
+            if image['file_path'].endswith('.svg'):
+                continue
+
+            # Skip logos that aren't english
+            if image['iso_639_1'] != 'en':
+                continue
+
+            # Choose the best image on the pixel count alone
+            valid_image = True
+            if image['width']*image['height'] > best['width']*best['height']:
+                best = results['logos'][index]
+
+        if not valid_image:
+            return None
+
+        return f'https://image.tmdb.org/t/p/original{best["file_path"]}'
 
 
     def download_image(self, image_url: str, destination: Path) -> None:

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -1,0 +1,175 @@
+from re import match
+
+from modules.Debug import info, warn, error
+
+class Title:
+    """
+    This class describes a title. A Title can either be initialized with a full
+    title without any formatting done to it, and then split by this class into
+    multiple lines with `split()`; or it can be initialized with those lines
+    directly. For example:
+
+    >>> t = Title("The One Where Rachel's Sister Babysits")
+    >>> t.split(25, 2, False)
+    ["The One Where",
+     "Rachel's Sister Babysits"]
+    >>> t.split(25, 2, True)
+    ["The One Where Rachel's",
+     "Sister Babysits"]
+    """
+
+    def __init__(self, full_title: str=None, *title_lines: tuple) -> None:
+        """
+        Constructs a new instance of a Title.
+        
+        :param      full_title:     Complete, unsplit title.
+        :param      title_lines:    A title that is pre-split into any number
+                                    of lines.
+        """
+        
+
+        if full_title != None:
+            # If the full title was given
+            self.full_title = full_title
+            self.__manually_specified = False
+        else:
+            # If title was given line-by-line, join with spaces
+            self.full_title = ' '.join(title_lines)
+            self.__manually_specified = True
+
+        # If title lines were specified
+        self.__title_lines = [] if self.__skip_split else list(title_lines)
+
+        # Generate title to use for matching purposes
+        match_func = lambda c: match('[a-zA-Z0-9]', c)
+        self.match_title = ''.join(filter(match_func, text)).lower()
+
+
+    def split(self, line_width: int, max_line_count: int=2,
+              top_heavy: bool=False) -> list:
+        """
+        Split this title's text into multiple lines. If the title cannot fit
+        into the given parameters, line width might not be respected, but the
+        maximum number of lines will be.
+        
+        :param      line_width:     Maximum ine width to base splitting on. 
+        :param      max_line_count: The maximum line count to split the title
+                                    into.
+        :param      top_heavy:      Whether to split the title in a top-heavy
+                                    style. This means the top lines will likely
+                                    be longer than the bottom ones. False for
+                                    bottom-heavy splitting.
+        
+        :returns:   List of split title text to be read top to bottom.
+        """
+
+        # If the object was initialized with lines, return those
+        if self.__manually_specified:
+            return self.__title_lines
+
+        # If the title can fit on one line, or a single line is requested
+        if len(self.full_title) <= line_width or max_line_count <= 1:
+            return [self.full_title]
+
+        # Misformat ahead..
+        if len(self.full_title) > max_line_count * character_count:
+            #print('WARN: Title too long, potential misformat')
+            pass
+
+        all_lines = [self.title]
+
+        # For top heavy splitting, start on top and move text DOWN
+        if top_heavy:
+            for _ in range(max_line_count+2-1):
+                # Start splitting from the last line added
+                top, bottom = all_lines.pop(), ''
+                while ((len(top) > line_width and ' ' in top) or
+                    len(bottom) in range(1, line_width//3)):
+                    # Look to split on special characters
+                    special_split = False
+                    for char in (':', ',', '(', ')', '[', ']'):
+                        if f'{char} ' in top[:line_width]:
+                            top, bottom_add = top.rsplit(f'{char} ', 1)
+                            top += char
+                            bottom = f'{bottom_add} {bottom}'
+                            special_split = True
+                            break
+
+                    # If no special character splitting was done, split on space
+                    if not special_split:
+                        try:
+                            top, bottom_add = top.rsplit(' ', 1)
+                            bottom = f'{bottom_add} {bottom}'.strip()
+                        except ValueError:
+                            break
+
+                all_lines += [top, bottom]
+            
+            # Strip every line, delete blank entries
+            all_lines = list(filter(lambda l: len(l), map(str.strip,all_lines)))
+
+            # If misformatted, combine overflow lines
+            if len(all_lines) > max_line_count:
+                all_lines[-2] = f'{all_lines[-2]} {all_lines[-1]}'
+                del all_lines[-1]
+
+            return all_lines
+
+        # For bottom heavy splitting, start on bottom and move text UP
+        for _ in range(max_line_count+2-1):
+            top, bottom = '', all_lines.pop()
+            while ((len(bottom) > line_width and ' ' in bottom) or
+                len(top) in range(1, line_width//3)):
+                # Look to split on special characters
+                special_split = False
+                for char in (':', ',', '(', ')', '[', ']'):
+                    if f'{char} ' in bottom[:line_width]:
+                        top_add, bottom = bottom.split(f'{char} ', 1)
+                        top = f'{top} {top_add}{char}'
+                        special_split = True
+                        break
+
+                # If no special character splitting was done, split on space
+                if not special_split:
+                    top_add, bottom = bottom.split(' ', 1)
+                    top = f'{top} {top_add}'.strip()
+
+            all_lines += [bottom, top]
+
+        # Reverse order, strip every line, delete blank entries
+        all_lines = list(filter(lambda l:len(l),map(str.strip,all_lines[::-1])))
+
+        # If misformatted, combine overflow lines
+        if len(all_lines) > max_line_count:
+            all_lines[-2] = f'{all_lines[-2]} {all_lines[-1]}'
+            del all_lines[-1]
+
+        return all_lines
+
+
+    def apply_profile(self, profile: 'Profile', line_width: int,
+                      max_line_count: int) -> list:
+        """
+        Apply the given profile to this title. If this object was created with
+        manually specified title lines, then the profile is applied to each
+        line, otherwise it's applied to the full title.
+        
+        :param      profile:    Profile object to call `convert_title()`.
+        
+        :returns:   List of modified title lines.
+        """
+
+        # If manually specified, apply the profile to each line, skip splitting
+        if self.__manually_specified:
+            return list(map(
+                lambda line: profile.convert_title(line),
+                self.__title_lines
+            ))
+
+        # Title lines weren't manually specified, apply profile then split
+        return self.split(
+            profile.convert_title(self.full_title),
+            line_width,
+            max_line_count
+        )
+        

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -5,13 +5,13 @@ from requests import get
 class WebInterface(ABC):
     """
     Abstract class that defines a WebInterface, which is a type of interface
-    that makes GET requests and returns some JSON result.
+    that makes GET requests and returns some JSON result. 
     """
     
     @abstractmethod
     def __init__(self) -> None:
         """
-        Constructs a new instance of a WebInterface. This creates creates a
+        Constructs a new instance of a WebInterface. This creates creates a 
         cached request and result, but no other attributes.
         """
 
@@ -22,9 +22,9 @@ class WebInterface(ABC):
 
     def _get(self, url: str, params: dict) -> dict:
         """
-        Wrapper for getting the JSON return of the specified GET request. If
-        the provided URL and parameters are identical to the previous request,
-        then a cached result is returned instead.
+        Wrapper for getting the JSON return of the specified GET request. If the
+        provided URL and parameters are identical to the previous request, then
+        a cached result is returned instead.
         
         :param      url:    URL to pass to GET.
 


### PR DESCRIPTION
# Major Changes
 - Added automatic downloading of logos for `ShowSummary`
    - Modified Manager to pass the `TMDbInterface` to `ShowArchive.create_summary()` if globally enabled
    - Modified `ShowArchive.create_summary()` to check for summary existence (_was_ part of `ShowSummary.create()`)
    - Modified `ShowArchive.create_summary()` to query TMDb for an english logo if one does not exist
    - Created `TMDbInterface.get_series_logo()` to return the URL of a logo for a given title and year
-  Created `Title` class
    - This class permits generalized title creation from full titles into an arbitrary number of title lines with fixed widths.
    - Implemented 'smarter' title splitting algorithm to return two types of titles: top heavy and bottom heavy.
      - Top heavy title: "Longish Top Line" / "Line 2"
      - Bottom-heavy title: "Short Top" / "and Longish Bottom Line"
    - Will be reworking code to pass around `Title` objects (rather than title top/bottom lines)
- Changed title case function from `str.title` to `titlecase.titlecase`
  - This method is **a lot** 'smarter' at producing accurate title capitalization than the default
  - Added `titlecase` to Pipfile
- Added option for minimum episode count for summary creation to preference YAML
  - Default (unspecified) value is 1
  - Option is `archive:` `summary:` `minimum_episodes:`
# Major Fixes 
- Corrected method to remove episode format strings from titles; was returning the unaltered episode titles
# Minor Changes
- Added logic for episode format strings without number indications - i.e. format strings such as "Chapter" (no {} indicator) will return the unaltered title text
- Renamed `AIRDATE_FORMAT` within `SonarrInterface` to `__AIRDATE_FORMAT` to better indicate that it should only be needed/used within the class itself
# Minor Fixes
- Fixed crash if show name is specified as a number (i.e. 1883)