### PR TITLE
Fix for multiline title cards not working on some Windows machines

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,18 +64,17 @@ set_preference_parser(pp)
 set_font_validator(FontValidator())
 
 # Validate that ImageMagick is configured correctly
-imi = ImageMagickInterface(pp.imagemagick_container)
 found = False
 for prefix in ('magick ', ''):
-    font_output = imi.run_get_stdout(f'{prefix}convert -list font')
+    pp.use_magick_prefix = 'magick' in prefix
+    imi = ImageMagickInterface(pp.imagemagick_container)
+    font_output = imi.run_get_output(f'convert -list font')
     if all(_ in font_output for _ in ('Font:', 'family:', 'style:')):
-        pp.use_magick_prefix = 'magick' in prefix
-        log.debug(f'Command Prefix: "{prefix}"')
+        log.debug(f'Using "{prefix}" command prefix')
         found = True
         break
 
 if not found:
-    font_output = imi.run_get_stdout('convert -list font')
     log.critical(f"ImageMagick doesn't appear to be installed")
     exit(1)
 

--- a/main.py
+++ b/main.py
@@ -65,8 +65,17 @@ set_font_validator(FontValidator())
 
 # Validate that ImageMagick is configured correctly
 imi = ImageMagickInterface(pp.imagemagick_container)
-font_output = imi.run_get_stdout('magick convert -list font')
-if not all(_ in font_output for _ in ('Font:', 'family:', 'style:')):
+found = False
+for prefix in ('magick ', ''):
+    font_output = imi.run_get_stdout(f'{prefix}convert -list font')
+    if all(_ in font_output for _ in ('Font:', 'family:', 'style:')):
+        pp.use_magick_prefix = 'magick' in prefix
+        log.debug(f'Command Prefix: "{prefix}"')
+        found = True
+        break
+
+if not found:
+    font_output = imi.run_get_stdout('convert -list font')
     log.critical(f"ImageMagick doesn't appear to be installed")
     exit(1)
 

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -323,7 +323,7 @@ class AnimeTitleCard(CardType):
         ])
 
         # Get the width of the season text (reported twice, get first width)
-        metrics = self.image_magick.run_get_stdout(width_command)
+        metrics = self.image_magick.run_get_output(width_command)
         width = list(map(int, findall('width: (\d+)', metrics)))[0]
 
         # Construct command to add season and episode text

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -197,7 +197,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{self.source_file.resolve()}"',
+            f'convert "{self.source_file.resolve()}"',
             f'+profile "*"',    # To avoid profile conversion warnings
             f'-modulate 100,125',
             f'"{self.__CONSTRAST_SOURCE.resolve()}"',
@@ -217,7 +217,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{image.resolve()}"',
+            f'convert "{image.resolve()}"',
             f'-gravity center', # For images that aren't 4x3, center crop
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',
@@ -243,7 +243,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{gradient_image.resolve()}"',
+            f'convert "{gradient_image.resolve()}"',
             *self.__title_text_global_effects(),
             *self.__title_text_black_stroke(),
             f'-annotate +75+175 "{self.title}"',
