### PR TITLE
Major episode matching rework by TVDb episode ID and title

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -57,9 +57,6 @@ sonarr_group.add_argument('--sonarr-list-ids', action='store_true',
 
 # Argument group for fixes relating to TheMovieDatabase
 tmdb_group = parser.add_argument_group('TheMovieDatabase', 'Fixes for how the Maker interacts with TheMovieDatabase')
-tmdb_group.add_argument('--tmdb-force-id', type=str, nargs=3, default=SUPPRESS, action='append',
-                        metavar=('TITLE', 'YEAR', 'TMDB_ID'),
-                        help='Manually specify an ID for a show')
 tmdb_group.add_argument('--tmdb-download-images', nargs=6, default=SUPPRESS, action='append',
                         metavar=('API_KEY', 'TITLE', 'YEAR', 'SEASON', 'EPISODES', 'DIRECTORY'),
                         help='Download the best title card source image for the given episode')
@@ -126,12 +123,6 @@ if args.sonarr_list_ids:
 if hasattr(args, 'delete_blacklist'):
     if args.delete_blacklist:
         TMDbInterface.delete_blacklist()
-
-if hasattr(args, 'tmdb_force_id'):
-    for arg_set in args.tmdb_force_id:
-        TMDbInterface.manually_specify_id(
-            title=arg_set[0], year=arg_set[1], id_=arg_set[2]
-        )
 
 if hasattr(args, 'tmdb_download_images'):
     for arg_set in args.tmdb_download_images:

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -1,23 +1,25 @@
 class EpisodeInfo:
     """
-    This class describes static information about an Episode.
+    This class describes static information about an Episode, such as the
+    season, episode, and absolute number, as well as the various ID's associated
+    with it - such as Sonarr, TVDb, and TMDb.
     """
 
     def __init__(self, title: 'Title', season_number: int, episode_number: int,
                  abs_number: int=None) -> None:
         """
-        Constructs a new instance.
+        Constructs a new instance of an EpisdeInfo object.
         
-        :param      title:           The title
-        :param      season_number:   The season number
-        :param      episode_number:  The episode number
-        :param      abs_number:      The absolute number
+        :param      title:           The Title object for this entry.
+        :param      season_number:   The season number for this entry.
+        :param      episode_number:  The episode number for this entry.
+        :param      abs_number:      The absolute episode number for this entry.
         """
 
         # Store title
         self.title = title
 
-        # Store index
+        # Store indices
         self.season_number = int(season_number)
         self.season = self.season_number
 
@@ -100,19 +102,20 @@ class EpisodeInfo:
 
     def set_abs_number(self, abs_number: int) -> None:
         """
-        Sets the absolute number.
+        Set the absolute number for this object.
         
-        :param      abs_number:  The absolute number
+        :param      abs_number:  The absolute number to set.
         """
 
-        self.abs_number = abs_number
+        self.abs_number = int(abs_number)
+        self.abs = self.abs_number
 
 
     def set_sonarr_id(self, sonarr_id: int) -> None:
         """
-        Sets the sonarr identifier.
+        Sets the Sonarr ID for this object.
         
-        :param      sonarr_id:  The sonarr identifier
+        :param      tmdb_id:  The Sonarr ID to set.
         """
 
         self.sonarr_id = int(sonarr_id)
@@ -120,9 +123,9 @@ class EpisodeInfo:
 
     def set_tvdb_id(self, tvdb_id: int) -> None:
         """
-        Sets the tvdb identifier.
+        Sets the TVDb ID for this object.
         
-        :param      tvdb_id:  The tvdb identifier
+        :param      tmdb_id:  The TVDb ID to set.
         """
 
         self.tvdb_id = int(tvdb_id)
@@ -130,9 +133,9 @@ class EpisodeInfo:
 
     def set_tmdb_id(self, tmdb_id: int) -> None:
         """
-        Sets the tmdb identifier.
+        Sets the TMDb ID for this object.
         
-        :param      tmdb_id:  The tmdb identifier
+        :param      tmdb_id:  The TMDb ID to set.
         """
 
         self.tmdb_id = int(tmdb_id)
@@ -140,14 +143,14 @@ class EpisodeInfo:
 
     def copy_ids(self, other: 'EpisodeInfo') -> None:
         """
-        { function_description }
+        Copy all ID's from the given EpisodeInfo object. This copies the Sonarr,
+        TVDb, and TMDb ID's.
         
-        :param      other:  The other
+        :param      other:  The EpisodeInfo object to copy ID's from.
         """
 
         if not isinstance(other, EpisodeInfo):
-            raise TypeError(f"Can only copy ID's from another EpisodeInfo "
-                            f"object")
+            raise TypeError(f"Can only copy ID's from EpisodeInfo objects")
 
         self.sonarr_id = other.sonarr_id
         self.tvdb_id = other.tvdb_id

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -23,7 +23,7 @@ class EpisodeInfo:
 
         self.episode_number = int(episode_number)
         self.episode = self.episode_number
-        
+
         self.abs_number = None if abs_number == None else int(abs_number)
         self.abs = self.abs_number
 
@@ -77,13 +77,21 @@ class EpisodeInfo:
 
     def __eq__(self, other_info: 'EpisodeInfo') -> bool:
         """
+        Returns whether the given EpisodeInfo object corresponds to the same
+        entry (has the same season and episode index).
 
+        :param      other_info: EpisodeInfo object to compare.
+
+        :returns:   True if the season and episode number of the two objects
+                    match, False otherwise.
         """
 
+        # Verify the comparison is another EpisodeInfo object
         if not isinstance(other_info, EpisodeInfo):
             raise TypeError(f'Can only compare equality between EpisodeInfo'
                             f' objects')
 
+        # Equality is determined by season and episode number only
         season_match = (self.season_number == other_info.season_number)
         episode_match = (self.episode_number == other_info.episode_number)
 

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -128,4 +128,20 @@ class EpisodeInfo:
         """
 
         self.tmdb_id = int(tmdb_id)
+
+
+    def copy_ids(self, other: 'EpisodeInfo') -> None:
+        """
+        { function_description }
+        
+        :param      other:  The other
+        """
+
+        if not isinstance(other, EpisodeInfo):
+            raise TypeError(f"Can only copy ID's from another EpisodeInfo "
+                            f"object")
+
+        self.sonarr_id = other.sonarr_id
+        self.tvdb_id = other.tvdb_id
+        self.tmdb_id = other.tmdb_id
         

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -70,6 +70,21 @@ class EpisodeInfo:
         return f'{self.season_number}-{self.episode_number+count}'
 
 
+    def __eq__(self, other_info: 'EpisodeInfo') -> bool:
+        """
+
+        """
+
+        if not isinstance(other_info, EpisodeInfo):
+            raise TypeError(f'Can only compare equality between EpisodeInfo'
+                            f' objects')
+
+        season_match = (self.season_number == other_info.season_number)
+        episode_match = (self.episode_number == other_info.episode_number)
+
+        return season_match and episode_match 
+
+
     def set_abs_number(self, abs_number: int) -> None:
         """
         Sets the absolute number.

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -19,8 +19,13 @@ class EpisodeInfo:
 
         # Store index
         self.season_number = int(season_number)
+        self.season = self.season_number
+
         self.episode_number = int(episode_number)
+        self.episode = self.episode_number
+        
         self.abs_number = None if abs_number == None else int(abs_number)
+        self.abs = self.abs_number
 
         # Create key for unique indexing associated with this Episode
         self.key = f'{self.season_number}-{self.episode_number}'

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -124,13 +124,12 @@ class Manager:
                                  f'"{show.series_info.short_name}"')
 
             # Pass the TMDbInterface to the show if globally enabled
