### PR TITLE
Rework all classes to use Title objects

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -73,8 +73,8 @@ tmdb_group.add_argument('--delete-blacklist', action='store_true',
 args = parser.parse_args()
 
 # Override unspecified defaults with their class specific defaults
-if args.font == '__default':
-    args.font = TitleCard.CARD_TYPES[args.card_type].TITLE_FONT
+if args.font == Path('__default'):
+    args.font = Path(TitleCard.CARD_TYPES[args.card_type].TITLE_FONT)
 if args.font_color == '__default':
     args.font_color = TitleCard.CARD_TYPES[args.card_type].TITLE_COLOR
 

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -28,8 +28,18 @@ class CardType(ImageMaker):
         'title': titlecase,
     }
 
-    """Standard size for a title card"""
+    """Standard size for all title cards"""
     TITLE_CARD_SIZE: str = '3200x1800'
+
+    @property
+    @abstractmethod
+    def TITLE_CHARACTERISTICS(self) -> dict:
+        """
+        Characteristics of title splitting for this card type. Must have keys
+        for max_line_width, max_line_count, and top_heavy. See `Title` class
+        for details.
+        """
+        raise NotImplementedError(f'All CardType objects must implement this')
 
     @property
     @abstractmethod

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -1,48 +1,29 @@
 from pathlib import Path
 
-from modules.Debug import *
+from modules.Debug import info, warn, error
+from modules.Title import Title
 from modules.TitleCard import TitleCard
 
 class Episode:
     """
     This class defines an episode of a series that has a corresponding Title
     Card. An Episode is defined (and identified) by its season and episode
-    number. Upon initialization, this class splits episode titles into up to two
-    lines (if necessary, as determined by length of the title and the card
-    class).
-
-    An example usage is shown below:
-
-    ```
-    >>> e = Episode(
-    >>>     1, 1, 
-    >>>     '/sources/Show (Year)/', 
-    >>>     '/media/Show (Year)/Season 1/Show (Year) - S01E01.jpg',
-    >>>     'Long Pilot Title: Episode 1 of Season 1'
-    >>> )
-    >>> e.title_top_line, e.title_bottom_line
-    ('Long Pilot Title:', 'Episode 1 of Season 1')
-    ```
+    number.
     """
 
     def __init__(self, season_number: int, episode_number: int,
                  card_class: 'CardType', base_source: Path, destination: Path,
-                 title: str, abs_number: int=None) -> None:
+                 title: Title, abs_number: int=None) -> None:
         """
-        Constructs a new instance.
+        Constructs a new instance of an Episode.
 
         :param      season_number:  The season number of this episode.
-
         :param      episode_number: The episode number of this episode.
-
         :param      base_source:    The base source directory to look for
                                     source images within.
-
         :param      destination:    The destination for the title card
                                     associated with this episode.
-
         :param      title:          The title (full text) of this episode.
-
         :param      abs_number:     The absolute episode number of this episode.
         """
 
@@ -52,34 +33,27 @@ class Episode:
         self.card_class = card_class
         self.abs_number = int(abs_number) if abs_number != None else None
 
-        # Set in/out paths
+        # Set source/destination paths
         source_name = (f's{season_number}e{episode_number}'
                        f'{TitleCard.INPUT_CARD_EXTENSION}')
         self.source = base_source / source_name
         self.destination = destination
 
-        # If title is a list, parse into top/botton text
+        # Store Title object
         self.title = title
-        if isinstance(title, (list, tuple)):
-            self.title_top_line = title[0]
-            self.title_bottom_line = title[1]
-        else:
-            top, bottom = card_class.split_title(title)
-            self.title_top_line, self.title_bottom_line = top, bottom
 
 
     def __repr__(self) -> str:
         """
-        Returns a unambiguous string representation of the object (for debug...).
+        Returns an unambiguous string representation of the object.
         
         :returns:   String representation of the object.
         """
 
