### PR TITLE
Re-read source files on per-show level, fixed custom episode text format strings

### DIFF
--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -423,7 +423,7 @@ class AnimeTitleCard(CardType):
         Make the necessary ImageMagick and system calls to create this object's
         defined title card.
         """
-
+        
         # Create the output directory and any necessary parents 
         self.output_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -423,7 +423,7 @@ class AnimeTitleCard(CardType):
         Make the necessary ImageMagick and system calls to create this object's
         defined title card.
         """
-        
+
         # Create the output directory and any necessary parents 
         self.output_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -93,10 +93,11 @@ class Manager:
             return None
 
         # For each show in the Manager, add translation
+        modified = False
         for show in (pbar := tqdm(self.shows)):
             pbar.set_description(f'Adding translations for '
                                  f'"{show.series_info.short_name}"')
-            show.add_translation(self.tmdb_interface)
+            modified |= show.add_translations(self.tmdb_interface)
 
 
     def read_show_source(self) -> None:

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -96,7 +96,7 @@ class Manager:
         for show in (pbar := tqdm(self.shows)):
             pbar.set_description(f'Adding translations for '
                                  f'"{show.series_info.short_name}"')
-            show.add_translation(self.tmdb_interface)
+            show.add_translations(self.tmdb_interface)
 
 
     def read_show_source(self) -> None:
@@ -124,6 +124,7 @@ class Manager:
         if not self.preferences.use_sonarr:
             return None
 
+        # Go through each show in the Manager, querying Sonarr
         for show in tqdm(self.shows, desc='Querying Sonarr'):
             show.check_sonarr_for_new_episodes(self.sonarr_interface)
 
@@ -135,6 +136,7 @@ class Manager:
         updated (if enabled). This calls Show.create_missing_title_cards().
         """
 
+        # Go through every show in the Manager, create cards
         for show in (pbar := tqdm(self.shows)):
             # Update progress bar
             pbar.set_description(f'Creating Title Cards for '
@@ -211,9 +213,7 @@ class Manager:
         self.create_shows()
         self.read_show_source()
         self.check_sonarr_for_new_episodes()
-        self.read_show_source()
         self.check_tmdb_for_translations()
-        self.read_show_source()
         self.create_missing_title_cards()
         self.update_archive()
         self.create_summaries()

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -85,25 +85,18 @@ class Manager:
             )
 
 
-    def check_tmdb_for_translations(self) -> bool:
-        """
-        Query TMDb for all translated episode titles (if indicated).
-
-        :returns:   True if any translations were added to shows.
-        """
+    def check_tmdb_for_translations(self) -> None:
+        """Query TMDb for all translated episode titles (if indicated)."""
 
         # If the TMDbInterface isn't enabled, skip
         if not self.tmdb_interface:
-            return False
+            return None
 
         # For each show in the Manager, add translation
-        modified = False
         for show in (pbar := tqdm(self.shows)):
             pbar.set_description(f'Adding translations for '
                                  f'"{show.series_info.short_name}"')
-            modified |= show.add_translations(self.tmdb_interface)
-
-        return modified
+            show.add_translation(self.tmdb_interface)
 
 
     def read_show_source(self) -> None:
@@ -121,24 +114,18 @@ class Manager:
             archive.find_multipart_episodes()
 
 
-    def check_sonarr_for_new_episodes(self) -> bool:
+    def check_sonarr_for_new_episodes(self) -> None:
         """
         Query Sonarr to see if any new episodes exist for every show known to
         this manager.