-            if self.preferences.use_tmdb:
-                if self.preferences.use_sonarr:
-                    created = show.create_missing_title_cards(
-                        self.tmdb_interface, self.sonarr_interface
-                    )
-                else:
-                    created=show.create_missing_title_cards(self.tmdb_interface)
+            if self.preferences.use_tmdb and self.preferences.use_sonarr:
+                created = show.create_missing_title_cards(
+                    self.tmdb_interface, self.sonarr_interface
+                )
+            elif self.preferences.use_tmdb:
+                created = show.create_missing_title_cards(self.tmdb_interface)
             else:
                 created = show.create_missing_title_cards()
 
@@ -157,8 +156,12 @@ class Manager:
             pbar.set_description(f'Updating archive for '
                                  f'"{show_archive.series_info.short_name}"')
 
-            # If TMDb is globally enabled, pass the interface along
-            if self.preferences.use_tmdb:
+            # Depending on which interfaces are enabled, pass those along
+            if self.preferences.use_tmdb and self.preferences.use_sonarr:
+                show_archive.update_archive(
+                    self.tmdb_interface, self.sonarr_interface
+                )
+            elif self.preferences.use_tmdb:
                 show_archive.update_archive(self.tmdb_interface)
             else:
                 show_archive.update_archive()

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -362,8 +362,11 @@ class Show:
         """
         Creates any missing title cards for each episode of this show.
 
-        :param      tmdb_interface: Optional interface to TMDb to download any
-                                    source images that are missing.
+        :param      tmdb_interface:     Optional interface to TMDb to download
+                                        any missing source images.
+        :param      sonarr_interface:   Optional interface to Sonarr to get
+                                        episode and series ID's before querying
+                                        TMDb.
 
         :returns:   True if any new cards were created, False otherwise.
         """

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -337,7 +337,7 @@ class Show:
             self.series_info
         )
 
