### PR TITLE
Added adjustable title card filename

### DIFF
--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -91,11 +91,7 @@ class Manager:
         """
 
         for show in tqdm(self.shows, desc='Reading source files'):
-            # Pass the Sonarr interface to the show if globally enabled
-            if self.sonarr_interface:
-                show.read_source(self.sonarr_interface)
-            else:
-                show.read_source()
+            show.read_source()
 
         for archive in tqdm(self.archives, desc='Reading archive source files'):
             archive.read_source()

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -40,6 +40,7 @@ class PreferenceParser:
         # Setup default values that can be overwritten by YAML
         self.series_files = []
         self.card_type = 'standard'
+        self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.archive_directory = None
         self.create_archive = False
         self.create_summaries = False
@@ -113,6 +114,13 @@ class PreferenceParser:
                 self.valid = False
             else:
                 self.card_type = value
+                
+        if self.__is_specified('options', 'filename_format'):
+            new_format = self.__yaml['options']['filename_format']
+            if not TitleCard.validate_card_format_string(new_format):
+                self.valid = False
+            else:
+                self.card_filename_format = new_format
 
         if self.__is_specified('archive', 'path'):
             self.archive_directory = Path(self.__yaml['archive']['path'])

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -273,16 +273,19 @@ class Show:
         return True
 
 
-    def _get_destination(self, entry: dict) -> Path:
+    def __get_destination(self, entry: dict) -> Path:
         """
-        Get the destination filename for the given entry.
+        Get the destination filename for the given entry of a datafile.
         
-        :param      entry:  The entry returned from a file interface.
+        :param      entry:  The entry returned from a file interface. Must
+                            have 'season_number', 'episode_number', and
+                            'title' keys.
         
-        :returns:   Path for the full title card destination
+        :returns:   Path for the full title card destination, and None
+                    if this show has no media directory.
         """
 
-        # If this show should not be written to a media directory, return 
+        # If this entry should not be written to a media directory, return 
         if not self.media_directory:
             return None
 
@@ -329,7 +332,7 @@ class Show:
             # Create Episode object for this entry, store under key
             self.episodes[key] = Episode(
                 base_source=self.source_directory,
-                destination=self._get_destination(entry),
+                destination=self.__get_destination(entry),
                 card_class=self.card_class,
                 **entry,
             )

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -21,20 +21,7 @@ class Show:
     within the Show's YAML take precedence over the global enables, with the
     exception of Interface objects (such as Sonarr and TMDb).
     """
-
-    # FILENAME_FORMAT_HELP_STRING: str = (
-    #     "Format String Options:\n"
-    #     "  {show}      : The show's name\n"
-    #     "  {year}      : The show's year\n"
-    #     "  {full_name} : The show's full name - equivalent to {show} ({year})\n"
-    #     "  {season}    : The episode's season number\n"
-    #     "  {episode}   : The episode's episode number\n"
-    #     "  {title}     : The episode title, as found in the source data file\n\n"
-    #     "Example: ShowX, aired in 2022, Season 1 Episode 10 titled 'Pilot'\n"
-    #     "  {show} - S{season:03} - {title}         -> ShowX - S001 - Pilot\n"
-    #     "  {full_name} - S{season:02}E{episode:02} -> ShowX (2022) - S01E10\n"
-    #     "  {show} {year} - S{season}E{episode}     -> ShowX 2022 - S1E10\n"
-    # )
+    
 
     def __init__(self, name: str, yaml_dict: dict, library_map: dict,
                  source_directory: Path) -> None:
@@ -329,41 +316,23 @@ class Show:
         return self.media_directory / season_folder / filename
 
 
-    def read_source(self, sonarr_interface: 'SonarrInterface'=None) -> None:
+    def read_source(self) -> None:
         """
         Read the source file for this show, adding the associated Episode
         objects to this show's episodes dictionary.
-
-        :param      sonarr_interface:   Optional SonarrInterface - currently
-                                        not used.
         """
 
+        # Go through each entry in the file interface
         for entry in self.file_interface.read():
             key = f'{entry["season_number"]}-{entry["episode_number"]}'
 