-        return (
-            f'<Episode(season_number={self.season_number}, episode_number='
-            f'{self.episode_number}, title_top_line="{self.title_top_line}",'
-            f' title_bottom_line="{self.title_bottom_line}">'
-        )
+        return (f'<Episode season_number={self.season_number}, episode_number='
+                f'{self.episode_number}, abs_number={self.abs_number}, '
+                f'card_class={self.card_class}, source={self.source}, '
+                f'destination={self.destination}, title={self.title}>')
 
 
     def matches(self, episode_info: dict) -> bool:
@@ -97,6 +71,6 @@ class Episode:
         season_match = episode_info['season_number'] == self.season_number
         episode_match = episode_info['episode_number'] == self.episode_number
 
-        return season_match and episode_match
+        return (season_match and episode_match)
 
         

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -123,9 +123,11 @@ class Profile:
         if self.hide_season_title:
             return ''
 
-        # Generic season titles
+        # Generic season titles are Specials and Season {n}
         if not self.__use_custom_seasons:
-            return 'Specials' if season_number == 0 else f'Season {season_number}'
+            if season_number == 0:
+                return 'Specials'
+            return f'Season {season_number}'
 
         # Custom season titles and method is season map
         if self.__map_or_range == 'map':
@@ -254,14 +256,13 @@ class Profile:
     def convert_title(self, title_text: str) -> str:
         """
         Convert the given title text through this profile's settings. This is
-        any combination of text substitutions, case functions such as
-        `str.upper()` or `str.lower()`, and optionally removing text that
-        matches the format of this profile's episode text format.
+        any combination of text substitutions, case functions, and optionally
+        removing text that matches the format of this profile's episode text
+        format.
 
-        For example, if the episode format string was
-        'Chapter {episode_number}', and the given `title_text` was 'Chapter 1:
-        Pilot', then the returned text (excluding any replacements or case
-        mappings) would be 'Pilot'.
+        For example, if the episode format string was 'Chapter {episode_number}'
+        and the given `title_text` was 'Chapter 1: Pilot', then the returned
+        text (excluding any replacements or case mappings) would be 'Pilot'.
         
         :param      title_text: The title text to convert.
         

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -4,6 +4,7 @@ from pickle import dump, load, HIGHEST_PROTOCOL
 
 from modules.Debug import *
 from modules.Show import Show
+from modules.Title import Title
 from modules.WebInterface import WebInterface
 
 class SonarrInterface(WebInterface):
@@ -169,7 +170,7 @@ class SonarrInterface(WebInterface):
 
 
     def _get_episode_title_for_id(self, series_id: int, season: int,
-                                  episode: int) -> str:
+                                  episode: int) -> Title:
         """
         Gets the episode title for a given series ID and season/episode number.
         
@@ -192,7 +193,7 @@ class SonarrInterface(WebInterface):
             curr_episode_number = int(episode['episodeNumber'])
 
             if season == curr_season_number and episode == curr_season_number:
-                return episode['title']
+                return Title(episode['title'])
 
         raise ValueError(
             f'Cannot find Season {season}, Episode {episode} of '
@@ -240,7 +241,7 @@ class SonarrInterface(WebInterface):
             new_info = {
                 'season_number':    int(episode['seasonNumber']),
                 'episode_number':   int(episode['episodeNumber']),
-                'title':            episode['title'],
+                'title':            Title(episode['title']),
                 # 'filename':         Path(episode['episodeFile']['path']).stem,
             }
 
@@ -254,7 +255,7 @@ class SonarrInterface(WebInterface):
 
 
     def get_episode_title(self, title: str, year: int, season: int,
-                          episode: int) -> str:
+                          episode: int) -> Title:
         """
         Gets the episode title of the requested entry.
         

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -8,8 +8,18 @@ class StarWarsTitleCard(CardType):
     """
     This class describes a type of ImageMaker that produces title cards in the
     theme of Star Wars cards as designed by reddit user /u/Olivier_286. These
