### PR TITLE
Fix StandardTitleCard errors for machines that don't have grep

### DIFF
--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -269,17 +269,17 @@ class StandardTitleCard(CardType):
             f'-gravity center',
             *self.__series_count_text_effects(),
             f'-annotate +0+689.5 "• "',
-            f'-gravity west',                               # Episode text
+            f'-gravity west',                       # Episode text
             *self.__series_count_text_effects(),
             f'-annotate +1640+697.2 "{self.episode_text}"',
-            f'null: 2>&1 | grep Metrics'
+            f'null: 2>&1'
         ])
 
         metrics = self.image_magick.run_get_stdout(command)
         
-        widths = list(map(int, findall('width: (\d+)', metrics)))
-        heights = list(map(int, findall('height: (\d+)', metrics)))
-
+        widths = list(map(int, findall('Metrics:.*width:\s+(\d+)', metrics)))
+        heights = list(map(int, findall('Metrics:.*height:\s+(\d+)', metrics)))
+        
         return {
             'width':    sum(widths),
             'width1':   widths[0],


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Fix errors for `StandardTitleCard` cards on machines without `grep` installed
  - Now uses slightly different regex to find font metrics
# Minor Changes
N/A
# Minor Fixes
N/A