-            # Construct the file destination for Episode object building
+            # Create Episode object for this entry, store under key
             self.episodes[key] = Episode(
                 base_source=self.source_directory,
                 destination=self._get_destination(entry),
                 card_class=self.card_class,
                 **entry,
             )
-
-            # Attempt to use sonarr to figure out more accurate destination
-            # if sonarr_interface and preferences.card_name_source == 'sonarr':
-            #     episode_filename = sonarr_interface.get_episode_filename(
-            #         self.name,
-            #         self.year,
-            #         episode.season_number,
-            #         episode.episode_number,
-            #     )
-
-            #     # If the filename couldn't be gathered from Sonarr, None is returned
-            #     if episode_filename:
-            #         episode.destination = self.media_directory / episode_filename
-            #     print('Sonarr found filename', episode.destination)
-
-            # self.episodes[key] = episode
 
 
     def check_sonarr_for_new_episodes(self,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -288,35 +288,13 @@ class Show:
         # If this entry should not be written to a media directory, return 
         if not self.media_directory:
             return None
-
-        # Get season and episode number for this entry
-        try:
-            season_number = int(entry['season_number'])
-            episode_number = int(entry['episode_number'])
-        except ValueError:
-            error(f'Invalid season/episode number "{entry["season_number"]},'
-                  f' "{entry["episode_number"]}"', 1)
-            return None
-
-        # Get the season folder corresponding to this episode's season
-        if season_number == 0:
-            season_folder = 'Specials'
-        else:
-            season_folder = f'Season {season_number}'
-
-        # filename = preferences.card_filename_format.format(
-        #     show=self.name, year=self.year, full_name=self.full_name,
-        #     season=season_number, episode=episode_number,
-        #     title=entry['title'][0] + entry['title'][1],
-        # )
-        # filename += TitleCard.OUTPUT_CARD_EXTENSION
-        # The standard plex filename for this episode
-        filename = (
-            f'{self.series_info.full_name} - S{season_number:02}'
-            f'E{episode_number:02}{TitleCard.OUTPUT_CARD_EXTENSION}'
+        
+        return TitleCard.get_output_filename(
+            self.preferences.card_filename_format,
+            self.series_info,
+            entry,
+            self.media_directory
         )
-
-        return self.media_directory / season_folder / filename
 
 
     def read_source(self) -> None:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -291,60 +291,6 @@ class SonarrInterface(WebInterface):
         self.__map_id_to_tvdb(series_info)
 
 
-    #TODO immplement
-    # def get_episode_filename(self, title: str, year: int, season_number: int,
-    #                          episode_number: int) -> str:
-
-    #     """
-    #     { item_description }
-    #     """
-
-    #     if not self:
-    #         return None
-
-    #     # Get the ID for this series
-    #     series_id = self.__set_sonarr_id(title, year)
-
-    #     # Construct GET arguments
-    #     url = f'{self._url_base}series/'
-    #     params = self._param_base
-
-    #     # Query Sonarr to get all series in the library
-    #     all_series = self._get(url, params)
-
-    #     # Match by ID, get the top-level series folder
-    #     series_folder = None
-    #     for show in all_series:
-    #         if show['id'] == series_id:
-    #             series_folder = Path(show['path']).name
-    #             break
-
-    #     # If no top-level series folder (for some reason..), exit
-    #     if not series_folder:
-    #         return None
-
-    #     # Construct GET arguments for this specific episode
-    #     url = f'{self._url_base}episode/'
-    #     params = self._param_base
-    #     params['seriesId'] = series_id
-
-    #     # Query for all episodes of this show
-    #     all_episodes = self._get(url, params)
-
-    #     # Find this season/episode number
-    #     for episode in all_episodes:
-    #         if (int(episode['seasonNumber']) == season_number
-    #             and int(episode['episodeNumber']) == episode_number):
-    #             # If episode found, check if file exists and get that filename
-    #             if episode['hasFile']:
-    #                 full_path = episode['episodeFile']['relativePath']
-    #                 filename = full_path[:full_path.rfind('.')]
-
-    #                 return str(series_folder / Path(filename))
-
-    #     return None
-
-
     @staticmethod
     def manually_specify_id(title: str, year: int, sonarr_id: int) -> None:
         """

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -18,6 +18,9 @@ class TitleCard:
     """Extensions of the input source image and output title card"""
     INPUT_CARD_EXTENSION: str = '.jpg'
     OUTPUT_CARD_EXTENSION: str = '.jpg'
+        
+    """Default filename format for all title cards"""
+    DEFAULT_FILENAME_FORMAT = '{full_name} - S{season:02}E{episode:02}'
 
     """Mapping of card type identifiers to CardType classes"""
     CARD_TYPES = {
@@ -73,6 +76,28 @@ class TitleCard:
         # File associated with this card is the episode's destination
         self.file = episode.destination
 
+    @staticmethod
+    def validate_card_format_string(format_string: str) -> bool:
+        """
+        Return whether the given card filename format string is valid or
+        not.
+        
+        :param      format_string:  Format string being validated.
+        
+        :returns:   True if the given string can be formatted correctly,
+                    False otherwise.
+        """
+        
+        try:
+            format_string.format(
+                name='TestName', full_name='TestName (2000)', year=2000,
+                season=1, episode=1, title='Episode Title',
+            )
+            return True
+        except ValueError as e:
+            error(f'Card format string is invalid - "{e}"')
+            return False
+            
 
     def create(self) -> bool:
         """

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -1,4 +1,4 @@
-from modules.Debug import *
+from modules.Debug import info, warn, error
 
 # CardType classes
 from modules.AnimeCard import AnimeCard
@@ -75,7 +75,50 @@ class TitleCard:
 
         # File associated with this card is the episode's destination
         self.file = episode.destination
-
+        
+        
+    @staticmethod
+    def get_output_filename(format_string: str, series_info: 'SeriesInfo', 
+                            datafile_entry: dict,
+                            media_directory: 'Path') -> 'Path':
+        """
+        Get the output filename for a title card described by the given values.
+        
+        :param      format_string:      Format string that specifies how to 
+                                        construct the filename.
+        :param      series_info:        Series info pertaining to this entry
+        :param      datafile_entry:     Episode data of an entry, as returned
+                                        by a DataFileInterface. 
+        :param      media_directory:    Top-level media directory.
+        
+        :returns:   Path for the full title card destination.
+        """
+        
+        # Get season number for this entry
+        season_number = datafile_entry['season_number']
+        
+        # Get the season folder for this entry's season
+        if season_number == 0:
+            season_folder = 'Specials'
+        else:
+            season_folder = f'Season {season_number}'
+        
+        # Get filename from the given format string
+        filename = format_string.format(
+            name=series_info.name,
+            full_name=series_info.full_name,
+            year=series_info.year,
+            season=season_number,
+            episode=datafile_entry['episode_number'],
+            title=datafile_entry['title'].full_title,
+        )
+        
+        # Add card extension
+        filename += TitleCard.OUTPUT_CARD_EXTENSION
+        
+        return media_directory / season_folder / filename
+        
+        
     @staticmethod
     def validate_card_format_string(format_string: str) -> bool:
         """


### PR DESCRIPTION
# Major Changes
- Added parsing for "filename_format" option to "options" section of global preferences YAML to `PreferenceParser` class
  - Added `TitleCard.validate_card_format_string()` method to check whether a given format string is valid or not
- Added `DEFAULT_FILENAME_FORMAT` variable to `TitleCard` class that is set to `"{full_name} - S{season:02}E{episode:02}"`
- Added `TitleCard.get_output_filename()` method which returns the full path of a title card for a given format string, `SeriesInfo` object, datafile entry, and top-level media directory
- Adjusted `Show.__get_destination()` method to use new `TitleCard.get_output_filename()` method, which supports the arbitrary format string specified in the global preferences
  - Closes #13 
# Major Fixes 
N/A
# Minor Changes
- Removed unused (commented) method `SonarrInterface.get_episode_filename()`, as filename specification will be done via preference file, and querying Sonarr for every episode is too slow
- Remove `SonarrInterface` argument from `Show.read_source()`
- Renamed `Show._get_destination()` to `Show.__get_destination()` as method should only be called internally by Show objects
# Minor Fixes
N/A