### PR TITLE
Match TMDb series by TVDb ID from Sonarr

### DIFF
--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -67,7 +67,7 @@ class Manager:
         for show in self.preferences.iterate_series_files():
             # Skip shows whose YAML was invalid
             if not show.valid:
-                error(f'Skipping series "{show.name}"')
+                error(f'Skipping series "{show.series_info}"')
                 continue
 
             self.shows.append(show)
@@ -136,7 +136,7 @@ class Manager:
             if created and self.preferences.use_plex:
                 self.plex_interface.refresh_metadata(
                     show.library_name,
-                    show.full_name
+                    show.series_info
                 )
 
 
@@ -152,8 +152,8 @@ class Manager:
 
         for show_archive in (pbar := tqdm(self.archives)):
             # Update progress bar
-            pbar.set_description(f'Updating archive for "'
-                                 f'{show_archive.name[:20]}"')
+            pbar.set_description(f'Updating archive for '
+                                 f'"{show_archive.series_info.short_name}"')
 
             # If TMDb is globally enabled, pass the interface along
             if self.preferences.use_tmdb:
@@ -174,7 +174,7 @@ class Manager:
         for show_archive in (pbar := tqdm(self.archives)):
             # Update progress bar
             pbar.set_description(f'Creating ShowSummary for "'
-                                 f'{show_archive.name[:20]}"')
+                                 f'{show_archive.series_info.short_name}"')
 
             # If TMDb is globally enabled, pass the interface along
             if self.preferences.use_tmdb:

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -1,0 +1,120 @@
+from re import match
+
+class SeriesInfo:
+    """
+    This class encapsulates information that is tied to a single Series.
+    """
+
+    """After how many characters to truncate the short name"""
+    SHORT_WIDTH = 15
+
+    def __init__(self, name: str, year: int) -> None:
+        """
+        Constructs a new instance.
+        
+        :param      name:  The name of the series.
+        :param      year:  The air year of the series.
+        """
+
+        # Set base attributes
+        self.name = str(name)
+        self.year = int(year)
+
+        # Set short name
+        if len(self.name) > self.SHORT_WIDTH:
+            self.short_name = f'{self.name[:self.SHORT_WIDTH]}..'
+        else:
+            self.short_name = self.name
+
+        # Set full and match name
+        self.full_name = f'{name} ({year})'
+        self.match_name = self.get_matching_title(self.name)
+
+        # Optional attributes
+        self.sonarr_id = None
+        self.tvdb_id = None
+        self.tmdb_id = None
+
+
+    def __str__(self) -> str:
+        """Returns a string representation of the object."""
+
+        return self.full_name
+
+
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return (f'<SeriesInfo name={self.name}, year={self.year}, sonarr_id='
+                f'{self.sonarr_id}, tvdb_id={self.tvdb_id}, tmdb_id='
+                f'{self.tmdb_id}>')
+
+
+    def update_name(self, name: str) -> None:
+        """
+        Update the name for this SeriesInfo.
+        
+        :param      name:  The new name of the series info.
+        """
+
+        self.name = name
+        self.full_name = f'{name} ({self.year})'
+
+
+    def set_sonarr_id(self, sonarr_id: int) -> None:
+        """
+        Set the Sonarr ID for this series.
+        
+        :param      sonarr_id:  The Sonarr ID used for this series.
+        """
+        
+        self.sonarr_id = int(sonarr_id)
+
+
+    def set_tvdb_id(self, tvdb_id: int) -> None:
+        """
+        Set the TVDb ID for this series.
+        
+        :param      tvdb_id:  The TVDb ID for this series.
+        """
+
+        self.tvdb_id = int(tvdb_id)
+
+
+    def set_tmdb_id(self, tmdb_id: int) -> None:
+        """
+        Set the TMDb ID for this series.
+        
+        :param      tmdb_id:    The TMDb ID for this series.
+        """
+
+        self.tmdb_id = int(tmdb_id)
+
+
+    @staticmethod
+    def get_matching_title(text: str) -> str:
+        """
+        Remove all non A-Z characters from the given title.
+        
+        :param      text:   The title to strip of special characters.
+        
+        :returns:   The input `text` with all non A-Z characters removed.
+        """
+
+        return ''.join(filter(lambda c: match('[a-zA-Z0-9]', c), text)).lower()
+
+
+    def matches(self, *names: tuple) -> bool:
+        """
+        Get whether any of the given names match this Series.
+        
+        :param      names:  The names to check
+        
+        :returns:   True if any of the given names match this series, False
+                    otherwise.
+        """
+
+        matching_names = map(self.get_matching_title, names)
+
+        return any(name == self.match_name for name in matching_names)
+        

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -10,6 +10,7 @@ from modules.Debug import *
 from modules.Episode import Episode
 import modules.preferences as global_preferences
 from modules.Profile import Profile
+from modules.SeriesInfo import SeriesInfo
 from modules.TitleCard import TitleCard
 
 class Show:
@@ -56,31 +57,30 @@ class Show:
         self.preferences = global_preferences.pp
         
         # Parse arguments given by the creator of this object
