### PR TITLE
Add option to skip syncing specials from Sonarr, minor bug fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ set_font_validator(FontValidator())
 
 # Validate that ImageMagick is configured correctly
 found = False
-for prefix in ('magick ', ''):
+for prefix in ('', 'magick '):
     pp.use_magick_prefix = 'magick' in prefix
     imi = ImageMagickInterface(pp.imagemagick_container)
     font_output = imi.run_get_output(f'convert -list font')

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -273,7 +273,7 @@ class PreferenceParser:
                 continue
 
             # Get library map for this file; error+skip missing library paths
-            if (library_map := file_yaml.get('library', {})):
+            if (library_map := file_yaml.get('libraries', {})):
                 if not all('path' in library_map[lib] for lib in library_map):
                     log.error(f'Libraries in series file "{file_object.resolve()}'
                               f'"are missing their "path" attributes.')

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -273,11 +273,11 @@ class PreferenceParser:
                 continue
 
             # Get library map for this file; error+skip missing library paths
-            library_map = file_yaml.get('libraries', {})
-            if not all('path' in library_map[lib] for lib in library_map):
-                log.error(f'Libraries in series file "{file_object.resolve()}" '
-                          f'are missing their "path" attributes.')
-                continue
+            if (library_map := file_yaml.get('library', {})):
+                if not all('path' in library_map[lib] for lib in library_map):
+                    log.error(f'Libraries in series file "{file_object.resolve()}'
+                              f'"are missing their "path" attributes.')
+                    continue
 
             # Get font map for this file
             font_map = file_yaml.get('fonts', {})

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -56,6 +56,7 @@ class PreferenceParser:
         self.use_sonarr = False
         self.sonarr_url = None
         self.sonarr_api_key = None
+        self.sonarr_sync_specials = True
         self.use_tmdb = False
         self.tmdb_api_key = None
         self.tmdb_retry_count = TMDbInterface.BLACKLIST_THRESHOLD
@@ -185,6 +186,10 @@ class PreferenceParser:
                 self.sonarr_url = self.__yaml['sonarr']['url']
                 self.sonarr_api_key = self.__yaml['sonarr']['api_key']
                 self.use_sonarr = True
+
+        if self.__is_specified('sonarr', 'sync_specials'):
+            value = self.__yaml['sonarr']['sync_specials']
+            self.sonarr_sync_specials = bool(value)
 
         if self.__is_specified('tmdb'):
             if not self.__is_specified('tmdb', 'api_key'):

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -73,6 +73,7 @@ class Show:
         self.library = None
         self.archive = True
         self.sonarr_sync = True
+        self.sync_specials = self.preferences.sonarr_sync_specials
         self.tmdb_sync = True
         self.hide_seasons = False
         self.__episode_range = {}
@@ -177,6 +178,9 @@ class Show:
 
         if self.__is_specified('sonarr_sync'):
             self.sonarr_sync = bool(self.__yaml['sonarr_sync'])
+
+        if self.__is_specified('sync_specials'):
+            self.sync_specials = bool(self.__yaml['sync_specials'])
 
         if self.__is_specified('tmdb_sync'):
             self.tmdb_sync = bool(self.__yaml['tmdb_sync'])
@@ -391,6 +395,13 @@ class Show:
                 lambda e: e.key not in self.episodes,
                 all_episodes,
             ))
+
+            # Filter episodes that are specials if sync_specials is False
+            if not self.sync_specials:
+                new_episodes = list(filter(
+                    lambda e: e.season_number != 0,
+                    new_episodes,
+                ))
 
             # If there are new episodes, add to the datafile, return True
             if new_episodes:

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -20,7 +20,7 @@ class TMDbInterface(WebInterface):
     API_BASE_URL = 'https://api.themoviedb.org/3/'
 
     """Default for how many failed requests lead to a blacklisted entry"""
-    BLACKLIST_THRESHOLD = 3
+    BLACKLIST_THRESHOLD = 5
 
     """Generic translated episode format strings for each language code"""
     GENERIC_TITLE_FORMATS = {

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 from yaml import dump, safe_load
-from urllib.request import urlretrieve
 
 from modules.Debug import log
 from modules.EpisodeInfo import EpisodeInfo
@@ -632,24 +631,6 @@ class TMDbInterface(WebInterface):
             return None
 
         return f'https://image.tmdb.org/t/p/original{best["file_path"]}'
-
-
-    def download_image(self, image_url: str, destination: Path) -> None:
-        """
-        Downloads the provided image URL to the destination filepath.
-        
-        :param      image_url:      The image url to download.
-        :param      destination:    The destination for the requested image.
-        """
-
-        # Make parent folder structure
-        destination.parent.mkdir(parents=True, exist_ok=True)
-
-        # Download the image and store it in destination
-        try:
-            urlretrieve(image_url, destination.resolve())
-        except Exception as e:
-            log.error(f'Cannot download, TMDb errored: "{e}"')
 
 
     @staticmethod

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -59,7 +59,7 @@ class WebInterface(ABC):
 
     def download_image(self, image_url: str, destination: 'Path') -> None:
         """
-        Downloads the provided image URL to the destination filepath.
+        Download the provided image URL to the destination filepath.
         
         :param      image_url:      The image url to download.
         :param      destination:    The destination for the requested image.
@@ -68,6 +68,7 @@ class WebInterface(ABC):
         # Make parent folder structure
         destination.parent.mkdir(parents=True, exist_ok=True)
 
+        # Attempt to download the image, if an error happens log to user
         try:
             with destination.open('wb') as file_handle:
                 file_handle.write(get(image_url).content)

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -55,3 +55,25 @@ class WebInterface(ABC):
 
         # Return latest result
         return self.__cached_results[-1]
+
+
+    def download_image(self, image_url: str, destination: 'Path') -> None:
+        """
+        Downloads the provided image URL to the destination filepath.
+        
+        :param      image_url:      The image url to download.
+        :param      destination:    The destination for the requested image.
+        """
+
+        # Make parent folder structure
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with destination.open('wb') as file_handle:
+                file_handle.write(get(image_url).content)
+            log.debug(f'downloaded {image_url} to {destination}')
+        except Exception as e:
+            log.error(f'Cannot download image, error: "{e}"')
+
+
+        


### PR DESCRIPTION
# Major Changes
- Add option to skip specials when syncing with Sonarr (via `sync_specials` attribute within `sonarr`)
  - If any specials are added to the data files manually, the cards are still made
  - Closes #73 
# Major Fixes 
N/A
# Minor Changes
- Changed default TMDb blacklist threshold to 5
# Minor Fixes
- Handle empty library specification (like `library: `)
- Fix for error while downloading images from TMDb on computers that don't have a python local certificate
- Attempt to not use `magick` command prefix _first_
  - Edge-case fix if IM is not in a docker container, some OS's would raise `FileNotFoundError` for the `magick` command execution