### PR TITLE
Better translation querying, bad blacklist handling, fixer rework

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -5,7 +5,6 @@ from modules.DataFileInterface import DataFileInterface
 from modules.GenreMaker import GenreMaker
 from modules.PreferenceParser import PreferenceParser
 from modules.preferences import set_preference_parser
-from modules.SonarrInterface import SonarrInterface
 from modules.TitleCard import TitleCard
 from modules.TMDbInterface import TMDbInterface
 

--- a/fixer.py
+++ b/fixer.py
@@ -14,69 +14,115 @@ parser.add_argument('-p', '--preference-file', type=Path,
                     default='preferences.yml', metavar='PREFERENCE_FILE',
                     help='Preference YAML file for parsing '
                          'ImageMagick/Sonarr/TMDb options')
-parser.add_argument('--sort-data-file', type=Path, default=SUPPRESS,
-                    metavar='DATAFILE', help='Sort the given datafile')
 
 # Argument group for 'manual' title card creation
 title_card_group = parser.add_argument_group('Title Cards',
                                              'Manual title card creation')
-title_card_group.add_argument('--card-type', type=str, default='standard',
-                              choices=TitleCard.CARD_TYPES.keys(),
-                              help='Create a title card of a specific type')
-title_card_group.add_argument('--title-card', type=str, nargs=3,
-                              default=SUPPRESS, 
-                              metavar=('EPISODE', 'SOURCE', 'DESTINATION'),
-                              help='Manually create a title card using these '
-                                   'parameters')
-title_card_group.add_argument('--season', type=str, default=None,
-                              metavar='SEASON_TEXT',
-                              help="Specify this card's season text")
-title_card_group.add_argument('--title', type=str, nargs='+', default='',
-                              metavar=('TITLE_LINE'),
-                              help="Specify this card's title text")
-title_card_group.add_argument('--font', '--font-file', type=Path,
-                              default='__default', metavar='FONT_FILE',
-                              help="Specify this card's custom font")
-title_card_group.add_argument('--font-size', '--size', type=str, default='100%',
-                              metavar='SCALE%',
-                              help='Specify a custom font scale, as percentage,'
-                                   ' to use for this card')
-title_card_group.add_argument('--font-color', '--color', type=str, 
-                              default='__default', metavar='#HEX',
-                              help='Specify a custom font color to use for this'
-                                   ' card')
+title_card_group.add_argument(
+    '--card-type',
+    type=str,
+    default='standard',
+    choices=TitleCard.CARD_TYPES.keys(),
+    metavar='TYPE',
+    help='Create a title card of a specific type')
+title_card_group.add_argument(
+    '--title-card',
+    type=Path,
+    nargs=2,
+    default=SUPPRESS,
+    metavar=('SOURCE', 'DESTINATION'),
+    help='Create a title card with the given source image, written to the given'
+         'destination')
+title_card_group.add_argument(
+    '--episode',
+    type=str,
+    default='EPISODE x',
+    metavar='EPISODE_TEXT',
+    help="Specify this card's episode text")
+title_card_group.add_argument(
+    '--season',
+    type=str,
+    default=None,
+    metavar='SEASON_TEXT',
+    help="Specify this card's season text")
+title_card_group.add_argument(
+    '--title',
+    type=str,
+    nargs='+',
+    default='',
+    metavar=('TITLE_LINE'),
+    help="Specify this card's title text")
+title_card_group.add_argument(
+    '--font', '--font-file',
+    type=Path,
+    default='__default',
+    metavar='FONT_FILE',
+    help="Specify this card's custom font")
+title_card_group.add_argument(
+    '--font-size', '--size',
+    type=str,
+    default='100%',
+    metavar='SCALE%',
+    help='Specify a custom font scale (as percentage)')
+title_card_group.add_argument(
+    '--font-color', '--color',
+    type=str, 
+    default='__default',
+    metavar='#HEX',
+    help='Specify a custom font color to use for this card')
+title_card_group.add_argument(
+    '--vertical-shift', '--shift',
+    type=float,
+    default=0.0,
+    metavar='PIXELS',
+    help='How many pixels to vertically shift the title text')
+title_card_group.add_argument(
+    '--interline-spacing', '--spacing',
+    type=float,
+    default=0.0,
+    metavar='PIXELS',
+    help='How many pixels to increase the interline spacing of for title text')
 
 # Argument group for genre maker
