### PR TITLE
Added fix for unbounded fonts

### DIFF
--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -370,13 +370,12 @@ class AnimeTitleCard(CardType):
 
 
     @staticmethod
-    def is_custom_font(*args, **kwargs) -> bool:
+    def is_custom_font(font: 'Font') -> bool:
         """
         Determines whether the given arguments represent a custom font for this
         card. This CardType does not use custom fonts, so this is always False.
         
-        :param      args and kwargs:    Generic arguments to permit generalized
-                                        function calls for any CardType.
+        :param      font:   The Font being evaluated.
         
         :returns:   False, as fonts are not customizable with this card.
         """

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -3,7 +3,7 @@ from re import findall
 
 from modules.CardType import CardType
 
-class AnimeCard(CardType):
+class AnimeTitleCard(CardType):
     """
     This class describes a type of ImageMaker that produces title cards in the
     theme of Star Wars cards as designed by reddit user /u/Olivier_286. These

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -23,7 +23,7 @@ class CardType(ImageMaker):
     DEFAULT_FONT_CASE = 'upper'
 
     """Mapping of 'case' strings to format functions"""
-    CASE_FUNCTION_MAP = {
+    CASE_FUNCTIONS = {
         'upper': str.upper,
         'lower': str.lower,
         'title': titlecase,

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from re import match
+
+from modules.Debug import log
+from modules.TitleCard import TitleCard
+
+class Font:
+    """
+    This class describes a font and all of its configurable attributes. Notably,
+    it's color, size, file, replacements, case function, vertical offset, and 
+    interline spacing.
+    """
+
+    def __init__(self, yaml: dict, card_class: 'CardType',
+                 series_info: 'SeriesInfo') -> None:
+        """
+        Constructs a new instance of a Font for the given YAML, CardType, and
+        series.
+        
+        :param      yaml:           'font' dictionary from a series YAML file.
+        :param      card_class:     CardType class to use values from.
+        :param      series_info:    Associated SeriesInfo (for logging only).
+        """
+
+        # Store arguments
+        self.__yaml = yaml
+        self.__card_class = card_class
+        self.__series_info = series_info
+        
+        # Generic font attributes
+        self.set_default()
+        
+        # Parse YAML
+        self.valid = True
+        self.__parse_attributes()
+
+        
+    def __repr__(self) -> str:
+        """Returns an unambiguous string representation of the object."""
+        
+        return f'<CustomFont for series {series_info}>'
+
+
+    def __parse_attributes(self) -> None:
+        """Parse this object's YAML and update the validity and attributes."""
+
+        # Font case
+        if (value := self.__yaml.get('case', '').lower()):
+            if value not in self.__card_class.CASE_FUNCTIONS:
+                log.error(f'Font case "{value}" of series {self} is invalid')
+                self.valid = False
+            else:
+                self.case = self.__card_class.CASE_FUNCTIONS[value]
+
+        # Font color
+        if (value := self.__yaml.get('color', None)):
+            if not bool(match('^#[a-fA-F0-9]{6}$', value)):
+                log.error(f'Font color "{value}" of series {self} is invalid - '
+                          f'specify as "#xxxxxx"')
+                self.valid = False
+            else:
+                self.color = value
+
+        # Font file
+        if (value := self.__yaml.get('file', None)):
+            if not Path(value).exists():
+                log.error(f'Font file "{value}" of series {self} not found')
+                self.valid = False
+            else:
+                self.file = str(Path(value).resolve())
+                self.replacements = {} # Reset for manually specified font
+
+        # Font replacements
+        if (value := self.__yaml.get('replacements', None)):
+            if any(len(key) != 1 for key in value.keys()):
+                log.error(f'Font replacements of series {self} is invalid - '
+                          f'must only be 1 character')
+                self.valid = False
+            else:
+                self.replacements = value
+
+        # Font Size
+        if (value := self.__yaml.get('size', None)):
+            if not bool(match(r'^\d+%$', value)):
+                log.error(f'Font size "{value}" of series {self} is invalid - '
+                          f'specify as "x%"')
+                self.valid = False
+            else:
+                self.size = float(value[:-1]) / 100.0
+
+        # Vertical shift
+        if (value := self.__yaml.get('vertical_shift', None)):
+            if not isinstance(value, int):
+                log.error(f'Font vertical shift "{value}" of series {self} is '
+                          f'invalid - must be an integer.')
+                self.valid = False
+            else:
+                self.vertical_shift = value
+
+        # Interline spacing
+        if (value := self.__yaml.get('interline_spacing', None)):
+            if not isinstance(value, int):
+                log.error(f'Font interline spacing "{value}" of series {self} '
+                          f'is invalid - must be an integer.')
+                self.valid = False
+            else:
+                self.interline_spacing = value
+
+
+    def set_default(self) -> None:
+        """Reset this object's attributes to its default values."""
+
+        self.color = self.__card_class.TITLE_COLOR
+        self.size = 1.0
+        self.file = self.__card_class.TITLE_FONT
+        self.replacements = self.__card_class.FONT_REPLACEMENTS
+        self.case = self.__card_class.CASE_FUNCTIONS[
+            self.__card_class.DEFAULT_FONT_CASE
+        ]
+        self.vertical_shift = 0
+        self.interline_spacing = 0
+
+
+    def get_attributes(self) -> dict:
+        """
+        Return a dictionary of attributes for this font to be unpacked.
+        
+        :returns:   Dictionary of attributes.
+        """
+
+        return {
+            'title_color': self.color,
+            'font_size': self.size,
+            'font': self.file,
+            'vertical_shift': self.vertical_shift,
+            'interline_spacing': self.interline_spacing,
+        }
+        

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -65,6 +65,12 @@ class PreferenceParser:
         self.__parse_yaml()
 
 
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return f'<PreferenceParser file={self.file}>'
+
+
     def __is_specified(self, *attributes: tuple) -> bool:
         """
         Determines whether the given attribute/sub-attribute has been manually 

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -11,19 +11,14 @@ class Profile:
     season titles.
     """
 
