### PR TITLE
Added font validation to title card creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,9 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from modules.Debug import log
+from modules.FontValidator import FontValidator
 from modules.PreferenceParser import PreferenceParser
-from modules.preferences import set_preference_parser
+from modules.preferences import set_preference_parser, set_font_validator
 from modules.Manager import Manager
 
 # Default path for a preference file to parse
@@ -46,6 +47,7 @@ if not (pp := PreferenceParser(args.preference_file)).valid:
 
 # Store the valid preference parser in the global namespace
 set_preference_parser(pp)
+set_font_validator(FontValidator())
 
 # Create and run the manager --run many times
 tcm = None

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -48,6 +48,11 @@ class Font:
     def __parse_attributes(self) -> None:
         """Parse this object's YAML and update the validity and attributes."""
 
+        # Whether to validate for this font
+        if (value := self.__yaml.get('validate', None)):
+            self.__validate = bool(value)
+            breakpoint()
+
         # Font case
         if (value := self.__yaml.get('case', '').lower()):
             if value not in self.__card_class.CASE_FUNCTIONS:
@@ -120,6 +125,10 @@ class Font:
     def set_default(self) -> None:
         """Reset this object's attributes to its default values."""
 
+        # Whether to validate for this font
+        self.__validate = global_preferences.pp.validate_fonts
+
+        # Title card characteristics
         self.color = self.__card_class.TITLE_COLOR
         self.size = 1.0
         self.file = self.__card_class.TITLE_FONT
@@ -150,7 +159,8 @@ class Font:
     def validate_title(self, title: 'Title') -> bool:
         """
         Return whether all the characters of the given Title are valid for this
-        font. This uses the global FontValidator object.
+        font. This uses the global FontValidator object, and always returns True
+        if validation is not enabled.
         
         :param      title:  The Title being validated.
         
@@ -158,6 +168,10 @@ class Font:
                     within this font, False otherwise.
         """
 
-        return self.__validator.validate_title(self.file, title)
+        # Validate title against this font
+        validity = self.__validator.validate_title(self.file, title)
+
+        # If validation isn't enabled, ignore result and return True
+        return validity if self.__validate else True
 
         

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -3,6 +3,7 @@ from re import match
 
 from modules.Debug import log
 from modules.TitleCard import TitleCard
+import modules.preferences as global_preferences
 
 class Font:
     """
@@ -26,6 +27,9 @@ class Font:
         self.__yaml = yaml
         self.__card_class = card_class
         self.__series_info = series_info
+
+        # This font's FontValidator object
+        self.__validator = global_preferences.fv
         
         # Generic font attributes
         self.set_default()
@@ -141,4 +145,19 @@ class Font:
             'vertical_shift': self.vertical_shift,
             'interline_spacing': self.interline_spacing,
         }
+
+
+    def validate_title(self, title: 'Title') -> bool:
+        """
+        Return whether all the characters of the given Title are valid for this
+        font. This uses the global FontValidator object.
+        
+        :param      title:  The Title being validated.
+        
+        :returns:   True if all the characters of the given Title are contained
+                    within this font, False otherwise.
+        """
+
+        return self.__validator.validate_title(self.file, title)
+
         

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -5,7 +5,7 @@ from yaml import safe_load, dump
 
 from modules.Debug import log
 
-class FontValidator():
+class FontValidator:
 
     FONT_VALIDATION_MAP = Path(__file__).parent / '.objects' / 'fvm.yml'
 
@@ -25,68 +25,69 @@ class FontValidator():
             self.__fonts = {}
 
 
-    def __set_character(self, font_key: str, character: str,
+    def __set_character(self, font_filepath: str, character: str,
                         status: bool) -> None:
         """
         Set the given character for the given font to the given status, then
         write the updated font map to file.
         
-        :param      font_key:   The font key
-        :param      character:  The character
-        :param      status:     The status
+        :param      font_filepath:  Filepath to the font being validated against
+        :param      character:      The character whose status is being set
+        :param      status:         Whether the given font has the given
+                                    character.
         """
 
         # Set the given status within the map
-        if font_key in self.__fonts:
-            self.__fonts[font_key][character] = status
+        if font_filepath in self.__fonts:
+            self.__fonts[font_filepath][character] = status
         else:
-            self.__fonts[font_key] = {character: status}
+            self.__fonts[font_filepath] = {
+                character: status, ' ': True,
+            }
 
         # Write updated map to file
         with self.FONT_VALIDATION_MAP.open('w') as file_handle:
             dump({'fonts': self.__fonts}, file_handle, allow_unicode=True)
 
 
-    def __has_character(self, font: Path, character: str) -> bool:
+    def __has_character(self, font_filepath: str, character: str) -> bool:
         """