-    cards are not as customizeable as the standard template.
+    cards are not as customizable as the standard template.
     """
+
+    """Characteristics for title splitting by this class"""
+    TITLE_CHARACTERISTICS = {
+        'max_line_width': 16,   # Character count to begin splitting titles
+        'max_line_count': 3,    # Maximum number of lines a title can take up
+        'top_heavy': True,      # This class uses top heavy titling
+    }
+
+    """How to name archive directories for this type of card"""
+    ARCHIVE_NAME = 'Star Wars Style'
 
     """Path to the font to use for the episode title"""
     TITLE_FONT =str((Path(__file__).parent/'ref'/'Monstice-Base.ttf').resolve())
@@ -23,14 +33,8 @@ class StarWarsTitleCard(CardType):
     """Standard font replacements for the title font"""
     FONT_REPLACEMENTS = {'Ō': 'O', 'ō': 'o'}
 
-    """After how many characters to split an episode title into two lines"""
-    MAX_LINE_LENGTH = 18
-
     """Whether this class uses season titles for the purpose of archives"""
     USES_SEASON_TITLE = False
-
-    """How to name archive directories for this type of card"""
-    ARCHIVE_NAME = 'Star Wars Style'
 
     """Path to the reference star image to overlay on all source images"""
     __STAR_GRADIENT_IMAGE = Path(__file__).parent / 'ref' / 'star_gradient.png'
@@ -43,18 +47,17 @@ class StarWarsTitleCard(CardType):
     EPISODE_NUMBER_FONT = Path(__file__).parent / 'ref'/'HelveticaNeue-Bold.ttf'
 
     
-    def __init__(self, source: Path, output_file: Path, title_top_line: str,
-                 title_bottom_line: str, episode_text: str,
-                 *args: tuple, **kwargs: dict) -> None:
+    def __init__(self, source: Path, output_file: Path, title: str,
+                 episode_text: str, *args: tuple, **kwargs: dict) -> None:
         """
         Constructs a new instance.
         
-        :param      source:        The source
-        :param      output_file:   The output file
-        :param      title:         The title
-        :param      episode_text:  The episode text
-        :param      args:          The arguments
-        :param      kwargs:        The keywords arguments
+        :param      source:             Source image for this card.
+        :param      output_file:        Output filepath for this card.
+        :param      title:              The title for this card.
+        :param      episode_text:       The episode text for this card.
+        :param      args and kwargs:    Unused arguments to permit generalized
+                                        function calls for any CardType.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface
@@ -65,11 +68,8 @@ class StarWarsTitleCard(CardType):
         self.output_file = output_file
 
         # Store episode title
-        if title_top_line in ('', None):
-            self.title = f'{title_bottom_line}'.upper().strip()
-        else:
-            self.title =f'{title_top_line}\n{title_bottom_line}'.upper().strip()
-
+        self.title = title.upper().strip()
+        
         # Modify episode text to remove "Episode"-like text, replace numbers
         # with text, strip spaces, and convert to uppercase
         self.episode_text = self.__modify_episode_text(episode_text)
@@ -89,9 +89,9 @@ class StarWarsTitleCard(CardType):
         
         :param      text:  The episode text to modify.
         
-        :returns:   The modified episode text with preface text removed, 
-                    numbers replaced with words, and converted to uppercase. If
-                    numbers cannot be replaced, that step is skipped.
+        :returns:   The modified episode text with preface text removed, numbers
+                    replaced with words, and converted to uppercase. If numbers
+                    cannot be replaced, that step is skipped.
         """
 
         # Convert to uppercase, remove space padding
@@ -109,7 +109,7 @@ class StarWarsTitleCard(CardType):
 
     def __add_star_gradient(self, source: Path) -> Path:
         """
-        Add the star gradient to the given source image.
+        Add the static star gradient to the given source image.
         
         :param      source: The source image to modify.
         
@@ -255,6 +255,7 @@ class StarWarsTitleCard(CardType):
     def create(self) -> None:
         """Create the title card as defined by this object."""
 
