### PR TITLE
Add 2-hour new episode waittime from Sonarr, fix font validation, other fixes

### DIFF
--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -24,6 +24,7 @@ class CardType(ImageMaker):
 
     """Mapping of 'case' strings to format functions"""
     CASE_FUNCTIONS = {
+        'source': str,
         'upper': str.upper,
         'lower': str.lower,
         'title': titlecase,

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -11,7 +11,7 @@ class CardType(ImageMaker):
     ImageMaker, because all CardTypes are designed to create title cards. This
     class outlines the requirements for creating a custom type of title card.
 
-    All subclasses of CardType must implement this classe's abstract properties
+    All subclasses of CardType must implement this class's abstract properties
     and methods in order to work with the TitleCardMaker. However, not all
     CardTypes need to use every argument of these methods. For example, the
     StandardTitleCard utilizes most all customizations for a title card (i.e.

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -216,9 +216,6 @@ class DataFileInterface:
         yaml = self.__read_data()
 
         for episode_info in new_episodes:
-            # Indicate new episode to user
-            log.info(f'Added {episode_info} to "{self.file.parent.name}"')
-
             # Create blank season data if this key doesn't exist
             season_key = f'Season {episode_info.season_number}'
             if season_key not in yaml:
@@ -237,6 +234,9 @@ class DataFileInterface:
             if episode_info.abs_number != None:
                 yaml[season_key][episode_info.episode_number]['abs_number'] =\
                     episode_info.abs_number
+
+            # Indicate new episode to user
+            log.info(f'Added {episode_info} to "{self.file.parent.name}"')
 
         # Write updated yaml
         self.sort_and_write(yaml)

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -42,7 +42,7 @@ class Font:
     def __repr__(self) -> str:
         """Returns an unambiguous string representation of the object."""
         
-        return f'<CustomFont for series {self.__series_info}>'
+        return f'<CustomFont for series "{self.__series_info}">'
 
 
     def __parse_attributes(self) -> None:

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -6,13 +6,19 @@ from yaml import safe_load, dump
 from modules.Debug import log
 
 class FontValidator:
+    """
+    This class describes a font validator. A FontValidator takes font files and
+    can indicate whether that font contains all the characters for some strings
+    (titles).
+    """
 
+    """File to the font validation map that persists between runs"""
     FONT_VALIDATION_MAP = Path(__file__).parent / '.objects' / 'fvm.yml'
 
     def __init__(self) -> None:
         """
         Constructs a new instance. This creates the parent directory for the 
-        temporary font map if it exists, and reads the font map if possible.
+        temporary font map if it exists, and reads the font map if it exists.
         """
 
         # Attept to read existing font file if it exists
@@ -32,7 +38,7 @@ class FontValidator:
         write the updated font map to file.
         
         :param      font_filepath:  Filepath to the font being validated against
-        :param      character:      The character whose status is being set
+        :param      character:      The character whose status is being set.
         :param      status:         Whether the given font has the given
                                     character.
         """

--- a/modules/GenreMaker.py
+++ b/modules/GenreMaker.py
@@ -123,8 +123,8 @@ class GenreMaker(ImageMaker):
 
         # If the source file doesn't exist, exit
         if not self.source.exists():
-            error(f'Cannot create genre card, "{self.source.resolve()}" does '
-                  f'not exist.')
+            log.error(f'Cannot create genre card, "{self.source.resolve()}" '
+                      f'does not exist.')
             return None
         
         # Resize source to fit in contrained space

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -11,7 +11,7 @@ from modules.TMDbInterface import TMDbInterface
 
 class Manager:
     """
-    This class describes a title card manager. The manager is used to control
+    This class describes a title card manager. The Manager is used to control
     title card and archive creation/management from a high level, and is meant
     to be the main entry point of the program.
     """
@@ -181,7 +181,7 @@ class Manager:
     def create_summaries(self) -> None:
         """
         Creates summaries for every ShowArchive known to this manager. This
-        calls ShowArchive.create_summary()` if summaries are globally enabled.
+        calls ShowArchive.create_summary() if summaries are globally enabled.
         """
 
         if not self.preferences.create_summaries:

--- a/modules/MultiEpisode.py
+++ b/modules/MultiEpisode.py
@@ -4,7 +4,7 @@ from modules.TitleCard import TitleCard
 
 class MultiEpisode:
     """
-    This class describes a MultiEpisode, which is a 'type' (essentially a 
+    This class describes a MultiEpisode, which is a 'type' (practically a 
     subclass) of Episode but describes a range of sequential episodes within a
     single season for a given series. The MultiEpisode uses the first episode's
     (sequentially) episode info and source.
@@ -12,11 +12,13 @@ class MultiEpisode:
 
     def __init__(self, episodes: ['Episode'], title: 'Title') -> None:
         """
-        Constructs a new instance.
+        Constructs a new instance of a MultiEpisode that represents the given
+        list of Episode objects, and has the given (modified) Title.
         
-        :param      episodes:       Episodes this object describes.
-        :param      title:          The modified title that describes these
-                                    multiple episodes.
+        :param      episodes:   List of Episode objects this MultiEpisode
+                                describes.
+        :param      title:      The modified title that describes these multiple
+                                episodes.
         """
         
         # Verify at least two episodes have been provided

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -194,7 +194,7 @@ class PreferenceParser:
                 min_res = self.__yaml['tmdb']['minimum_resolution']
                 width, height = map(int, min_res.lower().split('x'))
                 self.tmdb_minimum_resolution = {'width': width, 'height':height}
-            except:
+            except Exception:
                 log.critical(f'Invalid minimum resolution - specify as '
                              f'WIDTHxHEIGHT')
                 self.valid = False

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -497,7 +497,7 @@ class Show:
 
             # Skip if title is invalid for font
             if not self.font.validate_title(title_card.converted_title):
-                log.warning(f'Invalid font for {episode} of "{self}"')
+                log.warning(f'Invalid font for {episode} of {self}')
                 continue
 
             # Source exists, create the title card

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -497,7 +497,7 @@ class Show:
 
             # Skip if title is invalid for font
             if not self.font.validate_title(title_card.converted_title):
-                log.warning(f'Invalid font {self.font} for {episode}')
+                log.warning(f'Invalid font for {episode} of "{self}"')
                 continue
 
             # Source exists, create the title card

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from modules.Debug import log
 from modules.EpisodeInfo import EpisodeInfo
@@ -186,7 +186,7 @@ class SonarrInterface(WebInterface):
                     episode['airDateUtc'],
                     self.__AIRDATE_FORMAT
                 )
-                if air_datetime > datetime.now():
+                if air_datetime > datetime.now() + timedelta(hours=2):
                     continue
 
             # Skip episodes whose titles aren't in Sonarr to avoid placeholders

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -26,7 +26,7 @@ class StandardTitleCard(CardType):
     TITLE_COLOR = '#EBEBEB'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']'}
+    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-'}
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -599,8 +599,8 @@ class TMDbInterface(WebInterface):
         params = {'api_key': self.__api_key}
         results = self._get(url=url, params=params)
 
-        # If there are no logos, blacklist and exit
-        if len(results['logos']) == 0:
+        # If there are no logos (or series not found), blacklist and exit
+        if len(results.get('logos', [])) == 0:
             self.__update_blacklist(series_info, None, 'logo')
             return None
 


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Fix title validation always returning `True`, resulting in cards being created even if font was invalid
- Handle case where series cannot be found in TMDb when querying for logo (was raising `KeyError`)
# Minor Changes
- Added `source` font case that does not modify title from datafile
- Added two hour waiting period when querying new episodes from Sonarr (to mitigate bad metadata that needs to be fixed)
- Only warn for missing characters from a font once per runtime
# Minor Fixes
- Fix `log.error()` call in `GenreMaker` when source file does not exist
- Moved new-episode logging within `DataFileInterface` to post-existence check