-genre_group = parser.add_argument_group('Genre Cards', 'Manual genre card creation')
-genre_group.add_argument('--genre-card', type=str, nargs=3, default=SUPPRESS,
-                         metavar=('SOURCE', 'GENRE', 'DESTINATION'),
-                         help='Create a genre card with the given text')
-genre_group.add_argument('--genre-card-batch', type=Path, default=SUPPRESS,
-                         metavar=('SOURCE_DIRECTORY'),
-                         help='Create all genre cards for images in the given '
-                              'directory based on their file names')
-
-# Argument group for fixes relating to Sonarr
-sonarr_group = parser.add_argument_group('Sonarr', 'Fixes for how the maker interacts with Sonarr')
-sonarr_group.add_argument('--sonarr-list-ids', action='store_true',
-                          help='List all internal IDs used by Sonarr - use with'
-                               ' grep')
+genre_group = parser.add_argument_group(
+    'Genre Cards',
+    'Manual genre card creation')
+genre_group.add_argument(
+    '--genre-card',
+    type=str,
+    nargs=3,
+    default=SUPPRESS,
+    metavar=('SOURCE', 'GENRE', 'DESTINATION'),
+    help='Create a genre card with the given text')
+genre_group.add_argument(
+    '--genre-card-batch',
+    type=Path,
+    default=SUPPRESS,
+    metavar=('SOURCE_DIRECTORY'),
+    help='Create all genre cards for images in the given directory based on '
+         'their file names')
 
 # Argument group for fixes relating to TheMovieDatabase
-tmdb_group = parser.add_argument_group('TheMovieDatabase', 'Fixes for how the Maker interacts with TheMovieDatabase')
-tmdb_group.add_argument('--tmdb-download-images', nargs=6, default=SUPPRESS,
-                        action='append',
-                        metavar=('API_KEY', 'TITLE', 'YEAR', 'SEASON',
-                                 'EPISODES', 'DIRECTORY'),
-                        help='Download the best title card source image for the'
-                             ' given episode')
-tmdb_group.add_argument('--delete-blacklist', action='store_true',
-                        help='Whether to delete the existing TMDb blacklist')
-tmdb_group.add_argument('--add-translation', nargs=5, default=SUPPRESS,
-                        metavar=('TITLE', 'YEAR', 'DATAFILE', 'LANGUAGE_CODE',
-                                 'LABEL'),
-                        help='Add title translations from TMDb to the given '
-                             'datafile')
+tmdb_group = parser.add_argument_group(
+    'TheMovieDatabase',
+    'Fixes for how the Maker interacts with TheMovieDatabase')
+tmdb_group.add_argument(
+    '--tmdb-download-images',
+    nargs=6,
+    default=SUPPRESS,
+    action='append',
+    metavar=('API_KEY', 'TITLE', 'YEAR', 'SEASON', 'EPISODES', 'DIRECTORY'),
+    help='Download the best title card source image for the given episode')
+tmdb_group.add_argument(
+    '--delete-blacklist',
+    action='store_true',
+    help='Whether to delete the existing TMDb blacklist')
+tmdb_group.add_argument(
+    '--add-translation',
+    nargs=5,
+    default=SUPPRESS,
+    metavar=('TITLE', 'YEAR', 'DATAFILE', 'LANGUAGE_CODE', 'LABEL'),
+    help='Add title translations from TMDb to the given datafile')
 
 # Parse given arguments
 args, unknown = parser.parse_known_args()
@@ -98,23 +144,20 @@ if args.font == Path('__default'):
 if args.font_color == '__default':
     args.font_color = TitleCard.CARD_TYPES[args.card_type].TITLE_COLOR
 
-# Execute misc. options
-if hasattr(args, 'sort_data_file'):
-    dfi = DataFileInterface(args.sort_data_file)
-    dfi.sort(dfi._DataFileInterface__read_data())
-
 # Execute title card related options
 if hasattr(args, 'title_card'):
     TitleCard.CARD_TYPES[args.card_type](
-        episode_text=args.title_card[0],
-        source=Path(args.title_card[1]), 
-        output_file=Path(args.title_card[2]),
+        episode_text=args.episode,
+        source=Path(args.title_card[0]), 
+        output_file=Path(args.title_card[1]),
         season_text=('' if not args.season else args.season),
         title='\n'.join(args.title),
         font=args.font.resolve(),
         font_size=float(args.font_size[:-1])/100.0,
         title_color=args.font_color,
         hide_season=(not bool(args.season)),
+        vertical_shift=args.vertical_shift,
+        interline_spacing=args.interline_spacing,
         **arbitrary_data,
     ).create()
 