-
-        :returns:   True if anu new episodes were found, False otherwise.
         """
 
         # If sonarr is globally disabled, skip
         if not self.preferences.use_sonarr:
             return None
 
-        # Go through each show in the Manager, querying Sonarr
-        modified = False
         for show in tqdm(self.shows, desc='Querying Sonarr'):
-            modified |=show.check_sonarr_for_new_episodes(self.sonarr_interface)
-
-        return modified
+            show.check_sonarr_for_new_episodes(self.sonarr_interface)
 
 
     def create_missing_title_cards(self) -> None:
@@ -221,19 +208,12 @@ class Manager:
     def run(self) -> None:
         """Run the manager and exit."""
 
-        # Always create Show objects from series YAML and read their sources
         self.create_shows()
         self.read_show_source()
-
-        # If Sonarr has new episodes, add them and re-read source
-        if self.check_sonarr_for_new_episodes():
-            self.read_show_source()
-
-        # If any translations were added to datafiles, re-read source
-        if self.check_tmdb_for_translations():
-            self.read_show_source()
-
-        # Create cards, update archive, create summaries
+        self.check_sonarr_for_new_episodes()
+        self.read_show_source()
+        self.check_tmdb_for_translations()
+        self.read_show_source()
         self.create_missing_title_cards()
         self.update_archive()
         self.create_summaries()

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -377,7 +377,6 @@ class Show:
         )
 
         # For each episode, check if the data matches any contained Episodes
-        has_new = False
         if all_episodes:
             # Filter out episodes that already exist
             new_episodes = list(filter(
@@ -385,13 +384,10 @@ class Show:
                 all_episodes,
             ))
 
-            # Add all new entries to the datafile
-            self.file_interface.add_many_entries(new_episodes)
-
-        # If new entries were added, re-parse source file
-        if has_new:
-            self.read_source()
-            return True
+            # If there are new episodes, add to the datafile, return True
+            if new_episodes:
+                self.file_interface.add_many_entries(new_episodes)
+                return True
 
         return False
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -393,18 +393,22 @@ class Show:
         return False
 
 
-    def add_translation(self, tmdb_interface: 'TMDbInterface') -> None:
+    def add_translations(self, tmdb_interface: 'TMDbInterface') -> bool:
         """
         Add translated episode titles to the Episodes of this series.
         
         :param      tmdb_interface: Interface to TMDb to query for translated
                                     episode titles.
+
+        :returns:   True if any translations were added, False otherwise.
         """
 
         # If no title language was specified, or TMDb syncing isn't enabled,skip
         if self.title_language == {} or not self.tmdb_sync:
-            return None
+            return False
 
+        modified = False
+        # Go through every episode and look for translations
         for _, episode in (pbar := tqdm(self.episodes.items(), leave=False)):
             # Update progress bar
             pbar.set_description(f'Checking {episode}')
@@ -430,10 +434,13 @@ class Show:
                       f'"{self.title_language["key"]}" of {self}')
 
             # Modify data file entry with new title
+            modified = True
             self.file_interface.add_data_to_entry(
                 episode.episode_info,
                 **{self.title_language['key']: language_title},
             )
+
+        return modified
 
 
     def create_missing_title_cards(self, tmdb_interface: 'TMDbInterface'=None,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -69,6 +69,7 @@ class Show:
         # Setup default values that can be overwritten by YAML
         self.series_info = SeriesInfo(name, year)
         self.card_class = TitleCard.CARD_TYPES[self.preferences.card_type]
+        self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
         self.library_name = None
         self.library = None
         self.archive = True
@@ -90,7 +91,6 @@ class Show:
         self.valid = self.font.valid
 
         # Update derived attributes
-        self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
         self.source_directory = source_directory / self.series_info.full_name
         self.logo = self.source_directory / self.preferences.logo_filename
         self.file_interface = DataFileInterface(
@@ -156,6 +156,8 @@ class Show:
                         self.valid = False
                     else:
                         self.card_class = TitleCard.CARD_TYPES[card_type]
+                        etf = self.card_class.EPISODE_TEXT_FORMAT
+                        self.episode_text_format = etf
 
         if self.__is_specified('card_type'):
             if (value := self.__yaml['card_type']) not in TitleCard.CARD_TYPES:
@@ -163,6 +165,7 @@ class Show:
                 self.valid = False
             else:
                 self.card_class = TitleCard.CARD_TYPES[value]
+                self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
 
         if self.__is_specified('source_directory'):
             self.source_directory = Path(self.__yaml['source_directory'])

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -134,7 +134,6 @@ class Show:
         invalid attributes and update this object's validity.
         """
 
-        # Read all optional attributes
         if self.__is_specified('name'):
             self.series_info.update_name(self.__yaml['name'])
 
@@ -277,6 +276,9 @@ class Show:
         objects to this show's episodes dictionary.
         """
 
+        # Reset episodes dictionary
+        self.episodes = {}
+
         # Go through each entry in the file interface
         for entry in self.file_interface.read():
             # Create Episode object for this entry, store under key
@@ -355,21 +357,20 @@ class Show:
 
 
     def check_sonarr_for_new_episodes(self,
-                                      sonarr_interface:'SonarrInterface')->bool:
+                                      sonarr_interface:'SonarrInterface')->None:
         """
         Query the provided SonarrInterface object, checking if the returned
         episodes exist in this show's associated source. All new entries are
-        added to this object's DataFileInterface. This method should only be
-        called if Sonarr syncing is globally enabled.
-        
-        :param      sonarr_interface:   The Sonarr interface to query.
+        added to this object's DataFileInterface, and the source is re-read.
 
