### PR TITLE
Generalize line splitting, minor changes and fixes

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -13,6 +13,9 @@ parser = ArgumentParser(description='Manual fixes for the TitleCardMaker')
 parser.add_argument('-p', '--preference-file', type=Path, default='preferences.yml',
                     metavar='PREFERENCE_FILE',
                     help='Preference YAML file for parsing ImageMagick/Sonarr/TMDb options')
+parser.add_argument('--sort-data-file', type=Path, default=SUPPRESS,
+                    metavar='DATAFILE',
+                    help='Sort the given datafile')
 
 # Argument group for 'manual' title card creation
 title_card_group = parser.add_argument_group('Title Cards', 'Manual title card creation')
@@ -72,17 +75,23 @@ tmdb_group.add_argument('--delete-blacklist', action='store_true',
 # Check given arguments
 args = parser.parse_args()
 
+# Parse preference file for options that might need it
+pp = PreferenceParser(args.preference_file)
+if not pp.valid:
+    exit(1)
+set_preference_parser(pp)
+
 # Override unspecified defaults with their class specific defaults
 if args.font == Path('__default'):
     args.font = Path(TitleCard.CARD_TYPES[args.card_type].TITLE_FONT)
 if args.font_color == '__default':
     args.font_color = TitleCard.CARD_TYPES[args.card_type].TITLE_COLOR
 
-# Parse preference file for options that might need it
-pp = PreferenceParser(args.preference_file)
-if not pp.valid:
-    exit(1)
-set_preference_parser(pp)
+# Execute misc. options
+if hasattr(args, 'sort_data_file'):
+    dfi = DataFileInterface(args.sort_data_file)
+
+    dfi.sort(dfi._DataFileInterface__read_data())
 
 # Execute title card related options
 if hasattr(args, 'title_card'):

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -32,9 +32,6 @@ class CardType(ImageMaker):
     """Standard size for all title cards"""
     TITLE_CARD_SIZE: str = '3200x1800'
 
-    """Directory for all temporary images created during image creation"""
-    TEMP_DIR = Path(__file__).parent / '.objects'
-
     @property
     @abstractmethod
     def TITLE_CHARACTERISTICS(self) -> dict:

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -196,6 +196,33 @@ class DataFileInterface:
         # Update this entry with the new title(s)
         yaml[season_key][episode_number] = {'title': title.title_yaml}
         yaml[season_key][episode_number].update(extra_data)
+        
+        # Write updated data
+        self.__write_data(yaml)
+
+
+    def add_data_to_entry(self, season_number: int, episode_number: int,
+                          **new_data: dict) -> None:
+        """
+        Adds a data to entry.
+        
+        :param      season_number:   The season number
+        :param      episode_number:  The episode number
+        :param      new_data:        The new data
+        """
+
+        yaml = self.__read_data()
+
+        # Verify this entry already exists, warn and exit if not
+        season_key = f'Season {season_number}'
+        if (season_key not in yaml or episode_number not in yaml[season_key]):
+            warn(f'Cannot add data to entry for Season {season_number}, '
+                 f'Episode {episode_number} in "{self.file.resolve()}" - entry '
+                 f'does not exist')
+            return None
+
+        # Add new data
+        yaml[season_key][episode_number].update(new_data)
 
         # Write updated data
         self.__write_data(yaml)

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -76,10 +76,10 @@ class DataFileInterface:
 
         # Write updated data with this entry added
         with self.file.open('w') as file_handle:
-            dump({'data': yaml}, file_handle, allow_unicode=True)
+            dump({'data': yaml}, file_handle, allow_unicode=True, width=100)
 
 
-    def sort(self, yaml: dict) -> None:
+    def sort_and_write(self, yaml: dict) -> None:
         """
         Sort the given YAML and then write it to this interface's file. Sorting
         is done by season number, and then episode number, and then by info key.
@@ -97,7 +97,7 @@ class DataFileInterface:
                 sorted_yaml[season][episode] = {}
                 for key in sorted(yaml[season][episode]):
                     sorted_yaml[season][episode][key]=yaml[season][episode][key]
-
+                    
         # Write newly sorted YAML
         self.__write_data(yaml)
 
@@ -187,8 +187,7 @@ class DataFileInterface:
 
         # Verify this entry already exists, warn and exit if not
         season_key = f'Season {season_number}'
-        if (season_key not in yaml or 
-            episode_number not in yaml[season_key]):
+        if (season_key not in yaml or episode_number not in yaml[season_key]):
             warn(f'Cannot modify entry for Season {season_number}, Episode ',
                  f'{episode_number} in "{self.file.resolve()}" - entry does not'
                  f' exist')
@@ -266,8 +265,6 @@ class DataFileInterface:
 
             # If this episde already exists, warn and exit
             if episode in yaml[season_key]:
-                warn(f'Cannot add duplicate entry for Season {season}, Episode',
-                     f'{episode} in "{self.file.resolve()}"')
                 continue
 
             # Construct episode data
@@ -278,5 +275,5 @@ class DataFileInterface:
                 yaml[season_key][episode]['abs_number'] = entry['abs_number']
 
         # Write updated yaml
-        self.__write_data(yaml)
+        self.sort_and_write(yaml)
 

--- a/modules/GenreMaker.py
+++ b/modules/GenreMaker.py
@@ -17,11 +17,11 @@ class GenreMaker(ImageMaker):
     FONT = REF_DIRECTORY / 'MyriadRegular.ttf'
 
     """Base gradient image to overlay over source image"""
-    __GENRE_GRADIENT: Path = REF_DIRECTORY / 'genre_gradient.png'
+    __GENRE_GRADIENT = REF_DIRECTORY / 'genre_gradient.png'
 
     """Temporary image paths used in the process of title card making"""
-    __RESIZED_SOURCE: Path = Path(__file__).parent / '.objects' / 'resized.png'
-    __SOURCE_WITH_GRADIENT: Path = Path(__file__).parent / '.objects' /'swg.png'
+    __RESIZED_SOURCE = ImageMaker.TEMP_DIR / 'resized.png'
+    __SOURCE_WITH_GRADIENT = ImageMaker.TEMP_DIR / 'swg.png'
 
 
     def __init__(self, source: Path, genre: str, output: Path) -> None:

--- a/modules/ImageMaker.py
+++ b/modules/ImageMaker.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from modules.ImageMagickInterface import ImageMagickInterface
 import modules.preferences as global_preferences
@@ -12,6 +13,9 @@ class ImageMaker(ABC):
     function to produce an image. The specifics of how that image is created are
     completely customizable.
     """
+
+    """Directory for all temporary images created during image creation"""
+    TEMP_DIR = Path(__file__).parent / '.objects'
 
     @abstractmethod
     def __init__(self) -> None:

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -124,11 +124,17 @@ class Manager:
 
         for show in (pbar := tqdm(self.shows)):
             # Update progress bar
-            pbar.set_description(f'Creating Title Cards for "{show.name[:20]}"')
+            pbar.set_description(f'Creating Title Cards for '
+                                 f'"{show.series_info.short_name}"')
 
             # Pass the TMDbInterface to the show if globally enabled
             if self.preferences.use_tmdb:
-                created = show.create_missing_title_cards(self.tmdb_interface)
+                if self.preferences.use_sonarr:
+                    created = show.create_missing_title_cards(
+                        self.tmdb_interface, self.sonarr_interface
+                    )
+                else:
+                    created=show.create_missing_title_cards(self.tmdb_interface)
             else:
                 created = show.create_missing_title_cards()
 

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -16,19 +16,11 @@ class SeriesInfo:
         :param      year:  The air year of the series.
         """
 
-        # Set base attributes
-        self.name = str(name)
+        # Set year
         self.year = int(year)
 
-        # Set short name
-        if len(self.name) > self.SHORT_WIDTH:
-            self.short_name = f'{self.name[:self.SHORT_WIDTH]}..'
-        else:
-            self.short_name = self.name
-
-        # Set full and match name
-        self.full_name = f'{name} ({year})'
-        self.match_name = self.get_matching_title(self.name)
+        # Update all name attributes
+        self.update_name(name)
 
         # Optional attributes
         self.sonarr_id = None
@@ -57,8 +49,18 @@ class SeriesInfo:
         :param      name:  The new name of the series info.
         """
 
+        # Set name and full name
         self.name = name
         self.full_name = f'{name} ({self.year})'
+        
+        # Set short name
+        if len(self.name) > self.SHORT_WIDTH:
+            self.short_name = f'{self.name[:self.SHORT_WIDTH]}..'
+        else:
+            self.short_name = self.name
+            
+        # Set match name
+        self.match_name = self.get_matching_title(self.name)
 
 
     def set_sonarr_id(self, sonarr_id: int) -> None:

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -228,7 +228,8 @@ class Show:
             self.hide_seasons = bool(self.__yaml['seasons']['hide'])
 
         # Validate season map and episode range aren't specified at the same time
-        if self.__is_specified('seasons') and self.__is_specified('episode_ranges'):
+        if (self.__is_specified('seasons')
+            and self.__is_specified('episode_ranges')):
             if any(isinstance(key, int) for key in self.__yaml['seasons'].keys()):
                 error(f'Cannot specify season titles with both "seasons" and '
                       f'"episode_ranges"')

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -23,10 +23,10 @@ class ShowSummary(ImageMaker):
     LOGO_FILENAME: str = 'logo.png'
 
     """Paths to intermediate images created in the process of making a summary."""
-    __MONTAGE_PATH: Path = Path(__file__).parent / '.objects' / 'montage.png'
-    __MONTAGE_WITH_HEADER_PATH: Path = Path(__file__).parent / '.objects' / 'header.png'
-    __RESIZED_LOGO_PATH: Path = Path(__file__).parent / '.objects' / 'resized_logo.png'
-    __LOGO_AND_HEADER_PATH: Path = Path(__file__).parent / '.objects' / 'logo_and_header.png'
+    __MONTAGE_PATH = ImageMaker.TEMP_DIR / 'montage.png'
+    __MONTAGE_WITH_HEADER_PATH = ImageMaker.TEMP_DIR / 'header.png'
+    __RESIZED_LOGO_PATH = ImageMaker.TEMP_DIR / 'resized_logo.png'
+    __LOGO_AND_HEADER_PATH = ImageMaker.TEMP_DIR / 'logo_and_header.png'
     
     """Path to the 'created by' image to add to all show summaries"""
     __CREATED_BY_PATH: Path = Path(__file__).parent / 'ref' / 'created_by.png'

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -35,7 +35,7 @@ class StandardTitleCard(CardType):
 
     """Characteristics for title splitting by this class"""
     TITLE_CHARACTERISTICS = {
-        'max_line_width': 30,   # Character count to begin splitting titles
+        'max_line_width': 32,   # Character count to begin splitting titles
         'max_line_count': 3,    # Maximum number of lines a title can take up
         'top_heavy': False,     # This class uses bottom heavy titling
     }

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -18,6 +18,8 @@ class Title:
      "Sister Babysits"]
     """
 
+    SPLIT_CHARACTERS = (':', ',', ')', ']', '?', '!', '-', '.', '/')
+
     def __init__(self, title) -> None:
         """
         Constructs a new instance of a Title from either a full, unsplit title,
