### PR TITLE
Simplify repeated custom font specification

### DIFF
--- a/modules/Font.py
+++ b/modules/Font.py
@@ -12,16 +12,27 @@ class Font:
     interline spacing.
     """
 
-    def __init__(self, yaml: dict, card_class: 'CardType',
+    def __init__(self, yaml, font_map: dict, card_class: 'CardType',
                  series_info: 'SeriesInfo') -> None:
         """
         Constructs a new instance of a Font for the given YAML, CardType, and
         series.
         
         :param      yaml:           'font' dictionary from a series YAML file.
+        :type       yaml:           Dict or str. If str, must be a key of
+                                    font_map.
+        :param      font_map:       Map of font labels to custom font
+                                    descriptions.
         :param      card_class:     CardType class to use values from.
         :param      series_info:    Associated SeriesInfo (for logging).
         """
+
+        # If the given value is a key of the font map, use those values instead
+        if isinstance(yaml, str) and yaml in font_map:
+            yaml = font_map[yaml]
+        elif not isinstance(yaml, dict):
+            log.error(f'Invalid font for series "{series_info}"')
+            yaml = {}
 
         # Store arguments
         self.__yaml = yaml

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -22,16 +22,22 @@ class Font:
         :type       yaml:           Dict or str. If str, must be a key of
                                     font_map.
         :param      font_map:       Map of font labels to custom font
-                                    descriptions.
+                                    dictionaries.
         :param      card_class:     CardType class to use values from.
         :param      series_info:    Associated SeriesInfo (for logging).
         """
 
+        # Assume object is valid to start with
+        self.valid = True
+
         # If the given value is a key of the font map, use those values instead
         if isinstance(yaml, str) and yaml in font_map:
             yaml = font_map[yaml]
-        elif not isinstance(yaml, dict):
+        
+        # If font YAML (either from map or directly) is not a dictionary, bad!
+        if not isinstance(yaml, dict):
             log.error(f'Invalid font for series "{series_info}"')
+            self.valid = False
             yaml = {}
 
         # Store arguments
@@ -39,14 +45,13 @@ class Font:
         self.__card_class = card_class
         self.__series_info = series_info
 
-        # This font's FontValidator object
+        # Use the global FontValidator object
         self.__validator = global_preferences.fv
         
         # Generic font attributes
         self.set_default()
         
-        # Parse YAML
-        self.valid = True
+        # Parse YAML, update validity
         self.__parse_attributes()
 
         

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -273,11 +273,14 @@ class PreferenceParser:
                 continue
 
             # Get library map for this file; error+skip missing library paths
-            libraries = file_yaml.get('libraries', {})
-            if not all('path' in libraries[library] for library in libraries):
+            library_map = file_yaml.get('libraries', {})
+            if not all('path' in library_map[lib] for lib in library_map):
                 log.error(f'Libraries in series file "{file_object.resolve()}" '
                           f'are missing their "path" attributes.')
                 continue
+
+            # Get font map for this file
+            font_map = file_yaml.get('fonts', {})
 
             # Go through each series in this file
             for show_name in tqdm(file_yaml['series'], leave=False,
@@ -286,7 +289,8 @@ class PreferenceParser:
                 yield Show(
                     show_name,
                     file_yaml['series'][show_name],
-                    libraries,
+                    library_map,
+                    font_map,
                     self.source_directory,
                 )
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -24,8 +24,8 @@ class Show:
     """
 
 
-    def __init__(self, name: str, yaml_dict: dict, library_map: dict,
-                 source_directory: Path) -> None:
+    def __init__(self, name: str, yaml_dict: dict, library_map: dict, 
+                 font_map: dict, source_directory: Path) -> None:
         """
         Constructs a new instance of a Show object from the given YAML
         dictionary, library map, and referencing the base source directory. If
@@ -37,6 +37,8 @@ class Show:
                                         as found in a card YAML file.
         :param      library_map:        Map of library titles to media
                                         directories.
+        :param      font_map:           Map of font labels to custom font
+                                        descriptions.
         :param      source_directory:   Base source directory this show should
                                         search for and place source images.
         """
@@ -82,6 +84,7 @@ class Show:
         self.__parse_yaml()
         self.font = Font(
             self.__yaml.get('font', {}),
+            font_map,
             self.card_class,
             self.series_info
         )


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
N/A
# Minor Changes
- Simplify repeated duplicate custom font specification
  - In series YAML files, new `fonts` section can be specified which lists any number of custom fonts under a given _key_. That _key_ can then be specified as a `font:` value for a given series, using all of those attributes
  - Wiki has been updated
  - Closes #71 
# Minor Fixes
- Now sets the `Font.valid` object attribute to False if the `font:` YAML is not a dictionary, instead of raising IndexError