-        # For each episode, check if the data matches any contained Episode objects
+        # For each episode, check if the data matches any contained Episodes
         has_new = False
         if all_episodes:
             # Filter out episodes that already exist
@@ -372,10 +372,11 @@ class Show:
         if self.media_directory is None:
             return False
 
-        # If using Sonarr, get the TVDb ID for this show
-        tvdb_id = None
-        if sonarr_interface:
-            sonarr_interface.set_series_ids(self.series_info)
+        # If TMDb syncing is enabled, and a valid TMDb and Sonarr Interface were
+        # provided, get all episode ID's for this series
+        if self.tmdb_sync and tmdb_interface and sonarr_interface:
+            all_episodes = list(ei for _, ei in self.episodes.items())
+            sonarr_interface.set_all_episode_ids(self.series_info, all_episodes)
 
         # Go through each episode for this show
         created_new_cards = False

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -375,7 +375,7 @@ class Show:
         # If using Sonarr, get the TVDb ID for this show
         tvdb_id = None
         if sonarr_interface:
-            sonarr_interface.set_tvdb_id_for_series(self.series_info)
+            sonarr_interface.set_series_ids(self.series_info)
 
         # Go through each episode for this show
         created_new_cards = False

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -217,4 +217,23 @@ class SonarrInterface(WebInterface):
             error(f'Series "{series_info}" not found in Sonarr')
             return None
 
+
+    def set_all_episode_ids(self, series_info: SeriesInfo,
+                            all_episode_info: [EpisodeInfo]) -> None:
+        """
+        Sets the episode identifiers.
+        
+        :param      episode_info:  The episode information
+        """
+
+        # Set the Sonarr ID for this series
+        self.__set_ids(series_info)
+
+        # Get all sonarr-created EpisodeInfo objects
+        sonarr_episode_info = self.get_all_episodes_for_series(series_info)
+
+        # Go through each episode 
+        for episode_info in all_episode_info:
+            
+
         

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -215,7 +215,6 @@ class SonarrInterface(WebInterface):
         # If no ID was returned, error and return
         if series_info.sonarr_id == None:
             error(f'Series "{series_info}" not found in Sonarr')
