### PR TITLE
Permit "custom" season titles in Star Wars cards, other minor fixes and changes 

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -5,6 +5,7 @@ from modules.DataFileInterface import DataFileInterface
 from modules.GenreMaker import GenreMaker
 from modules.PreferenceParser import PreferenceParser
 from modules.preferences import set_preference_parser
+from modules.SonarrInterface import SonarrInterface
 from modules.TitleCard import TitleCard
 from modules.TMDbInterface import TMDbInterface
 
@@ -35,7 +36,7 @@ title_card_group.add_argument(
 title_card_group.add_argument(
     '--episode',
     type=str,
-    default='EPISODE x',
+    default='EPISODE',
     metavar='EPISODE_TEXT',
     help="Specify this card's episode text")
 title_card_group.add_argument(
@@ -100,6 +101,13 @@ genre_group.add_argument(
     metavar=('SOURCE_DIRECTORY'),
     help='Create all genre cards for images in the given directory based on '
          'their file names')
+
+# Argument group for fixes relating to Sonarr
+sonarr_group = parser.add_argument_group('Sonarr')
+sonarr_group.add_argument(
+    '--sonarr-list-ids',
+    action='store_true',
+    help="Whether to list all the ID's for all shows within Sonarr")
 
 # Argument group for fixes relating to TheMovieDatabase
 tmdb_group = parser.add_argument_group(
@@ -176,6 +184,13 @@ if hasattr(args, 'genre_card_batch'):
                 genre=file.stem.upper(),
                 output=Path(file.parent / f'{file.stem}-GenreCard{file.suffix}'),
             ).create()
+
+# Execute Sonarr related options
+if args.sonarr_list_ids:
+    if not pp.use_sonarr:
+        log.warning("Cannot print Sonarr ID's if Sonarr is disabled")
+    else:
+        SonarrInterface(pp.sonarr_url, pp.sonarr_api_key).list_all_series_id()
 
 # Execute TMDB related options
 if hasattr(args, 'delete_blacklist'):

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -490,7 +490,7 @@ class TMDbInterface(WebInterface):
 
         # If None was returned, episode not found - warn, blacklist, and exit
         if index == None:
-            log.info(f'TMDb has no matching episode for "{series_info}" '
+            log.debug(f'TMDb has no matching episode for "{series_info}" '
                      f'{episode_info}')
             self.__update_blacklist(series_info, episode_info, 'image')
             return None

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -189,7 +189,7 @@ class TitleCard:
                 season=1, episode=1, title='Episode Title',
             )
             return True
-        except ValueError as e:
+        except Exception as e:
             # Invalid format string, log
             log.error(f'Card format string is invalid - "{e}"')
             return False


### PR DESCRIPTION
# Major Changes
- Changed episode text string modification to use regex to match for more generic episode format text strings within `StarWarsTitleCard`
# Major Fixes 
- Corrected identification of custom season titles from custom episode text formats within `StarWarsTitleCard`
# Minor Changes
- Change log level for no matching episode message within `TMDbInterface`
- Re-add `--sonarr-list-ids` to `fixer.py`
# Minor Fixes
- Handle bad keys in filename format string validation
  - If an invalid/unspecified key/argument is provided in `filename_format`, this *was* causing a runtime error