### PR TITLE
Add check for valid Sonarr configuration, increased cache size, minor fixes

### DIFF
--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -47,7 +47,7 @@ class Episode:
 
 
     def __repr__(self) -> str:
-        """Returns a string representation of the object."""
+        """Returns an unambiguous string representation of the object"""
 
         return (f'<Episode episode_info={self.episode_info}, card_class='
                 f'{self.card_class}, source={self.source}, destination='

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -10,10 +10,10 @@ class EpisodeInfo:
         """
         Constructs a new instance of an EpisdeInfo object.
         
-        :param      title:           The Title object for this entry.
-        :param      season_number:   The season number for this entry.
-        :param      episode_number:  The episode number for this entry.
-        :param      abs_number:      The absolute episode number for this entry.
+        :param      title:          The Title object of this Episode.
+        :param      season_number:  The season number of this Episode.
+        :param      episode_number: The episode number of this Episode.
+        :param      abs_number:     The absolute episode number of this Episode.
         """
 
         # Store title
@@ -45,7 +45,7 @@ class EpisodeInfo:
 
 
     def __repr__(self) -> str:
-        """Returns a unambiguous string representation of the object."""
+        """Returns an unambiguous string representation of the object."""
 
         # Static information
         ret = (f'<EpisodeInfo title={self.title}, season_number='
@@ -104,7 +104,7 @@ class EpisodeInfo:
         """
         Set the absolute number for this object.
         
-        :param      abs_number:  The absolute number to set.
+        :param      abs_number: The absolute number to set.
         """
 
         self.abs_number = int(abs_number)
@@ -115,7 +115,7 @@ class EpisodeInfo:
         """
         Sets the Sonarr ID for this object.
         
-        :param      tmdb_id:  The Sonarr ID to set.
+        :param      tmdb_id:    The Sonarr ID to set.
         """
 
         self.sonarr_id = int(sonarr_id)
@@ -125,7 +125,7 @@ class EpisodeInfo:
         """
         Sets the TVDb ID for this object.
         
-        :param      tmdb_id:  The TVDb ID to set.
+        :param      tmdb_id:    The TVDb ID to set.
         """
 
         self.tvdb_id = int(tvdb_id)
@@ -135,7 +135,7 @@ class EpisodeInfo:
         """
         Sets the TMDb ID for this object.
         
-        :param      tmdb_id:  The TMDb ID to set.
+        :param      tmdb_id:    The TMDb ID to set.
         """
 
         self.tmdb_id = int(tmdb_id)

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -42,7 +42,7 @@ class ImageMagickInterface:
         
         :returns:   Input string with all necessary characters escaped. This 
                     assumes that text will be wrapped in "", and so only escapes
-                    " and ` characters
+                    " and ` characters.
         """
 
         # Handle possible None strings
@@ -56,17 +56,17 @@ class ImageMagickInterface:
         """
         Wrapper for running a given command. This uses either the host machine
         (i.e. direct calls); or through the provided docker container (if
-        `preferences` has been set; i.e. wrapped through "docker exec -t {id}
-        {command}"). `args` and `kwargs` are used to permit general usage of
-        the `subprocess.run()` function's options (`capture_output`, etc).
+        preferences has been set; i.e. wrapped through "docker exec -t {id}
+        {command}"). args and kwargs are used to permit general usage of
+        the subprocess.run() function's options (capture_output, etc).
 
         :param      command:    The command to execute
         
-        :param      args:       The arguments to pass to `subprocess.run()`.
+        :param      args:       The arguments to pass to subprocess.run().
 
-        :param      kwargs:     The keyword arguments to pass to `subprocess.run()`.
+        :param      kwargs:     The keyword arguments to pass to subprocess.run().
 
-        :returns:   The return of the `subprocess.run()` function execution.
+        :returns:   The return of the subprocess.run() function execution.
         """
         
         
@@ -86,7 +86,7 @@ class ImageMagickInterface:
         
         :param      command:            The command being executed.
         :param      args and kwargs:    Generalized arguments to pass to
-                                        `subprocess.run()`.
+                                        subprocess.run().
 
         :returns:   The decoded stdout output of the executed command.
         """

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -18,7 +18,7 @@ class Manager:
     def __init__(self) -> None:
         """
         Constructs a new instance of the manager. This uses the global
-        `PreferenceParser` object in preferences, and optionally creates
+        PreferenceParser object in preferences, and optionally creates
         interfaces as indicated by that parser.
         """
 
@@ -57,9 +57,9 @@ class Manager:
 
     def create_shows(self) -> None:
         """
-        Create `Show` and `ShowArchive` objects for each series entry found
-        known to the global `PreferenceParser`. This updates the `shows` and
-        `archives` lists with these objects.
+        Create Show and ShowArchive objects for each series YAML files known to
+        the global PreferenceParser. This updates the Manager's show and
+        archives lists.
         """
 
         self.shows = []
@@ -77,10 +77,7 @@ class Manager:
                 continue
 
             self.archives.append(
-                ShowArchive(
-                    self.preferences.archive_directory,
-                    show,
-                )
+                ShowArchive(self.preferences.archive_directory, show)
             )
 
 
@@ -191,20 +188,9 @@ class Manager:
 
 
     def run(self) -> None:
-        """
-        Run the manager and exit.
+        """Run the manager and exit."""
 
-        The following functions are executed in the following order:
-
-        `create_shows()`
-        `read_show_source()`
-        `check_sonarr_for_new_episodes()`
-        `create_missing_title_cards()`
-        `update_archive()`
-        `create_summaries()`
-        """
-
-        # Execute everything before waiting
+        # Execute everything
         self.create_shows()
         self.read_show_source()
         self.check_sonarr_for_new_episodes()

--- a/modules/MultiEpisode.py
+++ b/modules/MultiEpisode.py
@@ -66,7 +66,7 @@ class MultiEpisode:
         """Returns a string representation of the object."""
 
         return (f'S{self.season_number:02}'
-                f'E{self.episode_start}-E{self.episode_end}')
+                f'E{self.episode_start:02}-E{self.episode_end:02}')
 
 
     def __repr__(self) -> str:
@@ -111,7 +111,7 @@ class MultiEpisode:
 
     def set_destination(self, destination: 'Path') -> None:
         """
-        Sets the destination.
+        Set the destination for the card associated with these Episdoes.
         
         :param      destination:    The destination for the card that is created
                                     for these episodes.

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -48,8 +48,8 @@ class PlexInterface:
         try:
             response = get(url=url, params=params)
         except Exception as e:
-            error(f'Cannot query Plex. Returned error: "{e}"')
-            return None
+            error(f'Cannot query Plex - returned error: "{e}"')
+            exit(1)
 
         library_xml = fromstring(response.text)
 

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -3,7 +3,6 @@ from regex import match, IGNORECASE
 from modules.CardType import CardType
 from modules.Debug import info, warn, error
 from modules.MultiEpisode import MultiEpisode
-from modules.StandardTitleCard import StandardTitleCard
 
 class Profile:
     """

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -118,8 +118,14 @@ class Show:
         self.episodes = {}
 
 
+    def __str__(self) -> str:
+        """Returns a string representation of the object."""
+
+        return self.series_info.full_name
+
+
     def __repr__(self) -> str:
-        """Returns a unambiguous string representation of the object"""
+        """Returns an unambiguous string representation of the object"""
 
         return f'<Show "{self.series_info}" with {len(self.episodes)} Episodes>'
 
@@ -255,10 +261,9 @@ class Show:
         Determines whether the given attribute/sub-attribute has been manually 
         specified in the show's YAML.
         
-        :param      attribute:      The attribute to check for.
-        :param      sub_attribute:  The sub attribute to check for. Necessary if
-                                    the given attribute has attributes of its
-                                    own.
+        :param      attributes: Any number of attributes to check for. Each
+                                subsequent argument is checked for as a sub-
+                                attribute of the prior one.
         
         :returns:   True if specified, False otherwise.
         """
@@ -379,8 +384,8 @@ class Show:
                 matched.update(set(matching_episodes))
         
         # Add all MultiEpisode objects to this show's episode dictionary
-        for ind, mp in enumerate(multiparts):
-            self.episodes[f'MultiEpisode {ind}'] = mp
+        for mp in multiparts:
+            self.episodes[f'{mp.season_number}-{mp.episode_start}'] = mp
 
 
     def check_sonarr_for_new_episodes(self,
@@ -486,7 +491,7 @@ class Show:
 
                 # Download the image
                 tmdb_interface.download_image(image_url, episode.source)
-                
+
             # Source exists, create the title card
             created_new_cards |= title_card.create()
 

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -1,10 +1,8 @@
 from copy import deepcopy
-from pathlib import Path
 
 from tqdm import tqdm
 
 from modules.Debug import info, warn, error
-from modules.Show import Show
 from modules.ShowSummary import ShowSummary
 
 class ShowArchive:
@@ -41,7 +39,7 @@ class ShowArchive:
         'hidden-generic':  'No Season Titles, Generic Font',
     }
 
-    def __init__(self, archive_directory: Path, base_show: 'Show') -> None:
+    def __init__(self, archive_directory: 'Path', base_show: 'Show') -> None:
         """
         Constructs a new instance of this class. Creates a list of all
         applicable Show objects for later us.
@@ -51,8 +49,8 @@ class ShowArchive:
                                         `/Documents/` would operate on 
                                         `/Documents/Title (Year)/...`.
 
-        :param      args and kwargs:    Arguments passed directly to initialize 
-                                        a `Show` object with.
+        :param      base_show:          Base Show object this Archive is based
+                                        on.
         """
         
         # Empty lists to be populated with modified Show and ShowSummary objects
@@ -139,7 +137,7 @@ class ShowArchive:
                                     there is not an existing one.
         """
 
-        # Go through each ShowSumamry object within this Archive
+        # Go through each ShowSummary object within this Archive
         for summary in self.summaries:
             # If summary already exists, skip
             if summary.output.exists():
@@ -154,7 +152,7 @@ class ShowArchive:
                 if logo == None:
                     continue
 
-                info(f'Downloading series logo', 2)
+                info(f'Downloading series logo')
                 tmdb_interface.download_image(logo, summary.logo)
 
             # If the logo was downloaded (or already existed), create summary

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -2,16 +2,16 @@ from math import ceil
 from pathlib import Path
 from random import sample
 
-from modules.Debug import *
-from modules.Show import Show
+from modules.Debug import info, warn, error
 from modules.StandardTitleCard import StandardTitleCard
 from modules.ImageMaker import ImageMaker
 
 class ShowSummary(ImageMaker):
     """
-    This class describes a show summary. A show summary is a random subset of title
-    cards from a show's profile, montaged into (at most) a 3x3 grid, with a logo at
-    the top. The intention is to quickly visually identify the title cards.
+    This class describes a show summary. A show summary is a random subset of
+    title cards from a show's profile, montaged into (at most) a 3x3 grid, with
+    a logo at the top. The intention is to quickly visually identify the title
+    cards.
 
     This class is a type of ImageMaker.
     """
@@ -31,7 +31,8 @@ class ShowSummary(ImageMaker):
     """Path to the 'created by' image to add to all show summaries"""
     __CREATED_BY_PATH: Path = Path(__file__).parent / 'ref' / 'created_by.png'
 
-    def __init__(self, show: Show) -> None:
+
+    def __init__(self, show: 'Show') -> None:
         """
         Constructs a new instance of this object. This initialized a
         ImageMagickInterface object, and searches the provided show object

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -42,6 +42,17 @@ class SonarrInterface(WebInterface):
         self.__api_key = api_key
         self.__standard_params = {'apikey': api_key}
 
+        # Query system status to verify connection to Sonarr
+        url = f'{self.url}system/status'
+        params = self.__standard_params
+        try:
+            status = self._get(url, params)
+            if 'error' in status and status['error'] == 'Unauthorized':
+                raise Exception('Invalid API key')
+        except Exception as e:
+            error(f'Cannot query Sonarr - returned error: "{e}"')
+            exit(1)
+
         # Create blank dictionary of titles -> ID's
         self.__series_ids = {}
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -50,7 +50,7 @@ class SonarrInterface(WebInterface):
 
 
     def __repr__(self) -> str:
-        """Returns a unambiguous string representation of the object."""
+        """Returns an unambiguous string representation of the object."""
 
         return (f'<SonarrInterface url={self.url}, api_key={self.__api_key}'
                 f', mapping of {len(self.__series_ids)} series>')
@@ -58,7 +58,8 @@ class SonarrInterface(WebInterface):
 
     def __set_ids(self, series_info: SeriesInfo) -> None:
         """
-        Set the Sonarr series ID and the TVDb ID for the given SeriesInfo object
+        Set the Sonarr series ID and the TVDb ID for the given SeriesInfo
+        object.
         
         :param      series_info:    SeriesInfo to modify.
         """
@@ -87,8 +88,6 @@ class SonarrInterface(WebInterface):
         # Construct GET arguments
         url = f'{self.url}series'
         params = self.__standard_params
-
-        # Make GET request
         all_series = self._get(url, params)
 
         # Go through each series in Sonarr
@@ -115,8 +114,6 @@ class SonarrInterface(WebInterface):
         # Construct GET arguments
         url = f'{self.url}series/'
         params = self.__standard_params
-        
-        # Query Sonarr to get JSON of all series in the library
         all_series = self._get(url, params)
 
         # Go through each series in Sonarr

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -377,7 +377,10 @@ class TMDbInterface(WebInterface):
                f'/episode/{episode}/images')
         params = self.__standard_params
         results = self._get(url, params)
-
+        if 'stills' not in results:
+            error(f'TMDb somehow errored on {series_info} {episode_info}')
+            return None
+            
         # If 'stills' is in JSON, but is empty, then TMDb has no images
         if len(results['stills']) == 0:
             warn(f'TMDb has no images for "{series_info}" {episode_info}', 1)

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -403,9 +403,9 @@ class TMDbInterface(WebInterface):
         
         :param      series_info:    SeriesInfo for the entry.
         :param      episode_info:   EpisodeInfo for the entry.
-        :param      language_code:  The language code of the episode.
+        :param      language_code:  The language code for the desired title.
         
-        :returns:   The episode title. None if the entry does not exist.
+        :returns:   The episode title, None if the entry does not exist.
         """
 
         # Get the TV id for the provided series+year
@@ -465,7 +465,6 @@ class TMDbInterface(WebInterface):
 
         # If there are no logos, warn and exit
         if len(results['logos']) == 0:
-            warn(f'TMDb has no logos for "{series_info}"', 1)
             return None
 
         # Pick the best image based on image dimensions

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -208,5 +208,5 @@ class TitleCard:
             
         self.maker.create()
 
-        return True
+        return self.file.exists()
         


### PR DESCRIPTION
# Major Changes
- Added system status check when creating `SonarrInterface` objects
  - This prevents errors from arising during runtime, and validates the URL/API key immediately
- Updated `WebInterface` parent class to use a default cache size of 5 (was 1) to limit API requests (primarily to TMDb)
# Major Fixes 
N/A
# Minor Changes
- Updated various docstrings and comments 
- Added `Show.__str__()` method
- Added `exit(1)` statement to bad creation of `PlexInterface` objects
# Minor Fixes
- Fixed `ShowSummary` image selection failing on `MultiEpisode` objects
- Updated `TitleCard.create()` method to check for existence of card file when returning whether a card was created
  - Old logic returned True even if a card *wasn't* created, so long as source file already existed.
  - Prevents ImageMagick errors (which result in no card) returning `True`
- Modified `TMDbInterface` to check for 'stills' key in JSON result before indexing
  - This prevents errors where the entry is "found" but the returned TMDb ID is invalid, and breaks the next API request
  - Closes #29 (although TMDb is still returning the wrong ID in that instance)