-    def __init__(self, font_color: str, font_size: float, font: str,
-                 font_case: str, font_replacements: dict, hide_seasons: bool,
+    def __init__(self, font: 'Font', hide_seasons: bool,
                  season_map: dict, episode_range: dict, map_or_range: bool,
                  episode_text_format: str) -> None:
         """
         Constructs a new instance of a Profile. All given arguments will be
         applied through this Profile (and whether it's generic/custom).
         
-        :param      font_color:             The font color.
-        :param      font_size:              The font size.
-        :param      font:                   The font name.
-        :param      font_case:              The font case string.
-        :param      font_replacements:      The font replacements.
+        :param      font:                   The Font for this profile.
         :param      hide_seasons:           Whether to hide/show seasons.
         :param      season_map:             The season map.
         :param      episode_range:          The episode range.
@@ -32,11 +27,7 @@ class Profile:
         """
 
         # Store this profiles arguments as attributes
-        self.font_color = font_color
-        self.font_size = font_size
         self.font = font
-        self.font_case = CardType.CASE_FUNCTION_MAP[font_case]
-        self.font_replacements = font_replacements
         self.hide_season_title = hide_seasons
         self.__season_map = season_map
         self.__episode_range = episode_range
@@ -69,13 +60,7 @@ class Profile:
         )
 
         # Determine whether this profile uses a custom font
-        has_custom_font = card_class.is_custom_font(
-            font=self.font,
-            size=self.font_size,
-            color=self.font_color,
-            replacements=self.font_replacements,
-            case=self.font_case,
-        )
+        has_custom_font = card_class.is_custom_font(self.font)
 
         # Get list of profile strings applicable to this object
         valid_profiles = [{'seasons': 'generic', 'font': 'generic'}]
@@ -116,13 +101,7 @@ class Profile:
 
         # If the new profile has a generic font, reset font attributes
         if not self.__use_custom_font:
-            self.font = card_class.TITLE_FONT
-            self.font_size = 1.0
-            self.font_color = card_class.TITLE_COLOR
-            self.font_replacements = card_class.FONT_REPLACEMENTS
-            self.font_case = card_class.CASE_FUNCTION_MAP[
-                card_class.DEFAULT_FONT_CASE
-            ]
+            self.font.set_default()
 
 
     def get_season_text(self, episode_info: 'EpisodeInfo') -> str:
@@ -316,12 +295,12 @@ class Profile:
             title_text = self.__remove_episode_text_format(title_text)
 
         # Create translation table for this profile's replacements
-        translation = str.maketrans(self.font_replacements)
+        translation = str.maketrans(self.font.replacements)
 
         # Apply translation table to this text
         translated_text = title_text.translate(translation)
 
         # Apply this profile's font function to the translated text
-        return self.font_case(translated_text)
+        return self.font.case(translated_text)
 
 

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -213,13 +213,12 @@ class StarWarsTitleCard(CardType):
 
 
     @staticmethod
-    def is_custom_font(*args, **kwargs) -> bool:
+    def is_custom_font(font: 'Font') -> bool:
         """
         Determines whether the given arguments represent a custom font for this
         card. This CardType does not use custom fonts, so this is always False.
         
-        :param      args and kwargs:    Generic arguments to permit generalized
-                                        function calls for any CardType.
+        :param      font:   The Font being evaluated.
         
         :returns:   False, as fonts are not customizable with this card.
         """

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -3,7 +3,7 @@ from re import match, sub, IGNORECASE
 from modules.Debug import log
 
 # CardType classes
-from modules.AnimeCard import AnimeCard
+from modules.AnimeTitleCard import AnimeTitleCard
 from modules.StandardTitleCard import StandardTitleCard
 from modules.StarWarsTitleCard import StarWarsTitleCard
 
@@ -28,7 +28,7 @@ class TitleCard:
     CARD_TYPES = {
         'standard': StandardTitleCard,
         'generic': StandardTitleCard,
-        'anime': AnimeCard,
+        'anime': AnimeTitleCard,
         'star wars': StarWarsTitleCard,
     }
 
@@ -61,10 +61,8 @@ class TitleCard:
                 profile, **title_characteristics
             ), season_text=profile.get_season_text(episode.episode_info),
             episode_text=profile.get_episode_text(episode),
-            font=profile.font,
-            font_size=profile.font_size,
-            title_color=profile.font_color,
             hide_season=profile.hide_season_title,
+            **profile.font.get_attributes(),
             **extra_characteristics,
         )
 


### PR DESCRIPTION
# Major Changes
- Renamed `AnimeCard` to `AnimeTitleCard` to fit naming style of other card classes
- Created `Font` class that encapsulates font customization options
  - Moved all font attributes from `Show` class
  - Reworked code to use new objects, removed from `Show`
# Major Fixes 
- Added `vertical_shift` and `interline_spacing` attributes to series font YAML, accepted by `StandardTitleCard` class
  - Closes #43 
# Minor Changes
- Renamed `CardType.CASE_FUNCTION_MAP` to `CASE_FUNCTIONS`
# Minor Fixes
N/A