-        Determines whether the given character exists in the given font. 
+        Determines whether the given character exists in the given Font. 
         
-        :param      font:   Path to the font file being validated.
-        :param      title:  The Title being validated.
+        :param      font_filepath:  Filepath to the font being validated against
+        :param      title:          The Title being validated.
         
         :returns:   True if the given character exists in the given font, False
                     otherwise.
         """
 
-        # Get the key for this font, and ordinal value of this character
-        font_key = str(font.resolve())
+        # If this font and character has been checked, return that
+        if (status := self.__fonts.get(font_filepath, {}).get(character, None)):
+            return status
+
+        # Get the ordinal value of this character
         glyph = ord(character)
 
-        # If this font and character has been checked, return that
-        if (font_key in self.__fonts
-            and character in self.__fonts[font_key]):
-            return self.__fonts[font_key][character]
-
         # Go through each table in this font, return True if in a cmap
-        for table in TTFont(font.resolve())['cmap'].tables:
+        for table in TTFont(font_filepath)['cmap'].tables:
             if glyph in table.cmap:
                 # Update map for this character, return True
-                self.__set_character(font_key, character, True)
+                self.__set_character(font_filepath, character, True)
                 return True
 
         # Update map for this character, return False
-        self.__set_character(font_key, character, False)
-        log.debug(f'Character "{character}"" not in font "{font_key}"')
+        self.__set_character(font_filepath, character, False)
+        log.debug(f'Character "{character}"" not in font "{font_filepath}"')
         return False
 
 
-    def validate_title(self, font: Path, title: 'Title') -> bool:
+    def validate_title(self, font_filepath: str, title: str) -> bool:
         """
         Validate the given Title, returning whether all characters are contained
-        within the given font.
+        within the given Font.
         
-        :param      font:   Path to the font file being validated.
-        :param      title:  The Title being validated.
+        :param      font_filepath:  Filepath to the font being validated against
+        :param      title:          The title being validated.
         
         :returns:   True if all characters in the title are found within the
                     given font, False otherwise.
@@ -94,39 +95,9 @@ class FontValidator():
 
         # Map __has_character() to all characters in the title
         has_characters = map(
-            lambda char: self.__has_character(font, char),
-            title.full_title
+            lambda char: self.__has_character(font_filepath, char),
+            title.replace('\n', '')
         )
 
         return all(has_characters)
 