-            return None
 
 
     def set_all_episode_ids(self, series_info: SeriesInfo,

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -202,7 +202,7 @@ class SonarrInterface(WebInterface):
         return self.__get_all_episode_info(series_info.sonarr_id)
 
 
-    def set_tvdb_id_for_series(self, series_info: SeriesInfo) -> None:
+    def set_series_ids(self, series_info: SeriesInfo) -> None:
         """
         Set the TVDb ID to the given SeriesInfo object.
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -219,10 +219,13 @@ class SonarrInterface(WebInterface):
 
 
     def set_all_episode_ids(self, series_info: SeriesInfo,
-                            all_episode_info: [EpisodeInfo]) -> None:
+                            all_episodes: [EpisodeInfo]) -> None:
         """
-        Sets the episode identifiers.
+        Set all the episode ID's for the given list of EpisodeInfo objects. This
+        sets the Sonarr and TVDb ID's for each episode. As a byproduct, this
+        also updates the series ID's for the SeriesInfo object
         
+        :param      series_info:    SeriesInfo for the entry.
         :param      episode_info:  The episode information
         """
 
@@ -230,10 +233,16 @@ class SonarrInterface(WebInterface):
         self.__set_ids(series_info)
 
         # Get all sonarr-created EpisodeInfo objects
-        sonarr_episode_info = self.get_all_episodes_for_series(series_info)
+        all_sonarr_episodes = self.get_all_episodes_for_series(series_info)
 
         # Go through each episode 
-        for episode_info in all_episode_info:
-            
+        for episode in all_episodes:
+            # Find the matching EpisodeInfo object returned by Sonarr
+            for sonarr_info in all_sonarr_episodes:
+                # If these objects correspond to the same data, transfer ID's
+                # from the Sonarr EpisodeInfo objects to the primary ones
+                if episode.episode_info == sonarr_info:
+                    episode.episode_info.copy_ids(sonarr_info)
+                    break
 
         

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -9,8 +9,8 @@ from modules.WebInterface import WebInterface
 class SonarrInterface(WebInterface):
     """
     This class describes a Sonarr interface, which is a type of WebInterface.
-    The primary purpose of this class is to get episode titles for series
-    entries.
+    The primary purpose of this class is to get episode titles, as well as
+    database ID's for episodes.
     """
 
     """Episode titles that indicate a placeholder and are to be ignored"""
@@ -47,6 +47,13 @@ class SonarrInterface(WebInterface):
 
         # Parse all Sonarr series
         self.__map_all_ids()
+
+
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return (f'<SonarrInterface url={self.url}, api_key={self.__api_key}'
+                f', mapping of {len(self.__series_ids)} series>')
 
 
     def __set_ids(self, series_info: SeriesInfo) -> None:

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -139,50 +139,6 @@ class TMDbInterface(WebInterface):
             dump(self.__id_map, file_handle, HIGHEST_PROTOCOL)
 
 
-    @staticmethod
-    def manually_specify_id(title: str, year: int, id_: int) -> None:
-        """Public (static) implementation of `__add_id_to_map()`."""
-
-        TMDbInterface(None).__add_id_to_map(title, year, id_)
-
-
-    @staticmethod
-    def manually_download_season(api_key: str, title: str, year: int,
-                                 season: int, episode_count: int,
-                                 directory: Path) -> None:
-        """
-        Download episodes 1-episode_count of the requested season for the given
-        show. They will be named as s{season}e{episode}.jpg.
-        
-        :param      api_key:        The api key for sending requsts to TMDb.
-        :param      title:          The title of the requested show.
-        :param      year:           The year of the requested show.
-        :param      season:         The season to download.
-        :param      episode_count:  The number of episodes to download
-        :param      directory:      The directory to place the downloaded images
-                                    in.
-        """
-
-        # Create a temporary interface object for this function
-        dbi = TMDbInterface(api_key)
-
-        for episode in range(1, episode_count+1):
-            image_url=dbi.get_title_card_source_image(title,year,season,episode)
-
-            # If a valid URL was returned, download it
-            if image_url:
-                filename = f's{season}e{episode}.jpg'
-                dbi.download_image(image_url, directory / filename)
-
-
-    @staticmethod
-    def delete_blacklist() -> None:
-        """Delete the blacklist file referenced by this class."""
-
-        TMDbInterface.__BLACKLIST.unlink(missing_ok=True)
-        info(f'Deleted blacklist file "{TMDbInterface.__BLACKLIST.resolve()}"')
-
-
     def __set_tmdb_id(self, series_info: SeriesInfo) -> None:
         """
         Get the TMDb series ID associated with the given entry. If an ID is not

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -59,6 +59,7 @@ class TMDbInterface(WebInterface):
         
         # Store API key
         self.__api_key = api_key
+        self.__standard_params = {'api_key': api_key}
 
 
     def __update_blacklist(self, series_info: SeriesInfo,
@@ -501,5 +502,41 @@ class TMDbInterface(WebInterface):
         except Exception as e:
             error(f'TheMovieDB errored: "{e}"')
 
+
+    @staticmethod
+    def manually_download_season(api_key: str, title: str, year: int,
+                                 season: int, episode_count: int,
+                                 directory: Path) -> None:
+        """
+        Download episodes 1-episode_count of the requested season for the given
+        show. They will be named as s{season}e{episode}.jpg.
+        
+        :param      api_key:        The api key for sending requsts to TMDb.
+        :param      title:          The title of the requested show.
+        :param      year:           The year of the requested show.
+        :param      season:         The season to download.
+        :param      episode_count:  The number of episodes to download
+        :param      directory:      The directory to place the downloaded images
+                                    in.
+        """
+
+        # Create a temporary interface object for this function
+        dbi = TMDbInterface(api_key)
+
+        for episode in range(1, episode_count+1):
+            image_url=dbi.get_title_card_source_image(title,year,season,episode)
+
+            # If a valid URL was returned, download it
+            if image_url:
+                filename = f's{season}e{episode}.jpg'
+                dbi.download_image(image_url, directory / filename)
+
+
+    @staticmethod
+    def delete_blacklist() -> None:
+        """Delete the blacklist file referenced by this class."""
+
+        TMDbInterface.__BLACKLIST.unlink(missing_ok=True)
+        info(f'Deleted blacklist file "{TMDbInterface.__BLACKLIST.resolve()}"')
 
 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -216,7 +216,7 @@ class TMDbInterface(WebInterface):
 
         1. Episode TVDb ID
         2. Series TMDb ID and season+episode index with title match
-        3. Series TMDb ID and season+absolute episode # with title match
+        3. Series TMDb ID and season+absolute episode index with title match
         3. Series TMDb ID and title match on any episode
         
         :param      series_info:   The series information.
@@ -234,7 +234,7 @@ class TMDbInterface(WebInterface):
             params = {'api_key': self.__api_key, 'external_source': 'tvdb_id'}
             results = self._get(url, params)['tv_episode_results']
 
-            # If an episode was found, return it's index
+            # If an episode was found, return its index
             if len(results) > 0:
                 # Verify series TMDb ID is correct
                 if series_info.tmdb_id not in (results[0]['show_id'], None):
@@ -242,7 +242,7 @@ class TMDbInterface(WebInterface):
                 
                 # Set series TMDb ID
                 series_info.set_tmdb_id(results[0]['show_id'])
-                info(f'Found {episode_info} via TVDb ID')
+
                 return {
                     'season': results[0]['season_number'],
                     'episode': results[0]['episode_number'],
@@ -273,6 +273,10 @@ class TMDbInterface(WebInterface):
         # Episode has been found on TMDb, check title
         if 'name' in tmdb_info and episode_info.title.matches(tmdb_info['name']):
             # Title matches, return the resulting season/episode number
+            if episode_info.tvdb_id != None:
+                info(f'Add TVDb ID {episode_info.tvdb_id} to TMDb "'
+                     f'{series_info.full_name}" {episode_info}')
+
             return {
                 'season': tmdb_info['season_number'],
                 'episode': tmdb_info['episode_number'],
@@ -294,10 +298,14 @@ class TMDbInterface(WebInterface):
             for tmdb_episode in tmdb_season['episodes']:
                 if episode_info.title.matches(tmdb_episode['name']):
                     # Title match, return this entry
+                    info(f'Found {episode_info!r} under TMDb '
+                         f'S{tmdb_episode["season_number"]:02}'
+                         f'E{tmdb_episode["episode_number"]:02} - possible mismatch')
                     return {
                         'season': tmdb_episode['season_number'],
                         'episode': tmdb_episode['episode_number'],
                     }
+                    
         return None
 
 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -222,13 +222,15 @@ class TMDbInterface(WebInterface):
                 tmdb_id = results[0]['id']
                 series_info.set_tmdb_id(tmdb_id)
                 self.__add_id_to_map(series_info)
+
                 return None
 
         # Match by title and year if no ID was given
         # Construct GET arguments
         url = f'{self.API_BASE_URL}search/tv/'
         params = {'api_key': self.__api_key, 'query': series_info.name,
-                  'first_air_date_year': series_info.year}
+                  'first_air_date_year': series_info.year,
+                  'include_adult': False}
 
         # Query TMDb
         results = self._get(url=url, params=params)
@@ -243,6 +245,101 @@ class TMDbInterface(WebInterface):
         self.__add_id_to_map(series_info)
 
 
+    def __find_episode(self, series_info: SeriesInfo,
+                       episode_info: EpisodeInfo) -> dict:
+        """
+        Finds the episode index for the given entry. Searching is done in the
+        following priority:
+
+        1. Episode TVDb ID
+        2. Series TMDb ID and season+episode index with title match
+        3. Series TMDb ID and season+absolute episode # with title match
+        3. Series TMDb ID and title match on any episode
+        
+        :param      series_info:   The series information.
+        :param      episode_info:  The episode information.
+        
+        :returns:   Dictionary of the index for the given entry. This dictionary
+                    has keys 'season' and 'episode'. None if returned if the
+                    entry cannot be found.
+        """
+
+        # If the episode has a TVDb ID, query with that first
+        if episode_info.tvdb_id != None:
+            # GET parameters and request
+            url = f'{self.API_BASE_URL}find/{episode_info.tvdb_id}'
+            params = {'api_key': self.__api_key, 'external_source': 'tvdb_id'}
+            results = self._get(url, params)['tv_episode_results']
+
+            # If an episode was found, return it's index
+            if len(results) > 0:
+                # Verify series TMDb ID is correct
+                if series_info.tmdb_id not in (results[0]['show_id'], None):
+                    warn(f'Series TMDb ID mismatch for {episode_info}')
+                
+                # Set series TMDb ID
+                series_info.set_tmdb_id(results[0]['show_id'])
+                info(f'Found {episode_info} via TVDb ID')
+                return {
+                    'season': results[0]['season_number'],
+                    'episode': results[0]['episode_number'],
+                }
+
+        # If the series has no TMDb ID, cannot continue
+        if series_info.tmdb_id == None:
+            return None
+
+        # Match by series TMDb ID and series index with title matching
+        # GET parameters and request
+        url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
+               f'{episode_info.season}/episode/{episode_info.episode}')
+        params = self.__standard_params
+        tmdb_info = self._get(url, params)
+
+        # If episode was not found, query by absolute number in all seasons
+        if ('success' in tmdb_info and not tmdb_info['success']
+            and episode_info.abs_number != None):
+            # Query TMDb until the absolute number has been found
+            for season in range(0, episode_info.season_number+1)[::-1]:
+                url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
+                       f'{season}/episode/{episode_info.abs_number}/images')
+                tmdb_info = self._get(url=url, params=params)
+                if 'season_number' in tmdb_info:
+                    break
+
+        # Episode has been found on TMDb, check title
+        if episode_info.title.matches(tmdb_info['name']):
+            # Title matches, return the resulting season/episode number
+            info(f'Found {episode_info} via index and title ')
+            return {
+                'season': tmdb_info['season_number'],
+                'episode': tmdb_info['episode_number'],
+            }
+
+        # No title match on given or absolute index, try each season
+        for season in range(0, episode_info.season_number+1):
+            # GET parameters and request
+            url = f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/{season}'
+            params = self.__standard_params
+            tmdb_season = self._get(url, params)
+
+            # If the season DNE, this episode cannot be found
+            if 'success' in tmdb_season and not tmdb_season['success']:
+                warn(f'Tried every season, {episode_info} not found by title')
+                return None
+
+            # Season could be found, check each given title
+            for episode in season['episodes']:
+                if episode_info.title.matches(episode['name']):
+                    # Title match, return this entry
+                    info(f'Found {series_info} {episode_info} under TMDb '
+                         f'S{episode["season_number"]:02}E'
+                         f'E{episode["episode_number"]:02} - possible mismatch')
+                    return {
+                        'season': episode['season_number'],
+                        'episode': episode['episode_number'],
+                    }
+        info(f'Tried every season and episode, {episode_info} not found by title')
     def __determine_best_image(self, images: list) -> dict:
         """
         Determines the best image, returning it's contents from within the
@@ -299,37 +396,25 @@ class TMDbInterface(WebInterface):
             return None
 
         # Set the TV id for the provided series
+        # Set the TMDb ID for the provided series
         self.__set_tmdb_id(series_info)
 
-        # Get this entry's season and episode numbers
         season, episode = episode_info.season_number,episode_info.episode_number
+        # Get the TMDb index for this entry
+        index = self.__find_episode(series_info, episode_info)
 
-        # GET params
-        url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/{season}'
-               f'/episode/{episode}/images')
-        params = {'api_key': self.__api_key}
-
-        # Make the GET request
-        results = self._get(url=url, params=params)
-
-        # If absolute number has been given and the first query failed,try again
-        if (episode_info.abs_number != None and 'success' in results
-            and not results['success']):
-            # Try surround season numbers (TMDb indexes these weirdly..)
-            for new_season in range(1, season+1)[::-1]:
-                url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
-                       f'{new_season}/episode/{episode_info.abs_number}/images')
-                results = self._get(url=url, params=params)
-                if 'stills' in results:
-                    break
-
-        # If 'stills' wasn't in return JSON, episode wasn't found
         if 'stills' not in results:
             warn(f'TMDb has no matching episode for "{series_info}" '
                  f'{episode_info}', 1)
             self.__update_blacklist(series_info, episode_info)
             return None
 
+        season, episode = index['season'], index['episode']
+
+        # Use the found index to query TMDB for images
+        # GET parameters and request
+        url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/{season}'
+               f'/episode/{episode}/images')
         # If 'stills' is in JSON, but is empty, then TMDb has no images
         if len(results['stills']) == 0:
             warn(f'TMDb has no images for "{series_info}" {episode_info}', 1)

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -47,8 +47,7 @@ class Title:
         self.title_yaml = title
 
         # Generate title to use for matching purposes
-        match_func = lambda c: match('[a-zA-Z0-9]', c)
-        self.match_title = ''.join(filter(match_func, title)).lower()
+        self.match_title = self.get_matching_title(self.full_title)
 
 
     def __str__(self) -> str:
@@ -198,4 +197,32 @@ class Title:
 
         # Call split on the new title, join those lines
         return '\n'.join(new_title.split(**title_characteristics))
+
+
+    @staticmethod
+    def get_matching_title(text: str) -> str:
+        """
+        Remove all non A-Z characters from the given title.
+        
+        :param      text:   The title to strip of special characters.
+        
+        :returns:   The input `text` with all non A-Z characters removed.
+        """
+
+        return ''.join(filter(lambda c: match('[a-zA-Z0-9]', c), text)).lower()
+
+
+    def matches(self, *titles: tuple) -> bool:
+        """
+        Get whether any of the given titles match this Series.
+        
+        :param      titles: The titles to check
+        
+        :returns:   True if any of the given titles match this series, False
+                    otherwise.
+        """
+
+        matching_titles = map(self.get_matching_title, titles)
+
+        return any(title == self.match_title for title in matching_titles)
         


### PR DESCRIPTION
# Major Changes
- Updated `TMDbInterface` to use improved episode matching algorithm; closes #20 
  1. If a TVDb episode ID is provided, that is searched with TMDb `/find/` endpoint
  2. TMDb series ID, and series index (season+episode number) with a title match
  3. TMDb series ID, series index with absolute numbering with title match
  4. TMDb series ID and title match on any episode
- Added exclusion of adult content from TV searching in `TMDbInterface.__set_tmdb_id()` method
-  Updated `Manager` to pass Sonarr and TMDb interfaces to `ShowArchive`
# Major Fixes 
N/A
# Minor Changes
- Renamed `SonarrInterface.set_tvdb_id_for_series()` to `set_series_ids()`
- Added equality method to `EpisodeInfo` class
- Added `Title.get_matching_title()` and `matches()` methods (from `SeriesInfo` class)
# Minor Fixes
N/A