### PR TITLE
Add report of all missing assets 

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,13 +9,20 @@ from modules.Manager import Manager
 # Default path for a preference file to parse
 DEFAULT_PREFERENCE_FILE = Path('preferences.yml')
 
+# Default path for a missing file
+DEFAULT_MISSING_FILE = Path('missing.yml')
+
 # Set up argument parser
 parser = ArgumentParser(description='Start the TitleCardMaker')
 parser.add_argument('-p', '--preference-file', type=Path,
                     default=DEFAULT_PREFERENCE_FILE,
-                    help='Manually specify the preference file for the TitleCardMaker')
+                    metavar='FILE',
+                    help='Specify the preference file for the TitleCardMaker')
 parser.add_argument('-r', '--run', action='count', default=0,
-                    help='How many times to run the TitleCardMaker back-to-back')
+                    help='Run the TitleCardMaker')
+parser.add_argument('-m', '--missing', type=Path, default=DEFAULT_MISSING_FILE,
+                    metavar='FILE',
+                    help='File to write a list of missing assets to')
 
 # Parse given arguments
 args = parser.parse_args()
@@ -34,6 +41,11 @@ if not pp.valid:
 set_preference_parser(pp)
 
 # Create and run the manager --run many times
+tcm = None
 for _ in range(args.run):
     tcm = Manager()
     tcm.run()
+
+# Write missing assets
+if tcm != None:
+    tcm.report_missing(args.missing)

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -215,9 +215,12 @@ class Manager:
             for _, episode in show.episodes.items():
                 if not episode.source.exists():
                     show_dict[str(episode)] = {}
-                    show_dict[str(episode)]['source'] = str(episode.source)
+                    show_dict[str(episode)]['source'] = episode.source.name
                 if episode.destination != None and not episode.destination.exists():
-                    show_dict[str(episode)]['card'] = str(episode.destination.resolve())
+                    show_dict[str(episode)]['card'] = episode.destination.name
+
+            if not show.logo.exists():
+                show_dict['logo'] = show.logo.name
 
             if len(show_dict.keys()) > 0:
                 missing[str(show)] = show_dict


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
N/A
# Minor Changes
- Added missing report to `main` execution file
  - All missing cards, source files, and logos are written to the file in YAML format as:
```yaml
Series (Year):
  Episode SxxEyy:
    card: file.ext
    source: file.ext
  ...
  logo: file.ext
...
```
  - File can be modified with `-m` or `--missing` CLI flag
  - Closes #21  
# Minor Fixes
N/A