@@ -134,10 +177,6 @@ if hasattr(args, 'genre_card_batch'):
                 genre=file.stem.upper(),
                 output=Path(file.parent / f'{file.stem}-GenreCard{file.suffix}'),
             ).create()
-
-# Execute Sonarr related options
-if args.sonarr_list_ids:
-    SonarrInterface(pp.sonarr_url, pp.sonarr_api_key).list_all_series_id()
 
 # Execute TMDB related options
 if hasattr(args, 'delete_blacklist'):

--- a/main.py
+++ b/main.py
@@ -7,27 +7,36 @@ from modules.PreferenceParser import PreferenceParser
 from modules.preferences import set_preference_parser, set_font_validator
 from modules.Manager import Manager
 
-# Default path for a preference file to parse
+# Default path for the preference file to parse
 DEFAULT_PREFERENCE_FILE = Path('preferences.yml')
 
-# Default path for a missing file
+# Default path for the missing file to write to
 DEFAULT_MISSING_FILE = Path('missing.yml')
 
 # Set up argument parser
 parser = ArgumentParser(description='Start the TitleCardMaker')
-parser.add_argument('-p', '--preference-file', type=Path,
-                    default=DEFAULT_PREFERENCE_FILE,
-                    metavar='FILE',
-                    help='Specify the preference file for the TitleCardMaker')
-parser.add_argument('-r', '--run', action='count', default=0,
-                    help='Run the TitleCardMaker')
-parser.add_argument('-m', '--missing', type=Path, default=DEFAULT_MISSING_FILE,
-                    metavar='FILE',
-                    help='File to write a list of missing assets to')
-parser.add_argument('-l', '--log',
-                    choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
-                    default='INFO',
-                    help='Level of logging verbosity to use')
+parser.add_argument(
+    '-p', '--preference-file',
+    type=Path,
+    default=DEFAULT_PREFERENCE_FILE,
+    metavar='FILE',
+    help='Specify the global preferences file')
+parser.add_argument(
+    '-r', '--run',
+    action='count',
+    default=0,
+    help='Run the TitleCardMaker')
+parser.add_argument(
+    '-m', '--missing', 
+    type=Path,
+    default=DEFAULT_MISSING_FILE,
+    metavar='FILE',
+    help='File to write the list of missing assets to')
+parser.add_argument(
+    '-l', '--log',
+    choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
+    default='INFO',
+    help='Level of logging verbosity to use')
 
 # Parse given arguments
 args = parser.parse_args()
@@ -45,7 +54,7 @@ if not args.preference_file.exists():
 if not (pp := PreferenceParser(args.preference_file)).valid:
     exit(1)
 
-# Store the valid preference parser in the global namespace
+# Store the PreferenceParser and FontValidator in the global namespace
 set_preference_parser(pp)
 set_font_validator(FontValidator())
 

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -33,7 +33,7 @@ class CardType(ImageMaker):
     EPISODE_TEXT_FORMAT = 'EPISODE {episode_number}'
 
     """Standard size for all title cards"""
-    TITLE_CARD_SIZE: str = '3200x1800'
+    TITLE_CARD_SIZE = '3200x1800'
 
     @property
     @abstractmethod

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -76,7 +76,7 @@ class Manager:
                 
             self.shows.append(show)
 
-            # If archives are disabled globally, or for this show.. skip 
+            # If archives are disabled globally, or for this show - skip 
             if not self.preferences.create_archive or not show.archive:
                 continue
 
@@ -125,7 +125,7 @@ class Manager:
             return None
 
         # Go through each show in the Manager and query Sonarr
-        for show in tqdm(self.shows, desc='Querying Sonarr'):
+        for show in tqdm(self.shows + self.archives, desc='Querying Sonarr'):
             show.query_sonarr(self.sonarr_interface)
 
 

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -171,12 +171,8 @@ class Manager:
             pbar.set_description(f'Updating archive for '
                                  f'"{show_archive.series_info.short_name}"')
 