-        :returns:   True if Sonarr returned any new episodes, False otherwise.
+        This method should only be called if Sonarr syncing is globally enabled.
+        
+        :param      sonarr_interface:   The SonarrInterface to query.
         """
 
         # Check if Sonarr is enabled for this show in partocular
         if not self.sonarr_sync:
-            return False
+            return None
 
         # Get list of EpisodeInfo objects from Sonarr
         all_episodes = sonarr_interface.get_all_episodes_for_series(
@@ -377,7 +378,6 @@ class Show:
         )
 
         # For each episode, check if the data matches any contained Episodes
-        has_new = False
         if all_episodes:
             # Filter out episodes that already exist
             new_episodes = list(filter(
@@ -385,20 +385,16 @@ class Show:
                 all_episodes,
             ))
 
-            # Add all new entries to the datafile
-            self.file_interface.add_many_entries(new_episodes)
-
-        # If new entries were added, re-parse source file
-        if has_new:
-            self.read_source()
-            return True
-
-        return False
+            # If there are new episodes, add to the datafile, return True
+            if new_episodes:
+                self.file_interface.add_many_entries(new_episodes)
+                self.read_source()
 
 
-    def add_translation(self, tmdb_interface: 'TMDbInterface') -> None:
+    def add_translations(self, tmdb_interface: 'TMDbInterface') -> None:
         """
-        Add translated episode titles to the Episodes of this series.
+        Add translated episode titles to the Episodes of this series. This 
+        show's source file is re-read if any translations are added.
         
         :param      tmdb_interface: Interface to TMDb to query for translated
                                     episode titles.
@@ -408,6 +404,8 @@ class Show:
         if self.title_language == {} or not self.tmdb_sync:
             return None
 
+        # Go through every episode and look for translations
+        modified = False
         for _, episode in (pbar := tqdm(self.episodes.items(), leave=False)):
             # Update progress bar
             pbar.set_description(f'Checking {episode}')
@@ -428,15 +426,20 @@ class Show:
                 or language_title ==  episode.episode_info.title.full_title):
                 continue
 
-            # Adding data, log it
+            # Adding translated title, log it
             log.debug(f'Adding "{language_title}" to '
                       f'"{self.title_language["key"]}" of {self}')
 
             # Modify data file entry with new title
+            modified = True
             self.file_interface.add_data_to_entry(
                 episode.episode_info,
                 **{self.title_language['key']: language_title},
             )
+
+        # If any translations were added, re-read source
+        if modified:
+            self.read_source()
 
 
     def create_missing_title_cards(self, tmdb_interface: 'TMDbInterface'=None,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -377,6 +377,7 @@ class Show:
         )
 
         # For each episode, check if the data matches any contained Episodes
+        has_new = False
         if all_episodes:
             # Filter out episodes that already exist
             new_episodes = list(filter(
@@ -384,30 +385,29 @@ class Show:
                 all_episodes,
             ))
 
-            # If there are new episodes, add to the datafile, return True
-            if new_episodes:
-                self.file_interface.add_many_entries(new_episodes)
-                return True
+            # Add all new entries to the datafile
+            self.file_interface.add_many_entries(new_episodes)
+
+        # If new entries were added, re-parse source file
+        if has_new:
+            self.read_source()
+            return True
 
         return False
 
 
-    def add_translations(self, tmdb_interface: 'TMDbInterface') -> bool:
+    def add_translation(self, tmdb_interface: 'TMDbInterface') -> None:
         """
         Add translated episode titles to the Episodes of this series.
         
         :param      tmdb_interface: Interface to TMDb to query for translated
                                     episode titles.
-
-        :returns:   True if any translations were added, False otherwise.
         """
 
         # If no title language was specified, or TMDb syncing isn't enabled,skip
         if self.title_language == {} or not self.tmdb_sync:
-            return False
+            return None
 
-        modified = False
-        # Go through every episode and look for translations
         for _, episode in (pbar := tqdm(self.episodes.items(), leave=False)):
             # Update progress bar
             pbar.set_description(f'Checking {episode}')
@@ -433,13 +433,10 @@ class Show:
                       f'"{self.title_language["key"]}" of {self}')
 
             # Modify data file entry with new title
-            modified = True
             self.file_interface.add_data_to_entry(
                 episode.episode_info,
                 **{self.title_language['key']: language_title},
             )
-
-        return modified
 
 
     def create_missing_title_cards(self, tmdb_interface: 'TMDbInterface'=None,


### PR DESCRIPTION
# Major Changes
- Significant performance improvement
  - Modified `Show` class to only re-read source files after translations or new episodes have been added *per show*
# Major Fixes 
- Fixed `Show` class ignoring custom episode text format strings
# Minor Changes
- Renamed `Show.add_translation()` method to `Show.add_translations()`
# Minor Fixes
N/A