### PR TITLE
Fixed U+0080 character bug

### DIFF
--- a/modules/AnimeCard.py
+++ b/modules/AnimeCard.py
@@ -85,14 +85,18 @@ class AnimeCard(CardType):
         self.source_file = source
         self.output_file = output_file
 
-        # Store episode title
-        self.title = self.CASE_FUNCTION_MAP['title'](title).replace('"', r'\"')
-        self.kanji = kanji
+        # Apply titlecase case function, escape characters
+        self.title = self.image_magick.escape_chars(
+            self.CASE_FUNCTION_MAP['title'](title)
+        )
+
+        # Store kanji, set bool for whether to use it or not
+        self.kanji = self.image_magick.escape_chars(kanji)
         self.use_kanji = (kanji != None)
 
         # Store season and episode text
-        self.season_text = season_text.upper().replace('"', r'\"')
-        self.episode_text = episode_text.upper().replace('"', r'\"')
+        self.season_text = self.image_magick.escape_chars(season_text.upper())
+        self.episode_text = self.image_magick.escape_chars(episode_text.upper())
         self.hide_season = hide_season
 
 

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -32,6 +32,26 @@ class ImageMagickInterface:
         self.use_docker = bool(docker_id)
 
 
+    @staticmethod
+    def escape_chars(string: str) -> str:
+        """
+        Escape the necessary characters within the given string so that they
+        can be sent to ImageMagick.
+        
+        :param      string: The string to escape.
+        
+        :returns:   Input string with all necessary characters escaped. This 
+                    assumes that text will be wrapped in "", and so only escapes
+                    " and ` characters
+        """
+
+        # Handle possible None strings
+        if string is None:
+            return None
+
+        return string.replace('"', r'\"').replace('`', r'\`')
+
+
     def run(self, command: str, *args: tuple, **kwargs: dict):
         """
         Wrapper for running a given command. This uses either the host machine

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -103,12 +103,10 @@ class StandardTitleCard(CardType):
         self.source_file = source
         self.output_file = output_file
 
-        # Since all text is sent to ImageMagick wrapped in quotes, escape actual
-        # quotes found within the text
-        self.title = title.replace('"', r'\"')
-
-        self.season_text = season_text.upper().replace('"', r'\"')
-        self.episode_text = episode_text.upper().replace('"', r'\"')
+        # Ensure characters that need to be escaped are
+        self.title = self.image_magick.escape_chars(title)
+        self.season_text = self.image_magick.escape_chars(season_text.upper())
+        self.episode_text = self.image_magick.escape_chars(episode_text.upper())
 
         self.font = font
         self.font_size = font_size

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -71,11 +71,13 @@ class StarWarsTitleCard(CardType):
         self.output_file = output_file
 
         # Store episode title
-        self.title = title.upper().strip()
+        self.title = self.image_magick.escape_chars(title.upper())
         
         # Modify episode text to remove "Episode"-like text, replace numbers
         # with text, strip spaces, and convert to uppercase
-        self.episode_text = self.__modify_episode_text(episode_text)
+        self.episode_text = self.image_magick.escape_chars(
+            self.__modify_episode_text(episode_text)
+        )
 
 
     def __modify_episode_text(self, text: str) -> str:


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
N/A
# Minor Changes
N/A
# Minor Fixes
- Added `ImageMagickInterface.escape_chars()` method to escape any necessary characters before creating an ImageMagick command
  - Added logic for escaping U+0080 (`)
  - Modified all existing `CardType` implementations to use this new method

Closes #18 