@@ -106,11 +108,11 @@ class Title:
             for _ in range(max_line_count+2-1):
                 # Start splitting from the last line added
                 top, bottom = all_lines.pop(), ''
-                while ((len(top) > max_line_width and ' ' in top) or
-                    len(bottom) in range(1, max_line_width//3)):
+                while ((len(top) > max_line_width or len(bottom) in range(1, 6))
+                        and ' ' in top):
                     # Look to split on special characters
                     special_split = False
-                    for char in (':', ',', '(', ')', '[', ']'):
+                    for char in self.SPLIT_CHARACTERS:
                         if f'{char} ' in top[:max_line_width]:
                             top, bottom_add = top.rsplit(f'{char} ', 1)
                             top += char
@@ -141,12 +143,12 @@ class Title:
         # For bottom heavy splitting, start on bottom and move text UP
         for _ in range(max_line_count+2-1):
             top, bottom = '', all_lines.pop()
-            while ((len(bottom) > max_line_width and ' ' in bottom) or
-                len(top) in range(1, max_line_width//3)):
+            while ((len(bottom) > max_line_width or len(top) in range(1, 6))
+                    and ' ' in bottom):
                 # Look to split on special characters
                 special_split = False
-                for char in (':', ',', '(', ')', '[', ']'):
-                    if f'{char} ' in bottom[:max_line_width]:
+                for char in self.SPLIT_CHARACTERS:
+                    if f'{char} ' in bottom[:min(max_line_width, len(bottom)//2)]:
                         top_add, bottom = bottom.split(f'{char} ', 1)
                         top = f'{top} {top_add}{char}'
                         special_split = True


### PR DESCRIPTION
# Major Changes
- Created `DataFileInterface.add_data_to_entry()` method to add data to an entry of a datafile, which is less error prone than the `modify_entry()` method (which should go away!)
- Added `--sort-data-file` option to fixer.py for manually sorting datafiles
-  Added generalized character set for title splitting
  - Added `SPLIT_CHARACTERS` tuple containing a set of characters that will are checked for quick line-splitting for `Title` objects.
    - Added ?, !, -, ., and / characters for quick splitting
    - Removed [ and ( characters from quick splitting (when would an open symbol be followed by a space? I don't know)
# Major Fixes 
- Updated `SeriesInfo` to correctly set all name variables when `update_name()` method is called
# Minor Changes
- Moved `TEMP_DIR` directory variable from `CardType` class to `ImageMaker`, as all `ImageMaker`'s use this directory, not just title cards
  - Modified `ShowSummary` and `GenreMaker` to use new `TEMP_DIR`
- Renamed `DataFileInterface.sort()` to `sort_and_write()`, as this more clearly indicates the method writes to the datafile at the end of execution
- Set datafile width parameter to 100 characters for better formatting
- Changing `StandardTitleCard` character limit to 32, 30 was too small for standard font
# Minor Fixes
N/A