@@ -271,7 +271,7 @@ class AnimeTitleCard(CardType):
         kanji_offset = 375 + (165 * (len(self.title.split('\n'))-1))
 
         command = ' '.join([
-            f'magick convert "{gradient_image.resolve()}"',
+            f'convert "{gradient_image.resolve()}"',
             *self.__title_text_global_effects(),
             *self.__title_text_black_stroke(),
             f'-annotate +75+175 "{self.title}"',
@@ -316,7 +316,7 @@ class AnimeTitleCard(CardType):
 
         # Construct command for getting the width of the season text
         width_command = ' '.join([
-            f'magick convert -debug annotate {titled_image.resolve()}',
+            f'convert -debug annotate {titled_image.resolve()}',
             *season_text_command_list,
             ' null: 2>&1 | grep Metrics',
         ])
@@ -327,7 +327,7 @@ class AnimeTitleCard(CardType):
 
         # Construct command to add season and episode text
         command = ' '.join([
-            f'magick convert {titled_image.resolve()}',
+            f'convert {titled_image.resolve()}',
             *season_text_command_list,
             *self.__series_count_text_black_stroke(),
             f'-annotate +{75+width}+90 "{self.episode_text}"',
@@ -352,7 +352,7 @@ class AnimeTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{titled_image.resolve()}"',
+            f'convert "{titled_image.resolve()}"',
             *self.__series_count_text_global_effects(),
             *self.__series_count_text_black_stroke(),
             f'-annotate +75+90 "{self.episode_text}"',

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from re import findall
 
 from modules.CardType import CardType
+from modules.Debug import log
 
 class AnimeTitleCard(CardType):
     """

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -1,5 +1,7 @@
 from subprocess import run
 
+import modules.preferences as global_preferences
+
 class ImageMagickInterface:
     """
     This class describes an interface to ImageMagick. If initialized with a
@@ -28,6 +30,12 @@ class ImageMagickInterface:
         # Definitions of this interface, i.e. whether to use docker and how
         self.container = container
         self.use_docker = bool(container)
+
+        # Whether to prefix commands with "magick" or not
+        if global_preferences.pp.use_magick_prefix:
+            self.prefix = 'magick '
+        else:
+            self.prefix = ''
 
 
     @staticmethod
@@ -71,9 +79,9 @@ class ImageMagickInterface:
         # If a docker image ID is specified, execute the command in that container
         # otherwise, execute on the host machine (no docker wrapper)
         if self.use_docker:
-            command = f'docker exec -t {self.container} {command}'
+            command = f'docker exec -t {self.container} {self.prefix}{command}'
         else:
-            command = command
+            command = f'{self.prefix}{command}'
             
         return run(command, shell=True, *args, **kwargs)
 

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -1,5 +1,5 @@
 from shlex import split as command_split
-from subprocess import run, Popen, PIPE
+from subprocess import Popen, PIPE
 
 import modules.preferences as global_preferences
 from modules.Debug import log
@@ -60,19 +60,16 @@ class ImageMagickInterface:
         return string.replace('"', r'\"').replace('`', r'\`')
 
 
-    def run(self, command: str, *args: tuple, **kwargs: dict) -> (bytes, bytes):
+    def run(self, command: str) -> (bytes, bytes):
         """
         Wrapper for running a given command. This uses either the host machine
         (i.e. direct calls); or through the provided docker container (if
         preferences has been set; i.e. wrapped through "docker exec -t {id}
-        {command}"). args and kwargs are used to permit general usage of
-        the subprocess.run() function's options (capture_output, etc).
+        {command}").
 
-        :param      command:            The command (as string) to execute.
-        
-        :param      args and kwargs:    The arguments to pass to Popen.
+        :param      command:    The command (as string) to execute.
 
-        :returns:   The return of the subprocess.run() function execution.
+        :returns:   Tuple of the STDOUT and STDERR of the executed command.
         """
         
         
@@ -88,24 +85,20 @@ class ImageMagickInterface:
 
         # Execute, capturing stdout and stderr
         stdout, stderr = Popen(command, stdout=PIPE, stderr=PIPE).communicate()
-
+        
         return stdout, stderr
 
 
-    def run_get_stdout(self, command: str, *args: tuple, **kwargs: dict) -> str:
+    def run_get_output(self, command: str) -> str:
         """
         Wrapper for run(), but return the byte-decoded stdout.
         
-        :param      command:            The command being executed.
-        :param      args and kwargs:    Generalized arguments to pass to
-                                        subprocess.run().
+        :param      command:    The command (as string) being executed.
 
         :returns:   The decoded stdout output of the executed command.
         """
 
-        return self.run(
-            command, capture_output=True, *args, **kwargs
-        )[0].decode()
+        return b''.join(self.run(command)).decode()
 
 
     def delete_intermediate_images(self, *paths: tuple) -> None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -66,6 +66,9 @@ class PreferenceParser:
         self.valid = True
         self.__parse_yaml()
 
+        # Whether to use magick prefix, default false
+        self.use_magick_prefix = False
+
 
     def __repr__(self) -> str:
         """Returns a unambiguous string representation of the object."""

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -193,7 +193,7 @@ class ShowSummary(ImageMaker):
             f'"{logo.resolve()}"',
         ])
 
-        return int(self.image_magick.run_get_stdout(command))
+        return int(self.image_magick.run_get_output(command))
 
 
     def _add_logo(self, montage: Path, logo: Path) -> Path:

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from re import findall
 
 from modules.CardType import CardType
+from modules.Debug import log
 
 class StandardTitleCard(CardType):
     """
@@ -275,11 +276,17 @@ class StandardTitleCard(CardType):
             f'null: 2>&1'
         ])
 
+        # Get text dimensions from the output
         metrics = self.image_magick.run_get_stdout(command)
-        
         widths = list(map(int, findall('Metrics:.*width:\s+(\d+)', metrics)))
         heights = list(map(int, findall('Metrics:.*height:\s+(\d+)', metrics)))
-        
+
+        # Don't raise IndexError if no dimensions were found
+        if len(widths) < 2 or len(heights) < 2:
+            log.warning(f'Unable to identify font dimensions, file bug report')
+            widths = [370, 47, 357]
+            heights = [68, 83, 83]
+
         return {
             'width':    sum(widths),
             'width1':   widths[0],

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -183,7 +183,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{self.source_file.resolve()}"',
+            f'convert "{self.source_file.resolve()}"',
             f'+profile "*"',    # To avoid profile conversion warnings
             f'-gravity center', # For images that aren't 4x3, center crop
             f'-resize "{self.TITLE_CARD_SIZE}^"',
@@ -212,7 +212,7 @@ class StandardTitleCard(CardType):
         vertical_shift = 245 + self.vertical_shift
 
         command = ' '.join([
-            f'magick convert "{gradient_image.resolve()}"',
+            f'convert "{gradient_image.resolve()}"',
             *self.__title_text_global_effects(),
             *self.__title_text_black_stroke(),
             f'-annotate +0+{vertical_shift} "{self.title}"',
@@ -236,7 +236,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{titled_image.resolve()}"',
+            f'convert "{titled_image.resolve()}"',
             *self.__series_count_text_global_effects(),
             f'-font "{self.EPISODE_COUNT_FONT}"',
             f'-gravity center',
@@ -260,7 +260,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert -debug annotate xc: ',
+            f'convert -debug annotate xc: ',
             *self.__series_count_text_global_effects(),
             f'-font "{self.SEASON_COUNT_FONT}"',    # Season text
             f'-gravity east',
@@ -306,7 +306,7 @@ class StandardTitleCard(CardType):
 
         # Create text only transparent image of season count text
         command = ' '.join([
-            f'magick convert -size "{width}x{height}"',
+            f'convert -size "{width}x{height}"',
             f'-alpha on',
             f'-background transparent',
             f'xc:transparent',
@@ -348,7 +348,7 @@ class StandardTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick composite',
+            f'composite',
             f'-gravity center',
             f'-geometry +0+690.2',
             f'"{series_count_image.resolve()}"',

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -277,7 +277,7 @@ class StandardTitleCard(CardType):
         ])
 
         # Get text dimensions from the output
-        metrics = self.image_magick.run_get_stdout(command)
+        metrics = self.image_magick.run_get_output(command)
         widths = list(map(int, findall('Metrics:.*width:\s+(\d+)', metrics)))
         heights = list(map(int, findall('Metrics:.*height:\s+(\d+)', metrics)))
 

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -4,6 +4,7 @@ from re import match
 from num2words import num2words
 
 from modules.CardType import CardType
+from modules.Debug import log
 
 class StarWarsTitleCard(CardType):
     """

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -132,7 +132,7 @@ class StarWarsTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert "{source.resolve()}"',
+            f'convert "{source.resolve()}"',
             f'+profile "*"',    # To avoid profile conversion warnings
             f'-gravity center', # For images that aren't in 4x3, center crop
             f'-resize "{self.TITLE_CARD_SIZE}^"',
@@ -211,7 +211,7 @@ class StarWarsTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'magick convert {gradient_source.resolve()}',
+            f'convert {gradient_source.resolve()}',
             *self.__add_title_text(),
             *self.__add_episode_prefix(),
             *self.__add_episode_number_text(),


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Handle mis-formatted newline characters in multi-line titles on Windows machines
  - ImageMagick command STDOUT and STDERR are no longer piped to console output, so execution should be cleaner
  - Closes #65 (hopefully)
# Minor Changes
N/A
# Minor Fixes
- Use hard-coded image dimensions if the metrics cannot be read
- Detect whether to use `magick` command prefix or not at runtime