-
-    def validate_episode_titles(self, font: Path,
-                                datafile_interface: 'DataFileInterface') ->bool:
-        """
-
-        """
-
-        invalid = False
-        for data in datafile_interface.read():
-            invalid |= not self.validate_title(font, data['episode_info'].title)
-
-        return not invalid
-
-
-
-# from yaml import safe_load
-# from pathlib import Path
-
-# with Path('data.yml').open('r') as fh:
-#     yaml = safe_load(fh)
-
-# all_titles = ''
-# for season_key, season in yaml['data'].items():
-#     for episode_number, episode in season.items():
-#         all_titles += episode['title']
-
-# alpha = 'abcdefghijklmnopqrstuvwxyz'
-
-# missing = set(all_titles)-set(alpha)-set(alpha.upper())
-# print(''.join(missing))

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+from yaml import safe_load, dump
+
+from modules.Debug import log
+
+class FontValidator():
+
+    FONT_VALIDATION_MAP = Path(__file__).parent / '.objects' / 'fvm.yml'
+
+    def __init__(self) -> None:
+        """
+        Constructs a new instance. This creates the parent directory for the 
+        temporary font map if it exists, and reads the font map if possible.
+        """
+
+        # Attept to read existing font file if it exists
+        if self.FONT_VALIDATION_MAP.exists():
+            with self.FONT_VALIDATION_MAP.open('r') as file_handle:
+                self.__fonts = safe_load(file_handle)['fonts']
+        else:
+            # Create parent directories if necessary
+            self.FONT_VALIDATION_MAP.parent.mkdir(parents=True, exist_ok=True)
+            self.__fonts = {}
+
+
+    def __set_character(self, font_key: str, character: str,
+                        status: bool) -> None:
+        """
+        Set the given character for the given font to the given status, then
+        write the updated font map to file.
+        
+        :param      font_key:   The font key
+        :param      character:  The character
+        :param      status:     The status
+        """
+
+        # Set the given status within the map
+        if font_key in self.__fonts:
+            self.__fonts[font_key][character] = status
+        else:
+            self.__fonts[font_key] = {character: status}
+
+        # Write updated map to file
+        with self.FONT_VALIDATION_MAP.open('w') as file_handle:
+            dump({'fonts': self.__fonts}, file_handle, allow_unicode=True)
+
+
+    def __has_character(self, font: Path, character: str) -> bool:
+        """
+        Determines whether the given character exists in the given font. 
+        
+        :param      font:   Path to the font file being validated.
+        :param      title:  The Title being validated.
+        
+        :returns:   True if the given character exists in the given font, False
+                    otherwise.
+        """
+
+        # Get the key for this font, and ordinal value of this character
+        font_key = str(font.resolve())
+        glyph = ord(character)
+
+        # If this font and character has been checked, return that
+        if (font_key in self.__fonts
+            and character in self.__fonts[font_key]):
+            return self.__fonts[font_key][character]
+
+        # Go through each table in this font, return True if in a cmap
+        for table in TTFont(font.resolve())['cmap'].tables:
+            if glyph in table.cmap:
+                # Update map for this character, return True
+                self.__set_character(font_key, character, True)
+                return True
+
+        # Update map for this character, return False
+        self.__set_character(font_key, character, False)
+        log.debug(f'Character "{character}"" not in font "{font_key}"')
+        return False
+
+
+    def validate_title(self, font: Path, title: 'Title') -> bool:
+        """
+        Validate the given Title, returning whether all characters are contained
+        within the given font.
+        
+        :param      font:   Path to the font file being validated.
+        :param      title:  The Title being validated.
+        
+        :returns:   True if all characters in the title are found within the
+                    given font, False otherwise.
+        """
+
+        # Map __has_character() to all characters in the title
+        has_characters = map(
+            lambda char: self.__has_character(font, char),
+            title.full_title
+        )
+
+        return all(has_characters)
+
+
+    def validate_episode_titles(self, font: Path,
+                                datafile_interface: 'DataFileInterface') ->bool:
+        """
+
+        """
+
+        invalid = False
+        for data in datafile_interface.read():
+            invalid |= not self.validate_title(font, data['episode_info'].title)
+
+        return not invalid
+
+
+
+# from yaml import safe_load
+# from pathlib import Path
+
+# with Path('data.yml').open('r') as fh:
+#     yaml = safe_load(fh)
+
+# all_titles = ''
+# for season_key, season in yaml['data'].items():
+#     for episode_number, episode in season.items():
+#         all_titles += episode['title']
+
+# alpha = 'abcdefghijklmnopqrstuvwxyz'
+
+# missing = set(all_titles)-set(alpha)-set(alpha.upper())
+# print(''.join(missing))

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -42,6 +42,7 @@ class PreferenceParser:
         self.series_files = []
         self.card_type = 'standard'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
+        self.validate_fonts = True
         self.archive_directory = None
         self.create_archive = False
         self.create_summaries = False
@@ -131,6 +132,9 @@ class PreferenceParser:
                 self.valid = False
             else:
                 self.card_filename_format = new_format
+
+        if self.__is_specified('options', 'validate_fonts'):
+            self.validate_fonts = bool(self.__yaml['options']['validate_fonts'])
 
         if self.__is_specified('archive', 'path'):
             self.archive_directory = Path(self.__yaml['archive']['path'])

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -70,6 +70,7 @@ class Show:
         self.series_info = SeriesInfo(name, year)
         self.card_class = TitleCard.CARD_TYPES[self.preferences.card_type]
         self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
+        self.validate_font = self.preferences.validate_fonts
         self.library_name = None
         self.library = None
         self.archive = True
@@ -81,7 +82,7 @@ class Show:
         self.__season_map[0] = 'Specials'
         self.title_language = {}
 
