### PR TITLE
Multi episode title parsing, many bug fixes

### DIFF
--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -87,7 +87,7 @@ class AnimeTitleCard(CardType):
 
         # Apply titlecase case function, escape characters
         self.title = self.image_magick.escape_chars(
-            self.CASE_FUNCTION_MAP['title'](title)
+            self.CASE_FUNCTIONS['title'](title)
         )
 
         # Store kanji, set bool for whether to use it or not

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -26,6 +26,7 @@ class AnimeTitleCard(CardType):
 
     """Path to the font to use for the episode title"""
     TITLE_FONT = str((REF_DIRECTORY / 'Flanker Griffo.otf').resolve())
+    DEFAULT_FONT_CASE = 'title'
 
     """Color to use for the episode title"""
     TITLE_COLOR = 'white'
@@ -86,9 +87,7 @@ class AnimeTitleCard(CardType):
         self.output_file = output_file
 
         # Apply titlecase case function, escape characters
-        self.title = self.image_magick.escape_chars(
-            self.CASE_FUNCTIONS['title'](title)
-        )
+        self.title = self.image_magick.escape_chars(title)
 
         # Store kanji, set bool for whether to use it or not
         self.kanji = self.image_magick.escape_chars(kanji)
@@ -373,14 +372,16 @@ class AnimeTitleCard(CardType):
     def is_custom_font(font: 'Font') -> bool:
         """
         Determines whether the given arguments represent a custom font for this
-        card. This CardType does not use custom fonts, so this is always False.
+        card. This CardType only uses custom font cases.
         
         :param      font:   The Font being evaluated.
         
-        :returns:   False, as fonts are not customizable with this card.
+        :returns:   True if the given font uses a case function other than
+                    'title', False otherwise.
         """
 
-        return False
+        default_case = AnimeTitleCard.DEFAULT_FONT_CASE
+        return font.case != AnimeTitleCard.CASE_FUNCTIONS[default_case]
 
 
     @staticmethod

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -38,7 +38,7 @@ class Font:
     def __repr__(self) -> str:
         """Returns an unambiguous string representation of the object."""
         
-        return f'<CustomFont for series {series_info}>'
+        return f'<CustomFont for series {self.__series_info}>'
 
 
     def __parse_attributes(self) -> None:

--- a/modules/MultiEpisode.py
+++ b/modules/MultiEpisode.py
@@ -87,26 +87,43 @@ class MultiEpisode:
         Modify the given episode text format string to be suitable for a
         MultiEpisode. This replaces {abs_number} or {episode_number} with
         {abs_start}-{abs_end} and {episode_start}-{episode_end}, and adds an S
-        to the preceding text. For example:
+        to the preceding text (if a space preceeds the identifier) For example:
 
         >>> modify_format_string('EPISODE {abs_number}')
         'EPISODES {abs_start}-{abs_end}'
+        >>> modify_format_string('E{episode_number}')
+        'E{episode_start}-{episode_end}'
         
         :param      episode_format_string:  The episode format string to modify.
         
-        :returns:   The modified multiple'd format string.
+        :returns:   The modified format string.
         """
         
+        # Split for pluralized absolute numbers
         if ' {abs_number}' in episode_format_string:
-            # Split for absolute numbers
             pre, post = episode_format_string.split(' {abs_number}')
 
             return pre + 'S {abs_start}-{abs_end}' + post
 
-        # Split for episode numbers
-        pre, post = episode_format_string.split(' {episode_number}')
+        # Split for pluralized episode numbers
+        if ' {episode_number}' in episode_format_string:
+            pre, post = episode_format_string.split(' {episode_number}')
 
-        return pre + 'S {episode_start}-{episode_end}' + post
+            return pre + 'S {episode_start}-{episode_end}' + post
+
+        # Split for absolute number, no leading space and pluralization
+        if '{abs_number}' in episode_format_string:
+            pre, post = episode_format_string.split('{abs_number}')
+
+            return pre + '{abs_start}-{abs_end}' + post
+
+        # Split for episode number, no leading space and pluralization
+        if '{episode_number}' in episode_format_string:
+            pre, post = episode_format_string.split('{episode_number}')
+
+            return pre + '{episode_start}-{episode_end}' + post
+
+        return episode_format_string
 
 
     def set_destination(self, destination: 'Path') -> None:

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -177,6 +177,7 @@ class Profile:
                 episode_end=episode.episode_end,
                 abs_start=episode.abs_start,
                 abs_end=episode.abs_end,
+                **episode.extra_characteristics,
             )
 
         # Standard Episode class
@@ -185,12 +186,14 @@ class Profile:
                 season_number=episode.episode_info.season_number,
                 episode_number=episode.episode_info.episode_number,
                 abs_number=episode.episode_info.abs_number,
+                **episode.extra_characteristics,
             )
 
         return episode.card_class.EPISODE_TEXT_FORMAT.format(
             season_number=episode.episode_info.season_number,
             episode_number=episode.episode_info.episode_number,
             abs_number=episode.episode_info.abs_number, 
+            **episode.extra_characteristics,
         )
 
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -465,7 +465,7 @@ class Show:
         for _, episode in (pbar := tqdm(self.episodes.items(), leave=False)):
             # Update progress bar
             pbar.set_description(f'Creating {episode}')
-
+            
             # Skip episodes whose destination is None (don't create) or does exist
             if not episode.destination or episode.destination.exists():
                 continue

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -72,13 +72,14 @@ class Title:
         :returns:   The partless title.
         """
 
-        # Match for "title" (digit)
-        if (partless := match(r'^(.*?)\s*\(\d+\)', self.full_title)):
+        # Match for "title" (digit) or "title" (Part (digit))
+        if (partless := match(r'^(.*?)\s*\((?:Part\s*)?\d+\)',
+                              self.full_title, IGNORECASE)):
             return partless.group(1)
 
         # Match "title" - Part (digit) or "title": Part (digit)
-        if (partless := match(r'^(.*?)(?::|\s*-|,)\s*Part \d*', self.full_title,
-                              IGNORECASE)):
+        if (partless := match(r'^(.*?)(?::|\s*-|,)\s+Part\s*\d*', 
+                              self.full_title, IGNORECASE)):
             return partless.group(1)
 
         return self.full_title


### PR DESCRIPTION
# Major Changes
- Added option to set custom font case within cards using the `anime` card type
  - Set `AnimeTitleCard` default font case to `title` 
# Major Fixes 
- Fixed creation of source and media directory to correctly use values if YAML overwrites default values
# Minor Changes
- Added passing of extra episode characteristics to episode formatting function
- Added parsing of multi episode format strings without preceding spaces
- Added parsing for multiepisode titles formatted as `"Title (Part {digit})"`
- Removed unnecessary parsing of `source` attribute (should only be `source_directory`) from series YAML files
# Minor Fixes
- Fix edge cases for multi episode format string formatting
- Fixed bug for show's `SeriesInfo` object not being initialized for series' with invalid years
- Fixed error in `Font.__repr__()` method