+        # Add the starry gradient to the source image
         star_image = self.__add_star_gradient(self.source_file)
 
         # Create the output directory and any necessary parents 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -66,11 +66,8 @@ class TMDbInterface(WebInterface):
         shouldn't be queried to TheMovieDB (to prevent unnecessary queries).
         
         :param      title:      The show's title.
-
         :param      year:       The show's year.
-
         :param      season:     The entry's season number.
-
         :param      episode:    The entry's episode number.
         """
 
@@ -103,11 +100,8 @@ class TMDbInterface(WebInterface):
         not bother querying TMDb.
         
         :param      title:      The show's title.
-
         :param      year:       The show's year.
-
         :param      season:     The entry's season number.
-
         :param      episode:    The entry's episode number.
         
         :returns:   True if the entry is blacklisted, False otherwise.
@@ -132,9 +126,7 @@ class TMDbInterface(WebInterface):
         Adds a mapping of this full title to the corresponding TheMovieDB ID.
         
         :param      title:  The show's title.
-
         :param      year:   The show's year.
-
         :param      id_:    The show's ID, as returned by `__get_tv_id()`.
         """
 
@@ -160,15 +152,10 @@ class TMDbInterface(WebInterface):
         show. They will be named as s{season}e{episode}.jpg.
         
         :param      api_key:        The api key for sending requsts to TMDb.
-
         :param      title:          The title of the requested show.
-
         :param      year:           The year of the requested show.
-
         :param      season:         The season to download.
-
         :param      episode_count:  The number of episodes to download
-
         :param      directory:      The directory to place the downloaded images
                                     in.
         """
@@ -201,7 +188,6 @@ class TMDbInterface(WebInterface):
         The first result is returned every time.
         
         :param      title:  The title of the requested series
-
         :param      year:   The year the requested series first aired
         
         :returns:   The internal TMDb ID for the found series
@@ -276,13 +262,9 @@ class TMDbInterface(WebInterface):
         is returned.
         
         :param      title:      The title of the requested series.
-
         :param      year:       The year of the requested series.
-
         :param      season:     The season of the requested entry.
-
         :param      episode:    The episode of the requested entry.
-
         :param      abs_number: The absolute episode number of the entry.
         
         :returns:   URL to the 'best' source image for the requested entry. None
@@ -345,7 +327,6 @@ class TMDbInterface(WebInterface):
         Get the 'best' logo for the given series.
         
         :param      title:  The title of the requested series.
-
         :param      year:   The year of the requested series.
         
         :returns:   URL to the 'best' logo for the given series, and None if no
@@ -395,7 +376,6 @@ class TMDbInterface(WebInterface):
         Downloads the provided image URL to the destination filepath.
         
         :param      image_url:      The image url to download.
-
         :param      destination:    The destination for the requested image.
         """
 

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -18,41 +18,46 @@ class Title:
      "Sister Babysits"]
     """
 
-    def __init__(self, full_title: str=None, *title_lines: tuple) -> None:
+    def __init__(self, title) -> None:
         """
-        Constructs a new instance of a Title.
+        Constructs a new instance of a Title from either a full, unsplit title,
+        or a list of title lines.
         