-        # Set object attributes based off YAML and update validity attribute
+        # Set object attributes based off YAML and update validity
         self.__parse_yaml()
         self.font = Font(
             self.__yaml.get('font', {}),
@@ -171,6 +172,9 @@ class Show:
 
         if self.__is_specified('episode_text_format'):  
             self.episode_text_format = self.__yaml['episode_text_format']
+
+        if self.__is_specified('validate_font'):
+            self.validate_font = bool(self.__yaml['validate_font'])
 
         if self.__is_specified('archive'):
             self.archive = bool(self.__yaml['archive'])
@@ -447,11 +451,10 @@ class Show:
         """
         Creates any missing title cards for each episode of this show.
 
-        :param      tmdb_interface:     Optional interface to TMDb to download
-                                        any missing source images.
-        :param      sonarr_interface:   Optional interface to Sonarr to get
-                                        episode and series ID's before querying
-                                        TMDb.
+        :param      tmdb_interface:     Optional TMDbInterface to download any
+                                        missing source images from.
+        :param      sonarr_interface:   Optional SonarrInterface to get episode
+                                        and series ID's for improved querying.
 
         :returns:   True if any new cards were created, False otherwise.
         """
@@ -472,12 +475,27 @@ class Show:
             # Update progress bar
             pbar.set_description(f'Creating {episode}')
             
-            # Skip episodes whose destination is None (don't create) or does exist
+            # Skip episodes without destination (do not create), or that exist
             if not episode.destination or episode.destination.exists():
                 continue
 
-            # Attempt to make a TitleCard object for this episode and profile
-            # passing any extra characteristics from the episode along
+            # If the title card source images doesn't exist and can query TMDb..
+            if (not episode.source.exists()
+                and self.tmdb_sync and tmdb_interface):
+                # Query TMDbInterface for image
+                image_url = tmdb_interface.get_source_image(
+                    self.series_info,
+                    episode.episode_info
+                )
+
+                # Skip this card if no image is returned
+                if not image_url:
+                    continue
+
+                # Download the image
+                tmdb_interface.download_image(image_url, episode.source)
+
+            # Create a TitleCard object for this episode with Show's profile
             title_card = TitleCard(
                 episode,
                 self.profile,
@@ -485,24 +503,11 @@ class Show:
                 **episode.extra_characteristics,
             )
 
-            # If the title card source images doesn't exist..
-            if not episode.source.exists():
-                # Skip if cannot query database
-                if not self.tmdb_sync or not tmdb_interface:
-                    continue
-
-                # Query database for image
-                image_url = tmdb_interface.get_source_image(
-                    self.series_info,
-                    episode.episode_info
-                )
-
-                # Skip if no image is returned
-                if not image_url:
-                    continue
-
-                # Download the image
-                tmdb_interface.download_image(image_url, episode.source)
+            # If font validation is enabled, skip if title is invalid for font
+            if (self.validate_font
+                and not self.font.validate_title(title_card.converted_title)):
+                log.warning(f'Invalid font {self.font} for {episode}')
+                continue
 
             # Source exists, create the title card
             created_new_cards |= title_card.create()

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -70,7 +70,6 @@ class Show:
         self.series_info = SeriesInfo(name, year)
         self.card_class = TitleCard.CARD_TYPES[self.preferences.card_type]
         self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
-        self.validate_font = self.preferences.validate_fonts
         self.library_name = None
         self.library = None
         self.archive = True
@@ -172,9 +171,6 @@ class Show:
 
         if self.__is_specified('episode_text_format'):  
             self.episode_text_format = self.__yaml['episode_text_format']
-
-        if self.__is_specified('validate_font'):
-            self.validate_font = bool(self.__yaml['validate_font'])
 
         if self.__is_specified('archive'):
             self.archive = bool(self.__yaml['archive'])
@@ -503,9 +499,8 @@ class Show:
                 **episode.extra_characteristics,
             )
 
-            # If font validation is enabled, skip if title is invalid for font
-            if (self.validate_font
-                and not self.font.validate_title(title_card.converted_title)):
+            # Skip if title is invalid for font
+            if not self.font.validate_title(title_card.converted_title):
                 log.warning(f'Invalid font {self.font} for {episode}')
                 continue
 

--- a/modules/preferences.py
+++ b/modules/preferences.py
@@ -3,3 +3,8 @@ pp = None
 def set_preference_parser(to: 'PreferenceParser') -> None:
     global pp
     pp = to
+
+fv = None
+def set_font_validator(to: 'FontValidator') -> None:
+    global fv
+    fv = to


### PR DESCRIPTION
# Major Changes
- Added font character validation
  - If validation is enabled for a given series and a character within an episode's title is *not* present in that series' font, then the card is skipped (presuming the user will add a suitable font replacement)
  - All episode titles are checked against the series fonts (generic or custom) for if a given character is contained
  - Added global `FontValidator` object, similar to the `PreferenceParser`, which is used by all `Font` objects
  - Added parsing for global `"validate_fonts"` attribute within `"options"` section of preferences YAML (defaults to `True`)
  - Added parsing for override `"validate"` attribute in series YAML files (within `"font"`)
  - Closes #38 
# Major Fixes 
N/A
# Minor Changes
N/A
# Minor Fixes
N/A