### PR TITLE
Add support for passing arbitrary data to manual card creation

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -78,8 +78,13 @@ tmdb_group.add_argument('--add-translation', nargs=5, default=SUPPRESS,
                         help='Add title translations from TMDb to the given '
                              'datafile')
 
-# Check given arguments
-args = parser.parse_args()
+# Parse given arguments
+args, unknown = parser.parse_known_args()
+
+# Create dictionary of unknown arguments
+arbitrary_data = {}
+if len(unknown) % 2 == 0 and len(unknown) > 1:
+    arbitrary_data = {key: val for key, val in zip(unknown[::2], unknown[1::2])}
 
 # Parse preference file for options that might need it
 pp = PreferenceParser(args.preference_file)
@@ -110,6 +115,7 @@ if hasattr(args, 'title_card'):
         font_size=float(args.font_size[:-1])/100.0,
         title_color=args.font_color,
         hide_season=(not bool(args.season)),
+        **arbitrary_data,
     ).create()
 
 # Execute genre card related options
@@ -122,7 +128,7 @@ if hasattr(args, 'genre_card'):
 
 if hasattr(args, 'genre_card_batch'):
     for file in args.genre_card_batch.glob('*'):
-        if file.suffix.lower() in ('.jpg', '.jpeg', '.png', '.tiff', '.gif'):
+        if file.suffix.lower() in GenreMaker.VALID_IMAGE_EXTENSIONS:
             GenreMaker(
                 source=file,
                 genre=file.stem.upper(),

--- a/modules/ImageMaker.py
+++ b/modules/ImageMaker.py
@@ -17,6 +17,12 @@ class ImageMaker(ABC):
     """Directory for all temporary images created during image creation"""
     TEMP_DIR = Path(__file__).parent / '.objects'
 
+    """
+    Valid file extensions for input images - ImageMagick supports more than just
+    these types, but these are the most common across all OS's.
+    """
+    VALID_IMAGE_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.tiff', '.gif')
+
     @abstractmethod
     def __init__(self) -> None:
         """


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
N/A
# Minor Changes
- Added support to arbitrary (non-standard) data to manual title card creation (via `fixer.py`)
  - All "extra" arguments from CLI will become keywords
    - For example: `pipenv run fixer.py [...] kanji abc arb_key arb_data`
    - Creates `{'kanji': 'abc', 'arb_key': 'arb_data'}` as an arbitrary data dictionary
- Added tuple of common valid image extensions to `ImageMaker` class
# Minor Fixes
N/A