-        self.name = str(name)
         self.__yaml = yaml_dict
         self.__library_map = library_map
 
         # If year isn't given, skip completely
         if not self.__is_specified('year'):
-            error(f'Series "{self.name}" is missing required "year"')
+            error(f'Series "{name}" is missing required "year"')
             self.valid = False
             return 
 
         # Year is given, parse and update year/full name of this show
         year = self.__yaml['year']
         if not match(r'^\d{4}$', str(year)):
-            error(f'Year "{year}" of series "{self.name}" is invalid')
+            error(f'Year "{year}" of series "{name}" is invalid')
             self.valid = False
             return
-        else:
-            self.year = int(year)
-            self.full_name = f'{self.name} ({self.year})'
+
+        # Set this show's SeriesInfo object
+        self.series_info = SeriesInfo(name, year)
         
         # Setup default values that can be overwritten by the YML
         self.library_name = None
         self.library = None
         self.card_class = TitleCard.CARD_TYPES[self.preferences.card_type]
-        self.source_directory = source_directory / self.full_name
+        self.source_directory = source_directory / self.series_info.full_name
         self.episode_text_format = 'EPISODE {episode_number}'
         self.archive = True
         self.sonarr_sync = True
@@ -94,13 +94,16 @@ class Show:
         self.__episode_range = {}
         self.__season_map = {n: f'Season {n}' for n in range(1, 1000)}
         self.__season_map[0] = 'Specials'
+        self.title_language = {}
 
         # Modify object attributes based off YAML and update validity attribute
         self.valid = True
         self.__parse_yaml()
 
         # Update non YAML-able attributes for this show now that overwriting has occurred