-            # Depending on which interfaces are enabled, pass those along
-            if self.preferences.use_tmdb and self.preferences.use_sonarr:
-                show_archive.update_archive(
-                    self.tmdb_interface, self.sonarr_interface
-                )
-            elif self.preferences.use_tmdb:
+            # Pass the TMDbInterface to the show if globally enabled
+            if self.preferences.use_tmdb:
                 show_archive.update_archive(self.tmdb_interface)
             else:
                 show_archive.update_archive()

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -120,13 +120,13 @@ class Manager:
         this manager.
         """
 
-        # If sonarr is globally disabled, skip
+        # If Sonarr is globally disabled, skip
         if not self.preferences.use_sonarr:
             return None
 
-        # Go through each show in the Manager, querying Sonarr
+        # Go through each show in the Manager and query Sonarr
         for show in tqdm(self.shows, desc='Querying Sonarr'):
-            show.check_sonarr_for_new_episodes(self.sonarr_interface)
+            show.query_sonarr(self.sonarr_interface)
 
 
     def create_missing_title_cards(self) -> None:
@@ -143,11 +143,7 @@ class Manager:
                                  f'"{show.series_info.short_name}"')
 
             # Pass the TMDbInterface to the show if globally enabled
-            if self.preferences.use_tmdb and self.preferences.use_sonarr:
-                created = show.create_missing_title_cards(
-                    self.tmdb_interface, self.sonarr_interface
-                )
-            elif self.preferences.use_tmdb:
+            if self.preferences.use_tmdb:
                 created = show.create_missing_title_cards(self.tmdb_interface)
             else:
                 created = show.create_missing_title_cards()

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -355,8 +355,7 @@ class Show:
             self.episodes[f'0{mp.season_number}-{mp.episode_start}'] = mp
 
 
-    def check_sonarr_for_new_episodes(self,
-                                      sonarr_interface:'SonarrInterface')->None:
+    def query_sonarr(self, sonarr_interface: 'SonarrInterface') -> None:
         """
         Query the provided SonarrInterface object, checking if the returned
         episodes exist in this show's associated source. All new entries are

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -58,8 +58,6 @@ class ShowArchive:
         # If the base show for this object has archiving disabled, exit
         self.series_info = base_show.series_info
         self.__base_show = base_show
