### PR TITLE
Add ability to zero-pad season folders

### DIFF
--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -43,6 +43,7 @@ class PreferenceParser:
         self.card_type = 'standard'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.validate_fonts = True
+        self.zero_pad_seasons = False
         self.archive_directory = None
         self.create_archive = False
         self.create_summaries = False
@@ -135,6 +136,10 @@ class PreferenceParser:
 
         if self.__is_specified('options', 'validate_fonts'):
             self.validate_fonts = bool(self.__yaml['options']['validate_fonts'])
+
+        if self.__is_specified('options', 'zero_pad_seasons'):
+            val = self.__yaml['options']['zero_pad_seasons']
+            self.zero_pad_seasons = bool(val)
 
         if self.__is_specified('archive', 'path'):
             self.archive_directory = Path(self.__yaml['archive']['path'])
@@ -298,4 +303,28 @@ class PreferenceParser:
         height_ok = (height >= self.tmdb_minimum_resolution['height'])
 
         return width_ok and height_ok
+
+
+    def get_season_folder(self, season_number: int) -> str:
+        """
+        Get the season folder name for the given season number, padding the
+        season number if indicated by the preference file.
+        
+        :param      season_number:  The season number.
+        
+        :returns:   The season folder. This is 'Specials' for 0, and either a
+                    zero-padded or not zero-padded version of "Season {x}".
+        """
+
+        # Season 0 is always Specials
+        if season_number == 0:
+            return 'Specials'
+
+        # Zero pad the season number if indicated
+        if self.zero_pad_seasons:
+            return f'Season {season_number:02}'
+
+        # Return non-zero-padded season name
+        return f'Season {season_number}'
+
 

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -1,6 +1,7 @@
 from re import match, sub, IGNORECASE
 
 from modules.Debug import log
+import modules.preferences as global_preferences
 
 # CardType classes
 from modules.AnimeTitleCard import AnimeTitleCard
@@ -48,7 +49,7 @@ class TitleCard:
                                             directly to the creation of the
                                             CardType object.
         """
-        
+
         # Store this card's associated episode and profile
         self.episode = episode
         self.profile = profile
@@ -91,10 +92,9 @@ class TitleCard:
         """
         
         # Get the season folder for this entry's season
-        if episode_info.season_number == 0:
-            season_folder = 'Specials'
-        else:
-            season_folder = f'Season {episode_info.season_number}'
+        season_folder = global_preferences.pp.get_season_folder(
+            episode_info.season_number
+        )
         
         # Get filename from the given format string
         filename = format_string.format(
@@ -150,10 +150,9 @@ class TitleCard:
                                      mod_format_string, flags=IGNORECASE)
 
         # # Get the season folder for these episodes
-        if multi_episode.season_number == 0:
-            season_folder = 'Specials'
-        else:
-            season_folder = f'Season {multi_episode.season_number}'
+        season_folder = global_preferences.pp.get_season_folder(
+            multi_episode.season_number
+        )
 
         # Get filename from the modified format string
         filename = modified_format_string.format(


### PR DESCRIPTION
# Major Changes
- Add ability to zero-pad (to the tens place) all season folders
  - Top-level `zero_pad_seasons` option is now used
  - If enabled, folders like `Season 1` become `Season 01` (Specials is unchanged)
  - Closes #59 
# Major Fixes 
N/A
# Minor Changes
N/A
# Minor Fixes
N/A