### PR TITLE
Fix all non-docker ImageMagick calls on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ set_font_validator(FontValidator())
 
 # Validate that ImageMagick is configured correctly
 imi = ImageMagickInterface(pp.imagemagick_container)
-font_output = imi.run_get_stdout('convert -list font')
+font_output = imi.run_get_stdout('magick convert -list font')
 if not all(_ in font_output for _ in ('Font:', 'family:', 'style:')):
     log.critical(f"ImageMagick doesn't appear to be installed")
     exit(1)

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -197,7 +197,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{self.source_file.resolve()}"',
+            f'magick convert "{self.source_file.resolve()}"',
             f'+profile "*"',    # To avoid profile conversion warnings
             f'-modulate 100,125',
             f'"{self.__CONSTRAST_SOURCE.resolve()}"',
@@ -217,7 +217,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{image.resolve()}"',
+            f'magick convert "{image.resolve()}"',
             f'-gravity center', # For images that aren't 4x3, center crop
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',
@@ -243,7 +243,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{gradient_image.resolve()}"',
+            f'magick convert "{gradient_image.resolve()}"',
             *self.__title_text_global_effects(),
             *self.__title_text_black_stroke(),
             f'-annotate +75+175 "{self.title}"',
@@ -271,7 +271,7 @@ class AnimeTitleCard(CardType):
         kanji_offset = 375 + (165 * (len(self.title.split('\n'))-1))
 
         command = ' '.join([
-            f'convert "{gradient_image.resolve()}"',
+            f'magick convert "{gradient_image.resolve()}"',
             *self.__title_text_global_effects(),
             *self.__title_text_black_stroke(),
             f'-annotate +75+175 "{self.title}"',
@@ -316,7 +316,7 @@ class AnimeTitleCard(CardType):
 
         # Construct command for getting the width of the season text
         width_command = ' '.join([
-            f'convert -debug annotate {titled_image.resolve()}',
+            f'magick convert -debug annotate {titled_image.resolve()}',
             *season_text_command_list,
             ' null: 2>&1 | grep Metrics',
         ])
@@ -327,7 +327,7 @@ class AnimeTitleCard(CardType):
 
         # Construct command to add season and episode text
         command = ' '.join([
-            f'convert {titled_image.resolve()}',
+            f'magick convert {titled_image.resolve()}',
             *season_text_command_list,
             *self.__series_count_text_black_stroke(),
             f'-annotate +{75+width}+90 "{self.episode_text}"',
@@ -352,7 +352,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{titled_image.resolve()}"',
+            f'magick convert "{titled_image.resolve()}"',
             *self.__series_count_text_global_effects(),
             *self.__series_count_text_black_stroke(),
             f'-annotate +75+90 "{self.episode_text}"',

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -182,7 +182,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{self.source_file.resolve()}"',
+            f'magick convert "{self.source_file.resolve()}"',
             f'+profile "*"',    # To avoid profile conversion warnings
             f'-gravity center', # For images that aren't 4x3, center crop
             f'-resize "{self.TITLE_CARD_SIZE}^"',
@@ -211,7 +211,7 @@ class StandardTitleCard(CardType):
         vertical_shift = 245 + self.vertical_shift
 
         command = ' '.join([
-            f'convert "{gradient_image.resolve()}"',
+            f'magick convert "{gradient_image.resolve()}"',
             *self.__title_text_global_effects(),
             *self.__title_text_black_stroke(),
             f'-annotate +0+{vertical_shift} "{self.title}"',
@@ -235,7 +235,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{titled_image.resolve()}"',
+            f'magick convert "{titled_image.resolve()}"',
             *self.__series_count_text_global_effects(),
             f'-font "{self.EPISODE_COUNT_FONT}"',
             f'-gravity center',
@@ -259,7 +259,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert -debug annotate xc: ',
+            f'magick convert -debug annotate xc: ',
             *self.__series_count_text_global_effects(),
             f'-font "{self.SEASON_COUNT_FONT}"',    # Season text
             f'-gravity east',
@@ -299,7 +299,7 @@ class StandardTitleCard(CardType):
 
         # Create text only transparent image of season count text
         command = ' '.join([
-            f'convert -size "{width}x{height}"',
+            f'magick convert -size "{width}x{height}"',
             f'-alpha on',
             f'-background transparent',
             f'xc:transparent',
@@ -341,7 +341,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'composite',
+            f'magick composite',
             f'-gravity center',
             f'-geometry +0+690.2',
             f'"{series_count_image.resolve()}"',

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -132,7 +132,7 @@ class StarWarsTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert "{source.resolve()}"',
+            f'magick convert "{source.resolve()}"',
             f'+profile "*"',    # To avoid profile conversion warnings
             f'-gravity center', # For images that aren't in 4x3, center crop
             f'-resize "{self.TITLE_CARD_SIZE}^"',
@@ -211,7 +211,7 @@ class StarWarsTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert {gradient_source.resolve()}',
+            f'magick convert {gradient_source.resolve()}',
             *self.__add_title_text(),
             *self.__add_episode_prefix(),
             *self.__add_episode_number_text(),


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Fix all ImageMagick calls for Windows installs (not through a Docker container)
  - Windows doesn't add `convert` command to environment variables, only `magick`. So all commands are now prefixed with `magick`.
# Minor Changes
N/A
# Minor Fixes
N/A