-        :param      full_title:     Complete, unsplit title.
-        :param      title_lines:    A title that is pre-split into any number
-                                    of lines.
+        :param      title:  Title for this object.
+        :type       title:  str if the full title (from any source), or a list
+                            if parsed from YAML
         """
         
-
-        if full_title != None:
-            # If the full title was given
-            self.full_title = full_title
+        # If given as str, then title is not manually specified
+        if isinstance(title, str):
+            self.full_title = title
+            self.__title_lines = []
             self.__manually_specified = False
-        else:
+        elif isinstance(title, list):
             # If title was given line-by-line, join with spaces
-            self.full_title = ' '.join(title_lines)
+            self.full_title = ' '.join(title)
+            self.__title_lines = title
             self.__manually_specified = True
+        else:
+            error(f'Title can only be created by str or list')
+            return
 
-        # If title lines were specified
-        self.__title_lines = [] if self.__skip_split else list(title_lines)
+        # This title as represented in YAML
+        self.title_yaml = title
 
         # Generate title to use for matching purposes
         match_func = lambda c: match('[a-zA-Z0-9]', c)
-        self.match_title = ''.join(filter(match_func, text)).lower()
+        self.match_title = ''.join(filter(match_func, title)).lower()
 
 
-    def split(self, line_width: int, max_line_count: int=2,
-              top_heavy: bool=False) -> list:
+    def split(self, max_line_width: int, max_line_count: int,
+              top_heavy: bool) -> list:
         """
         Split this title's text into multiple lines. If the title cannot fit
         into the given parameters, line width might not be respected, but the
         maximum number of lines will be.
         
-        :param      line_width:     Maximum ine width to base splitting on. 
+        :param      max_line_width: Maximum line width to base splitting on. 
         :param      max_line_count: The maximum line count to split the title
                                     into.
         :param      top_heavy:      Whether to split the title in a top-heavy
@@ -68,27 +73,28 @@ class Title:
             return self.__title_lines
 
         # If the title can fit on one line, or a single line is requested
-        if len(self.full_title) <= line_width or max_line_count <= 1:
+        if len(self.full_title) <= max_line_width or max_line_count <= 1:
             return [self.full_title]
 
         # Misformat ahead..
-        if len(self.full_title) > max_line_count * character_count:
+        if len(self.full_title) > max_line_count * max_line_width:
             #print('WARN: Title too long, potential misformat')
             pass
 
-        all_lines = [self.title]
+        # Start splitting on the base full title
+        all_lines = [self.full_title]
 
         # For top heavy splitting, start on top and move text DOWN
         if top_heavy:
             for _ in range(max_line_count+2-1):
                 # Start splitting from the last line added
                 top, bottom = all_lines.pop(), ''