-        if not base_show.archive:
-            return
 
         # For each applicable sub-profile, create and modify new show/show summary
         valid_profiles = base_show.profile.get_valid_profiles(
@@ -113,15 +111,28 @@ class ShowArchive:
             show.find_multipart_episodes()
 
 
-    def update_archive(self, *args: tuple, **kwargs: dict) -> None:
+    def query_sonarr(self, *args: tuple, **kwargs: dict) -> None:
         """
-        Create all missing title cards for each show object in this archive.
-        
+        Call query_sonarr() on each Show object in this archive.
+
         :param      args and kwargs:    The arguments to pass directly to
-                                        `Show.create_missing_title_cards()`.
+                                        Show.query_sonarr().
         """
 
-        # Create missing cards for each `Show` object in this archive
+        # Query Sonarr for each show (updates episode ID's, namely)
+        for show in self.shows:
+            show.query_sonarr(*args, **kwargs)
+
+
+    def update_archive(self, *args: tuple, **kwargs: dict) -> None:
+        """
+        Create all missing title cards for each Show object in this archive.
+        
+        :param      args and kwargs:    The arguments to pass directly to
+                                        Show.create_missing_title_cards().
+        """
+
+        # Create missing cards for each Show object in this archive
         for show in self.shows:
             show.create_missing_title_cards(*args, **kwargs)
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -252,14 +252,15 @@ class SonarrInterface(WebInterface):
 
 
     def set_all_episode_ids(self, series_info: SeriesInfo,
-                            all_episodes: [EpisodeInfo]) -> None:
+                            all_episodes: ['Episode']) -> None:
         """
         Set all the episode ID's for the given list of EpisodeInfo objects. This
         sets the Sonarr and TVDb ID's for each episode. As a byproduct, this
         also updates the series ID's for the SeriesInfo object
         
         :param      series_info:    SeriesInfo for the entry.
-        :param      episode_info:  The episode information
+        :param      all_episodes:   List of Episodes to update the EpisodeInfo
+                                    object of.
         """
 
         # Set the Sonarr ID for this series

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -5,27 +5,10 @@ from modules.CardType import CardType
 
 class StandardTitleCard(CardType):
     """
-    This class describes the object that actually makes the title card using
-    programmed ImageMagick commands. 
-
-    Once initialized with the required title card information, the maker should
-    only be used to call `create()`. This will use those arguments to construct
-    the desired title card, and delete all intermediate files from that process.
-
-    The process for this creation is:
-        1. Take the source image and add the preset gradient overlay.
-        2. Add the title text (either one or two lines) to the image. Using the
-           provided text line(s), font, and color.
-        3. Create the output file's necessary parent folders.
-        4. If no season text is required, add just the episode count and go to 8.
-        5. If season text is required, query ImageMagick's to get the end width
-           of the season and episode text.
-        6. Create a transparent image of only the provided season and episode
-           text of the dimensions computed in 5.
-        7. Place the intermediate transparent text image on top of the image
-           with title text.
-        8. The resulting title card file is placed at the provided output path. 
-        9. Delete all intermediate files created above.
+    This class describes a type of CardType that produces the 'generic' title
+    cards based on Reddit user /u/UniversalPolymath. This card supports 
+    customization of every aspect of the card, but does not use any arbitrary
+    data.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -58,9 +41,6 @@ class StandardTitleCard(CardType):
     SEASON_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Semibold.otf'
     EPISODE_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Regular.otf'
     SERIES_COUNT_TEXT_COLOR = '#CFCFCF'
-
-    """Character used to join season and episode text (with spacing)"""
-    SERIES_COUNT_JOIN_CHARACTER = '•'
 
     """Paths to intermediate files that are deleted after the card is created"""
     __SOURCE_WITH_GRADIENT = CardType.TEMP_DIR / 'source_gradient.png'
@@ -288,7 +268,7 @@ class StandardTitleCard(CardType):
             f'-font "{self.EPISODE_COUNT_FONT}"',   # Separator dot
             f'-gravity center',
             *self.__series_count_text_effects(),
-            f'-annotate +0+689.5 "{self.SERIES_COUNT_JOIN_CHARACTER} "',
+            f'-annotate +0+689.5 "• "',
             f'-gravity west',                               # Episode text
             *self.__series_count_text_effects(),
             f'-annotate +1640+697.2 "{self.episode_text}"',
@@ -331,9 +311,9 @@ class StandardTitleCard(CardType):
             f'-annotate +0+{height-25} "{self.season_text} "',
             f'-font "{self.EPISODE_COUNT_FONT}"',
             *self.__series_count_text_black_stroke(),
-            f'-annotate +{width1}+{height-25-6.5} "{self.SERIES_COUNT_JOIN_CHARACTER}"',
+            f'-annotate +{width1}+{height-25-6.5} "•"',
             *self.__series_count_text_effects(),
-            f'-annotate +{width1}+{height-25-6.5} "{self.SERIES_COUNT_JOIN_CHARACTER}"',
+            f'-annotate +{width1}+{height-25-6.5} "•"',
             *self.__series_count_text_black_stroke(),
             f'-annotate +{width1+width2}+{height-25} "{self.episode_text}"',
             *self.__series_count_text_effects(),

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -508,14 +508,13 @@ class TMDbInterface(WebInterface):
         # Get the TMDb index for this entry
         index = self.__find_episode(series_info, episode_info)
 
-        # If None was returned, episode not found - warn, blacklist, and exit
+        # If episode was not found - blacklist, and exit
         if index == None:
             self.__update_blacklist(series_info, episode_info, 'title')
             return None
 
-        season, episode = index['season'], index['episode']
-
         # GET params
+        season, episode = index['season'], index['episode']
         url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/{season}'
                f'/episode/{episode}')
         params = {'api_key': self.__api_key, 'language': language_code}

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 
 from requests import get
 
+from modules.Debug import log
+
 class WebInterface(ABC):
     """
     Abstract class that defines a WebInterface, which is a type of interface
@@ -9,7 +11,7 @@ class WebInterface(ABC):
     """
 
     """How many requests to cache"""
-    CACHE_LENGTH = 5
+    CACHE_LENGTH = 10
     
     @abstractmethod
     def __init__(self) -> None:


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Added fixing for malformed blacklist to `TMDbInterface`
  - If the Maker is interrupted while writing the blacklist file, it can become malformed and break
  - Upon initialization, the object will correct any bad entries in the blacklist
# Minor Changes
- Reorganized `fixer.py` structure
  - Removed unused `--sort-data-file` argument
  - Reworked `--title-card` argument
  - Added `--vertical-shift` and `--interline-spacing` arguments
- Changed cache length of `WebInterface` to 10
- Renamed `Show.check_sonarr_for_new_episodes()` to `Show.query_sonarr()` since it includes ID gathering
- Improved TMDb title querying to use episode ID's from Sonarr
- Added `query_sonarr()` method to `ShowArchive`
- Moved episode ID syncing from `Show.create_missing_title_cards()` method into `Show.check_sonarr_for_new_episodes()` so that episode title querying is improved
# Minor Fixes
N/A