-        self.media_directory = self.library / self.full_name if self.library else None
+        self.media_directory = None
+        if self.library:
+            self.media_directory = self.library / self.series_info.full_name
         self.logo = self.source_directory / self.preferences.logo_filename
         self.file_interface = DataFileInterface(
             self.source_directory / DataFileInterface.GENERIC_DATA_FILE_NAME
@@ -125,25 +128,20 @@ class Show:
 
 
     def __repr__(self) -> str:
-        """
-        Returns a unambiguous string representation of the object (for debug...).
-        
-        :returns:   String representation of the object.
-        """
+        """Returns a unambiguous string representation of the object"""
 
-        return f'<Show "{self.full_name}" with {len(self.episodes)} Episodes>'
+        return f'<Show "{self.series_info}" with {len(self.episodes)} Episodes>'
 
 
     def __parse_yaml(self):
         """
-        Parse the show's YAML and update this object's attributes. Error on
-        any invalid attributes and update `valid` attribute.
+        Parse the show's YAML and update this object's attributes. Error on any
+        invalid attributes and update `valid` attribute.
         """
 
         # Read all optional tags
         if self.__is_specified('name'):
-            self.name = self.__yaml['name']
-            self.full_name = f'{self.name} ({self.year})'
+            self.series_info.update_name(self.__yaml['name'])
 
         if self.__is_specified('library'):
             value = self.__yaml['library']
@@ -324,24 +322,11 @@ class Show:
         # filename += TitleCard.OUTPUT_CARD_EXTENSION
         # The standard plex filename for this episode
         filename = (
-            f'{self.full_name} - S{season_number:02}E{episode_number:02}'
-            f'{TitleCard.OUTPUT_CARD_EXTENSION}'
+            f'{self.series_info.full_name} - S{season_number:02}'
+            f'E{episode_number:02}{TitleCard.OUTPUT_CARD_EXTENSION}'
         )
 
         return self.media_directory / season_folder / filename
-
-
-    @staticmethod
-    def strip_specials(text: str) -> str:
-        """
-        Remove all non A-Z characters from the given title.
-        
-        :param      text:   The title to strip of special characters.
-        
-        :returns:   The input `text` with all non A-Z characters removed.
-        """
-
-        return ''.join(filter(lambda c: match('[a-zA-Z0-9]', c), text)).lower()
 
 
     def read_source(self, sonarr_interface: 'SonarrInterface'=None) -> None:
@@ -401,10 +386,10 @@ class Show:
         # Get dict of episode data from Sonarr
         try:
             all_episodes = sonarr_interface.get_all_episodes_for_series(
-                self.name, self.year
+                self.series_info
             )
         except ValueError:
-            error(f'Cannot find series "{self.full_name}" in Sonarr', 1)
+            error(f'Cannot find series "{self.series_info}" in Sonarr', 1)
             return False
 
         # For each episode, check if the data matches any contained Episode objects
@@ -428,13 +413,13 @@ class Show:
         return False
 
 
-    def create_missing_title_cards(self,
-                                   tmdb_interface: 'TMDbInterface'=None) ->bool:
+    def create_missing_title_cards(self, tmdb_interface: 'TMDbInterface'=None,
+                              sonarr_interface: 'SonarrInterface'=None) -> bool:
         """
         Creates any missing title cards for each episode of this show.
 
-        :param      tmdb_interface: Optional interface to TMDb for attempting to
-                                    download any source images that are missing.
+        :param      tmdb_interface: Optional interface to TMDb to download any
+                                    source images that are missing.
 
         :returns:   True if any new cards were created, False otherwise.
         """
@@ -442,6 +427,11 @@ class Show:
         # If the media directory is unspecified, then exit
         if self.media_directory is None:
             return False
+
+        # If using Sonarr, get the TVDb ID for this show
+        tvdb_id = None
+        if sonarr_interface:
+            sonarr_interface.set_tvdb_id_for_series(self.series_info)
 
         # Go through each episode for this show
         created_new_cards = False
@@ -470,8 +460,7 @@ class Show:
 
                 # Query database for image
                 image_url = tmdb_interface.get_title_card_source_image(
-                    self.name,
-                    self.year,
+                    self.series_info,
                     episode.season_number,
                     episode.episode_number,
                     episode.abs_number,

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -60,14 +60,18 @@ class ShowArchive:
         self.summaries = []
 
         # If the base show for this object has archiving disabled, exit
-        self.name = base_show.name
-        self.full_name = base_show.full_name
+        self.series_info = base_show.series_info
         self.__base_show = base_show
         if not base_show.archive:
             return
 
         # For each applicable sub-profile, create and modify new show/show summary
-        for profile_attributes in base_show.profile.get_valid_profiles(base_show.card_class):
+        valid_profiles = base_show.profile.get_valid_profiles(
+            base_show.card_class
+        )
+
+        # Go through each valid profile
+        for profile_attributes in valid_profiles:
             # Create show object for this profile
             new_show = deepcopy(base_show)
 
@@ -81,7 +85,7 @@ class ShowArchive:
                 profile_directory += f' - {base_show.card_class.ARCHIVE_NAME}'
 
             new_show.media_directory = (
-                archive_directory / new_show.full_name / profile_directory
+                archive_directory/base_show.series_info.full_name/profile_directory
             )
 
             # Convert this new show's profile
@@ -134,10 +138,7 @@ class ShowArchive:
             # If the logo doesn't exist, and we're given a TMDBInterface,
             # attempt to download the best logo
             if not summary.logo.exists() and tmdb_interface:
-                logo = tmdb_interface.get_series_logo(
-                    self.__base_show.name,
-                    self.__base_show.year,
-                )
+                logo = tmdb_interface.get_series_logo(self.series_info)
 
                 # If a valid logo was returned, download it
                 if logo == None:

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -75,8 +75,8 @@ class ShowSummary(ImageMaker):
         # Skip if the number of available episodes is below the minimum
         minimum = self.preferences.summary_minimum_episode_count
         if episode_count < minimum:
-            info(f'Skipping ShowSummary for {self.show.full_name} - has '
-                 f'{episode_count} episodes, minimum setting is {minimum}', 1)
+            info(f'Skipping ShowSummary for {self.show.series_info.full_name} -'
+                 f' has {episode_count} episodes, minimum setting is {minimum}')
             return None
 
         # Get a random subset of images to create the summary with

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from pickle import dump, load, HIGHEST_PROTOCOL
 
 from modules.Debug import *
-from modules.Show import Show
+from modules.SeriesInfo import SeriesInfo
 from modules.Title import Title
 from modules.WebInterface import WebInterface
 
@@ -15,10 +15,13 @@ class SonarrInterface(WebInterface):
     """
 
     """Datetime format string for airDateUtc field in Sonarr API requests"""
-    __AIRDATE_FORMAT: str = '%Y-%m-%dT%H:%M:%SZ'
+    __AIRDATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
     """Path to the map of sonarr titles to ID's"""
-    __ID_MAP: Path = Path(__file__).parent / '.objects' / 'sonarr_id_map.pkl'
+    __ID_MAP = Path(__file__).parent / '.objects' / 'sonarr_id_map.pkl'
+
+    """Path to the mapping of Sonarr IDs to TVDb ID's"""
+    __TVDB_ID_MAP = Path(__file__).parent / '.objects' / 'sid_tvdb_id.pkl'
 
     def __init__(self, url: str, api_key: str) -> None:
         """
@@ -33,6 +36,7 @@ class SonarrInterface(WebInterface):
 
         # Create objects directory if it does not exist
         self.__ID_MAP.parent.mkdir(parents=True, exist_ok=True)
+        self.__TVDB_ID_MAP.parent.mkdir(parents=True, exist_ok=True)
 
         # Attempt to read existing ID map
         if self.__ID_MAP.exists():
@@ -40,6 +44,12 @@ class SonarrInterface(WebInterface):
                 self.__id_map = load(file_handle)
         else:
             self.__id_map = {}
+
+        if self.__TVDB_ID_MAP.exists():
+            with self.__TVDB_ID_MAP.open('rb') as file_handle:
+                self.__tvdb_id_map = load(file_handle)
+        else:
+            self.__tvdb_id_map = {}
 
         # Add /api/ endpoint if not provided
         if not url.endswith('api') and not url.endswith('api/'):
@@ -50,38 +60,49 @@ class SonarrInterface(WebInterface):
         self._param_base = {'apikey': api_key}
 
 
-    def __add_id_to_map(self, full_title: str, id_: int) -> None:
+    def __map_title_to_id(self, series_info: SeriesInfo) -> None:
         """
-        Add the given ID to the object's map. Also write this updated map object
-        to the file.
+        Add the given ID to the object's map. Write this updated map object to
+        the file.
         
-        :param      full_title: The full title of the entry to map.
-        :param      id_:        The ID of the entry to store.
+        :param      series_info:    SeriesInfo to modify
         """
 
-        self.__id_map[full_title] = int(id_)
+        # Add to map
+        self.__id_map[series_info.full_name] = series_info.sonarr_id
 
+        # Write new map to file
         with self.__ID_MAP.open('wb') as file_handle:
             dump(self.__id_map, file_handle, HIGHEST_PROTOCOL)
 
 
-    def _get_series_id(self, title: str, year: int) -> int:
+    def __map_id_to_tvdb(self, series_info: SeriesInfo) -> None:
+        """
+        Add the given Sonarr ID to the object's mapping of Sonarr ID's to TVDb
+        ID's. Write this updated map object to the file.
+        
+        :param      series_info:    SeriesInfo to modify
+        """
+
+        # Add to map
+        self.__tvdb_id_map[series_info.sonarr_id] = series_info.tvdb_id
+
+        # Write new map to file
+        with self.__TVDB_ID_MAP.open('wb') as file_handle:
+            dump(self.__tvdb_id_map, file_handle, HIGHEST_PROTOCOL)
+
+
+    def __set_sonarr_id(self, series_info: SeriesInfo) -> None:
         """
         Gets the series ID used by Sonarr to identify this show.
         
-        :param      title:  The title of the series.
-        
-        :returns:   The series ID as used by Sonarr, None if the series was
-                    not found.
+        :param      series_info:    SeriesInfo to modify
         """
 
-        # Get titles to operate with
-        full_title = f'{title} ({year})'
-        match_title = Show.strip_specials(title)
-
-        # If already mapped, return
-        if full_title in self.__id_map:
-            return self.__id_map[full_title]
+        # If already mapped, return th
+        if series_info.full_name in self.__id_map:
+            series_info.set_sonarr_id(self.__id_map[series_info.full_name])
+            return None
 
         # Construct GET arguments
         url = f'{self._url_base}series/'
@@ -93,32 +114,24 @@ class SonarrInterface(WebInterface):
         # Go through each series
         for show in all_series:
             # Skip shows with a year mismatch, prevents parsing titles (slower)
-            if int(show['year']) != year:
+            if int(show['year']) != series_info.year:
                 continue
 
             # Year matches, verify the given title matches main/alternate titles
-            current_title = Show.strip_specials(show['title'])
-            alternate_titles = [
-                Show.strip_specials(_['title']) for _ in show['alternateTitles']
-            ]
+            if series_info.matches(show['title'], *show['alternateTitles']):
+                series_info.set_sonarr_id(show['id'])
+                self.__map_title_to_id(series_info)
 
-            if match_title == current_title or match_title in alternate_titles:
-                id_ = int(show['id'])
-                self.__add_id_to_map(full_title, id_)
-
-                return id_
-
-        return None
+                return None
 
 
-    def get_absolute_episode_number(self, title: str, year: int,
+    def get_absolute_episode_number(self, series_info: SeriesInfo,
                                     season_number: int,
                                     episode_number: int) -> int:
         """
         Gets the absolute episode number of the given entry.
         
-        :param      title:          The title of the series.
-        :param      year:           The year of the series.
+        :param      series_info:    SeriesInfo for the entry.
         :param      season_number:  The season number of the entry.
         :param      episode_number: The episode number of the entry.
         
@@ -127,15 +140,15 @@ class SonarrInterface(WebInterface):
         """
 
         # Get the ID for this series
-        series_id = self._get_series_id(title, year)
+        self.__set_sonarr_id(series_info)
 
         # If not found, skip
-        if not series_id:
-            error(f'Cannot find series "{title} ({year})" in Sonarr')
+        if not series_info.sonarr_id:
+            error(f'Cannot find series "{series_info}" in Sonarr')
             return None
 
         # Get all episodes, and match by season+episode number
-        for episode in self._get_all_episode_data_for_id(series_id):
+        for episode in self._get_all_episode_data_for_id(series_info):
             season_match = (episode['season_number'] == season_number)
             episode_match = (episode['episode_number'] == episode_number)
 
@@ -167,38 +180,6 @@ class SonarrInterface(WebInterface):
             padding = len(f'{show["id"]} : ')
             titles = f'\n{" " * padding}'.join([main_title] + alt_titles)
             print(f'{show["id"]} : {titles}')
-
-
-    def _get_episode_title_for_id(self, series_id: int, season: int,
-                                  episode: int) -> Title:
-        """
-        Gets the episode title for a given series ID and season/episode number.
-        
-        :param      series_id:  The series identifier
-        
-        :returns:   The episode title.
-        """
-
-        # Construct GET arguments
-        url = f'{self._url_base}episode/'
-        params = self._param_base
-        params.update(seriesId=series_id)
-
-        # Query Sonarr to get JSON of all episodes for this series id
-        all_episodes = self._get(url, params)
-
-        # Go through each episode
-        for episode in all_episodes:
-            curr_season_number = int(episode['seasonNumber'])
-            curr_episode_number = int(episode['episodeNumber'])
-
-            if season == curr_season_number and episode == curr_season_number:
-                return Title(episode['title'])
-
-        raise ValueError(
-            f'Cannot find Season {season}, Episode {episode} of '
-            f'seriesId={series_id}'
-        )
 
 
     def _get_all_episode_data_for_id(self, series_id: int) -> list:
@@ -254,44 +235,60 @@ class SonarrInterface(WebInterface):
         return episode_info
 
 
-    def get_episode_title(self, title: str, year: int, season: int,
-                          episode: int) -> Title:
-        """
-        Gets the episode title of the requested entry.
-        
-        :param      title:      The title of the requested series.
-        :param      year:       The year of the requested series.
-        :param      season:     The season number of the entry.
-        :param      episode:    The episode number of the entry.
-        
-        :returns:   The episode title.
-        """
-
-        series_id = self._get_series_id(title, year)
-
-        return self._get_episode_title_for_id(series_id, season, episode)
-
-
-    def get_all_episodes_for_series(self, title: str, year: int) -> list:
+    def get_all_episodes_for_series(self, series_info: SeriesInfo) -> list:
         """
         Gets all episode info for the given series title from Sonarr. The
         returned info is season/episode number and title for each episode.
 
         Only episodes that have already aired are returned.
         
-        :param      title:  The title of the series.
-        :param      year:   The year of the series.
+        :param      series_info:    SeriesInfo for the entry.
         
         :returns:   List of dictionaries of episode data.
         """
 
-        series_id = self._get_series_id(title, year)
+        # Set the Sonarr ID for this series
+        self.__set_sonarr_id(series_info)
 
-        if series_id == None:
-            error(f'Series "{title} ({year})" not found in Sonarr')
+        # If no ID was returned, error and return an empty list
+        if series_info.sonarr_id == None:
+            error(f'Series "{series_info}" not found in Sonarr')
             return []
 
-        return self._get_all_episode_data_for_id(series_id)
+        return self._get_all_episode_data_for_id(series_info.sonarr_id)
+
+
+    def set_tvdb_id_for_series(self, series_info: SeriesInfo) -> None:
+        """
+        Set the TVDb ID to the given SeriesInfo object.
+
+        :param      series_info:    SeriesInfo for the entry.
+        """
+
+        # Set the Sonarr ID for this series
+        self.__set_sonarr_id(series_info)
+
+        # If no ID was returned, error and return
+        if series_info.sonarr_id == None:
+            error(f'Series "{series_info}" not found in Sonarr')
+            return None
+
+        # If the series ID has already been mapped, return that value
+        if series_info.sonarr_id in self.__tvdb_id_map:
+            series_info.set_tvdb_id(self.__tvdb_id_map[series_info.sonarr_id])
+            return None
+
+        # Construct GET arguments
+        url = f'{self._url_base}series/{series_info.sonarr_id}'
+        params = self._param_base
+        params.update({'id': series_info.sonarr_id})
+
+        # Query Sonarr for info on this series
+        sonarr_info = self._get(url, params)
+
+        # Add this ID to the map
+        series_info.set_tvdb_id(sonarr_info['tvdbId'])
+        self.__map_id_to_tvdb(series_info)
 
 
     #TODO immplement
@@ -306,7 +303,7 @@ class SonarrInterface(WebInterface):
     #         return None
 
     #     # Get the ID for this series
-    #     series_id = self._get_series_id(title, year)
+    #     series_id = self.__set_sonarr_id(title, year)
 
     #     # Construct GET arguments
     #     url = f'{self._url_base}series/'
@@ -349,17 +346,22 @@ class SonarrInterface(WebInterface):
 
 
     @staticmethod
-    def manually_specify_id(title: str, year: int, id_: int) -> None:
+    def manually_specify_id(title: str, year: int, sonarr_id: int) -> None:
         """
         Manually override the Sonarr ID for the given full title.
 
-        :param      title:  The title of the series.
-        :param      year:   The year of the series.
-        :param      id_:    The Sonarr ID for this series.
+        :param      title:      The title of the series.
+        :param      year:       The year of the series.
+        :param      sonarr_id:  The Sonarr ID for this series.
         """
 
-        SonarrInterface('', '').__add_id_to_map(f'{title} ({year})', id_)
-        info(f'Specified ID {id_} for "{title} ({year})"')
+        # Create SeriesInfo object for this info
+        series_info = SeriesInfo(title, year)
+        series_info.set_sonarr_id(sonarr_id)
+
+        SonarrInterface('', '').__map_title_to_id(series_info)
+
+        info(f'Specified ID {series_info.sonarr_id} for "{series_info}"')
         
 
 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -5,6 +5,7 @@ from urllib.request import urlretrieve
 
 from modules.Debug import *
 import modules.preferences as global_preferences
+from modules.SeriesInfo import SeriesInfo
 from modules.WebInterface import WebInterface
 
 class TMDbInterface(WebInterface):
@@ -59,19 +60,18 @@ class TMDbInterface(WebInterface):
         self.__api_key = api_key
 
 
-    def __update_blacklist(self, title: str, year: int, season: int,
+    def __update_blacklist(self, series_info: SeriesInfo, season: int,
                            episode: int) -> None:
         """
         Adds the given entry to the blacklist; indicating that this exact entry
         shouldn't be queried to TheMovieDB (to prevent unnecessary queries).
         
-        :param      title:      The show's title.
-        :param      year:       The show's year.
-        :param      season:     The entry's season number.
-        :param      episode:    The entry's episode number.
+        :param      series_info:    SeriesInfo for the entry.
+        :param      season:         The entry's season number.
+        :param      episode:        The entry's episode number.
         """
 
-        key = f'{title} ({year})-{season}-{episode}'
+        key = f'{series_info.full_name}-{season}-{episode}'
 
         # If previously indexed and next has passed, increase count and set next
         later = datetime.now() + timedelta(days=1)
@@ -86,28 +86,27 @@ class TMDbInterface(WebInterface):
             # Add new entry to blacklist with 1 failure, next time is in one day
             self.__blacklist[key] = {'failures': 1, 'next': later}
 
-        warn(f'Query failed {self.__blacklist[key]["failures"]} times', 3)
+        # warn(f'Query failed {self.__blacklist[key]["failures"]} times', 2)
 
         # Write latest version of blacklist to file, in case program exits
         with self.__BLACKLIST.open('wb') as file_handle:
             dump(self.__blacklist, file_handle, HIGHEST_PROTOCOL)
 
 
-    def __is_blacklisted(self, title: str, year: int, season: int,
+    def __is_blacklisted(self, series_info: SeriesInfo, season: int,
                          episode: int) -> bool:
         """
         Determines if the specified entry is in the blacklist (i.e. should
         not bother querying TMDb.
         
-        :param      title:      The show's title.
-        :param      year:       The show's year.
-        :param      season:     The entry's season number.
-        :param      episode:    The entry's episode number.
+        :param      series_info:    SeriesInfo for the entry.
+        :param      season:         The entry's season number.
+        :param      episode:        The entry's episode number.
         
         :returns:   True if the entry is blacklisted, False otherwise.
         """
 
-        key = f'{title} ({year})-{season}-{episode}'
+        key = f'{series_info.full_name}-{season}-{episode}'
 
         # If never indexed before, skip failure check
         if key not in self.__blacklist:
@@ -121,17 +120,22 @@ class TMDbInterface(WebInterface):
         return datetime.now() < self.__blacklist[key]['next']
 
 
-    def __add_id_to_map(self, title: str, year: int, id_: int) -> None:
+    def __add_id_to_map(self, series_info: SeriesInfo) -> None:
         """
-        Adds a mapping of this full title to the corresponding TheMovieDB ID.
+        Adds a mapping of this full title to the corresponding TheMovieDB ID. If
+        a TVDb ID was provided, map that as well
         
-        :param      title:  The show's title.
-        :param      year:   The show's year.
-        :param      id_:    The show's ID, as returned by `__get_tv_id()`.
+        :param      series_info:    SeriesInfo for the entry.
         """
 
-        self.__id_map[f'{title} ({year})'] = id_
+        # Map full title to the TMDb id
+        self.__id_map[series_info.full_name] = series_info.tmdb_id
 
+        # If TVDb ID is available, map TVDb ID to the TMDb ID
+        if series_info.tvdb_id != None:
+            self.__id_map[series_info.tvdb_id] = series_info.tmdb_id
+
+        # Write updated map to file
         with self.__ID_MAP.open('wb') as file_handle:
             dump(self.__id_map, file_handle, HIGHEST_PROTOCOL)
 
@@ -180,41 +184,65 @@ class TMDbInterface(WebInterface):
         info(f'Deleted blacklist file "{TMDbInterface.__BLACKLIST.resolve()}"')
 
 
-    def __get_tv_id(self, title: str, year: int) -> int:
+    def __set_tmdb_id(self, series_info: SeriesInfo) -> None:
         """
-        Get the internal TMDb ID for the provided series. Matching is done by
-        name and the start air year.
-
-        The first result is returned every time.
+        Get the TMDb series ID associated with the given entry. If an ID is not
+        provided, then matching is done with title and year. If this has been
+        mapped previously, get value from map.
         
-        :param      title:  The title of the requested series
-        :param      year:   The year the requested series first aired
-        
-        :returns:   The internal TMDb ID for the found series
+        :param      series_info:    SeriesInfo for the entry.
         """
 
-        # If this full title has been mapped, no need to query 
-        if f'{title} ({year})' in self.__id_map:
-            return self.__id_map[f'{title} ({year})']
+        # If TVDb ID is available and is mapped, set that ID
+        if series_info.tvdb_id != None and series_info.tvdb_id in self.__id_map:
+            series_info.set_tmdb_id(self.__id_map[series_info.tvdb_id])
+            return None
 
-        # Base params are api_key and the query (title)
+        # If already mapped, set that ID
+        if series_info.full_name in self.__id_map:
+            series_info.set_tmdb_id(self.__id_map[series_info.full_name])
+            return None
+
+        # Match by TVDB ID if available
+        if series_info.tvdb_id != None:
+            # Construct GET arguments
+            url = f'{self.API_BASE_URL}find/{series_info.tvdb_id}'
+            params = {'api_key': self.__api_key, 'external_source': 'tvdb_id'}
+
+            # Query TMDb
+            results = self._get(url=url, params=params)['tv_results']
+
+            if len(results) == 0:
+                # If there is no entry with this ID, error and return
+                error(f'TMDb returned no results for "{series_info}"')
+            elif len(results) != 1:
+                # If more than one entry was returned (somehow?), warn
+                warn(f'TMDb returned >1 series for "{series_info}"')
+            else:
+                # Get the TMDb ID for this series, set for object and add to map
+                tmdb_id = results[0]['id']
+                series_info.set_tmdb_id(tmdb_id)
+                self.__add_id_to_map(series_info)
+                return None
+
+        # Match by title and year if no ID was given
+        # Construct GET arguments
         url = f'{self.API_BASE_URL}search/tv/'
-        params = {'api_key': self.__api_key, 'query': title,
-                  'first_air_date_year': year}
+        params = {'api_key': self.__api_key, 'query': series_info.name,
+                  'first_air_date_year': series_info.year}
 
-        # Query TheMovieDB
+        # Query TMDb
         results = self._get(url=url, params=params)
 
         # If there are no results, error and return
         if int(results['total_results']) == 0:
-            error(f'TheMovieDB returned no results for "{title}"')
+            error(f'TMDb returned no results for "{series_info}"')
             return None
 
-        # Found new ID, add to map and return
-        new_id = results['results'][0]['id']
-        self.__add_id_to_map(title, year, new_id)
-
-        return new_id
+        # Get the TMDb ID for this series, set for object and add to map
+        tmdb_id = results[0]['id']
+        series_info.set_tmdb_id(tmdb_id)
+        self.__add_id_to_map(series_info)
 
 
     def __determine_best_image(self, images: list) -> dict:
@@ -255,89 +283,133 @@ class TMDbInterface(WebInterface):
         return images[best_image['index']] if valid_image else None
 
 
-    def get_title_card_source_image(self, title: str, year: int, season: int,
+    def get_title_card_source_image(self, series_info: SeriesInfo, season: int,
                                     episode: int, abs_number: int=None) -> str:
         """
         Get the best source image for the requested entry. The URL of this image
         is returned.
         
-        :param      title:      The title of the requested series.
-        :param      year:       The year of the requested series.
-        :param      season:     The season of the requested entry.
-        :param      episode:    The episode of the requested entry.
-        :param      abs_number: The absolute episode number of the entry.
+        :param      series_info:    SeriesInfo for the entry.
+        :param      season:         The season of the requested entry.
+        :param      episode:        The episode of the requested entry.
+        :param      abs_number:     The absolute episode number of the entry.
         
         :returns:   URL to the 'best' source image for the requested entry. None
                     if no images are available.
         """
 
         # Don't query the database if this episode is in the blacklist
-        if self.__is_blacklisted(title, year, season, episode):
+        if self.__is_blacklisted(series_info, season, episode):
             return None
 
-        # Get the TV id for the provided series+year
-        tv_id = self.__get_tv_id(title, year)
+        # Set the TV id for the provided series
+        self.__set_tmdb_id(series_info)
 
         # GET params
-        url = f'{self.API_BASE_URL}tv/{tv_id}/season/{season}/episode/{episode}/images'
+        url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/{season}'
+               f'/episode/{episode}/images')
         params = {'api_key': self.__api_key}
 
         # Make the GET request
         results = self._get(url=url, params=params)
 
-        # If an absolute number has been given and the first query failed, try again
-        if abs_number != None and 'success' in results and not results['success']:
-            info(f'Trying absolute episode number {abs_number} in different seasons', 2)
-
+        # If absolute number has been given and the first query failed,try again
+        if (abs_number != None and 'success' in results
+            and not results['success']):
             # Try surround season numbers (TMDb indexes these weirdly..)
             for new_season in range(1, season+1)[::-1]:
-                info(f'Trying /season/{new_season}/episode/{abs_number}', 3)
-                url = f'{self.API_BASE_URL}tv/{tv_id}/season/{new_season}/episode/{abs_number}/images'
+                url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
+                       f'{new_season}/episode/{abs_number}/images')
                 results = self._get(url=url, params=params)
                 if 'stills' in results:
                     break
 
         # If 'stills' wasn't in return JSON, episode wasn't found
         if 'stills' not in results:
-            warn(f'TMDb has no matching episode for "{title} ({year})" Season '
+            warn(f'TMDb has no matching episode for "{series_info}" Season '
                  f'{season}, Episode {episode}', 2)
-            self.__update_blacklist(title, year, season, episode)
+            self.__update_blacklist(series_info, season, episode)
             return None
 
         # If 'stills' is in JSON, but is empty, then TMDb has no images
         if len(results['stills']) == 0:
-            warn(f'TMDb has no images for "{title} ({year})" Season {season}, '
+            warn(f'TMDb has no images for "{series_info}" Season {season}, '
                  f'Episode {episode}', 2)
-            self.__update_blacklist(title, year, season, episode)
+            self.__update_blacklist(series_info, season, episode)
             return None
 
         # Get the best image, None is returned if requirements weren't met
         best_image = self.__determine_best_image(results['stills'])
         if not best_image:
-            warn(f'TMDb images for "{title} ({year})" Season {season}, Episode '
+            warn(f'TMDb images for "{series_info}" Season {season}, Episode '
                  f'{episode} do not meet dimensional requirements.', 2)
-            self.__update_blacklist(title, year, season, episode)
+            self.__update_blacklist(series_info, season, episode)
             return None
         
         return f'https://image.tmdb.org/t/p/original{best_image["file_path"]}'
 
 
-    def get_series_logo(self, title: str, year: int) -> str:
+    def get_episode_title(self, series_info: SeriesInfo, season: int,
+                          episode: int, abs_number: int=None,
+                          language_code: str='en-US') -> str:
+        """
+        Get the episode title for the given entry for the given language.
+        
+        :param      series_info:    SeriesInfo for the entry.
+        :param      season:         The season number of the episode.
+        :param      episode:        The episode number of the episode
+        :param      language_code:  The language code of the episode.
+        
+        :returns:   The episode title. None if the entry does not exist.
+        """
+
+        # Get the TV id for the provided series+year
+        self.__set_tmdb_id(series_info)
+
+        # GET params
+        url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/{season}'
+               f'/episode/{episode}')
+        params = {'api_key': self.__api_key, 'language': language_code}
+
+        # Make the GET request
+        results = self._get(url=url, params=params)
+
+        # If absolute number has been given and the first query failed,try again
+        if (abs_number != None and 'success' in results
+            and not results['success']):
+            # Try surround season numbers (TMDb indexes these weirdly..)
+            for new_season in range(1, season+1)[::-1]:
+                url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
+                       f'{new_season}/episode/{abs_number}')
+                results = self._get(url=url, params=params)
+
+                # Return name if this query succeeded
+                if 'name' in results:
+                    return results['name']
+
+        # No absolute number to test (or tried all), skip!
+        if 'success' in results and not results['success']:
+            return None
+
+        # Return the name for this episode
+        return results['name']
+
+
+    def get_series_logo(self, series_info: SeriesInfo) -> str:
         """
         Get the 'best' logo for the given series.
         
-        :param      title:  The title of the requested series.
-        :param      year:   The year of the requested series.
+        :param      series_info:    SeriesInfo for the entry.
         
         :returns:   URL to the 'best' logo for the given series, and None if no
                     images are available.
         """
 
-        # Get the TV id for the provided series+year
-        tv_id = self.__get_tv_id(title, year)
+        # Set the TV id for the provided series+year
+        self.__set_tmdb_id(series_info)
 
         # GET params
-        url = f'{self.API_BASE_URL}tv/{tv_id}/images'
+        url = f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/images'
         params = {'api_key': self.__api_key}
 
         # Make the GET request
@@ -345,7 +417,7 @@ class TMDbInterface(WebInterface):
 
         # If there are no logos, warn and exit
         if len(results['logos']) == 0:
-            warn(f'TMDb has no logos for "{title} ({year})"', 1)
+            warn(f'TMDb has no logos for "{series_info}"', 1)
             return None
 
         # Pick the best image based on image dimensions

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -240,8 +240,7 @@ class TMDbInterface(WebInterface):
             return None
 
         # Get the TMDb ID for this series, set for object and add to map
-        tmdb_id = results[0]['id']
-        series_info.set_tmdb_id(tmdb_id)
+        series_info.set_tmdb_id(results['results'][0]['id'])
         self.__add_id_to_map(series_info)
 
 


### PR DESCRIPTION
# Major Changes
- Created new `SeriesInfo` class that contains *static* information about a given series, currently:
  - Title
  - Year
  - Internal Sonarr ID
  - TMDb ID
  - TVDb ID
- Rework aspects of `TitleCardManager`, `PlexInterface`,  `ShowArchive`, `SonarrInterface`, and `TMDbInterface` classes to use `SeriesInfo` objects rather than passing titles, years, ID's, etc.
- Updated `TMDbInterface` to attempt to match a series by the series' TVDb ID **first**, and if that fails then the fallback method is matching by series name and year (like before)
  - Closes #22 
# Major Fixes 
N/A
# Minor Changes
N/A
# Minor Fixes
N/A