-                while ((len(top) > line_width and ' ' in top) or
-                    len(bottom) in range(1, line_width//3)):
+                while ((len(top) > max_line_width and ' ' in top) or
+                    len(bottom) in range(1, max_line_width//3)):
                     # Look to split on special characters
                     special_split = False
                     for char in (':', ',', '(', ')', '[', ']'):
-                        if f'{char} ' in top[:line_width]:
+                        if f'{char} ' in top[:max_line_width]:
                             top, bottom_add = top.rsplit(f'{char} ', 1)
                             top += char
                             bottom = f'{bottom_add} {bottom}'
@@ -113,17 +119,18 @@ class Title:
                 all_lines[-2] = f'{all_lines[-2]} {all_lines[-1]}'
                 del all_lines[-1]
 
+            warn(f'Top split "{self.full_title}" into {"|".join(all_lines)}')
             return all_lines
 
         # For bottom heavy splitting, start on bottom and move text UP
         for _ in range(max_line_count+2-1):
             top, bottom = '', all_lines.pop()
-            while ((len(bottom) > line_width and ' ' in bottom) or
-                len(top) in range(1, line_width//3)):
+            while ((len(bottom) > max_line_width and ' ' in bottom) or
+                len(top) in range(1, max_line_width//3)):
                 # Look to split on special characters
                 special_split = False
                 for char in (':', ',', '(', ')', '[', ']'):
-                    if f'{char} ' in bottom[:line_width]:
+                    if f'{char} ' in bottom[:max_line_width]:
                         top_add, bottom = bottom.split(f'{char} ', 1)
                         top = f'{top} {top_add}{char}'
                         special_split = True
@@ -143,33 +150,34 @@ class Title:
         if len(all_lines) > max_line_count:
             all_lines[-2] = f'{all_lines[-2]} {all_lines[-1]}'
             del all_lines[-1]
-
+        warn(f'Bottom split "{self.full_title}" into {"|".join(all_lines)}')
         return all_lines
 
 
-    def apply_profile(self, profile: 'Profile', line_width: int,
-                      max_line_count: int) -> list:
+    def apply_profile(self, profile: 'Profile',
+                      **title_characteristics: dict) -> str:
         """
         Apply the given profile to this title. If this object was created with
         manually specified title lines, then the profile is applied to each
-        line, otherwise it's applied to the full title.
+        line, otherwise it's applied to the full title. Then newlines ('\n') are
+        used to join each line
         
         :param      profile:    Profile object to call `convert_title()`.
         
-        :returns:   List of modified title lines.
+        :returns:   This title with the given profile and splitting details
+                    applied.
         """
 
         # If manually specified, apply the profile to each line, skip splitting
         if self.__manually_specified:
-            return list(map(
+            return '\n'.join(list(map(
                 lambda line: profile.convert_title(line),
                 self.__title_lines
-            ))
+            )))
 
-        # Title lines weren't manually specified, apply profile then split
-        return self.split(
-            profile.convert_title(self.full_title),
-            line_width,
-            max_line_count
-        )
+        # Title lines weren't manually specified - apply profile, make new Title
+        new_title = Title(profile.convert_title(self.full_title))
+
+        # Call split on the new title, join those lines
+        return '\n'.join(new_title.split(**title_characteristics))
         

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -25,8 +25,8 @@ class TitleCard:
         'star wars': StarWarsTitleCard,
     }
 
-
-    def __init__(self, episode: 'Episode', profile: 'Profile') -> None:
+    def __init__(self, episode: 'Episode', profile: 'Profile',
+                 **title_characteristics: dict) -> None:
         """
         Constructs a new instance of this class.
         
@@ -40,18 +40,17 @@ class TitleCard:
         self.episode = episode
         self.profile = profile
 
-        # Get temporary absolute number
+        # If the episode has no absolute number, use the season number instead
         if episode.abs_number == None:
             abs_number = episode.episode_number
         else:
             abs_number = episode.abs_number
         
-        # Construct this title card's StandardTitleCard from the given arguments
+        # Construct this episode's CardType instance
         self.maker = self.episode.card_class(
             source=episode.source,
             output_file=episode.destination,
-            title_top_line=profile.convert_title(episode.title_top_line),
-            title_bottom_line=profile.convert_title(episode.title_bottom_line),
+            title=episode.title.apply_profile(profile, **title_characteristics),
             season_text=profile.get_season_text(
                 episode.season_number, abs_number
             ), episode_text=profile.get_episode_text(
@@ -83,7 +82,7 @@ class TitleCard:
             # warn(f'Source image {self.episode.source.resolve()} does not exist', 2)
             return False
             
-        info(f'Creating title card for {self.episode.destination.name}', 2)
+        info(f'Creating title card {self.episode.destination.name}', 2)
         self.maker.create()
 
         return True


### PR DESCRIPTION
# Major Changes
- Rewrote all existing code to work on Title objects
  - Added `TITLE_CHARACTERISTICS` abstract property to `CardType` class
    - This is a dictionary of characteristics to apply to splitting of episode titles for that class
    - Includes `max_line_width`, `max_line_count`, and `top_heavy`
  - Modified `DataFileInterface` to return and accept `Title` objects instead of fixed title top/bottom lines
  - Added `TITLE_CHARACTERISTICS` to `StandardTitleCard` and `StarWarsTitleCard` classes
- Reworked `StandardTitleCard` class to not have separate method for 2-line title text, instead uses a newline separated title (from `Title` class) and a preset interline spacing of -22 (closest match to existing look)
# Major Fixes 
- Fixed `Title` class to work as expected (`apply_profile()` didn't work)
# Minor Changes
- Modified `Episode` class to accept `Title` objects instead of tuple of lines
- Modified `SonarrInterface` to return `Title` objects for methods that get an episode title for a given entry
# Minor Fixes
Docstring correction

Closes issue #8 