### PR TITLE
Fixes for Anime title cards, minor fixes and changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from pathlib import Path
 try:
     from modules.Debug import log
     from modules.FontValidator import FontValidator
-    from modules.ImageMagickInterface import ImageMagickInterface
     from modules.PreferenceParser import PreferenceParser
     from modules.preferences import set_preference_parser, set_font_validator
     from modules.Manager import Manager
@@ -62,21 +61,6 @@ if not (pp := PreferenceParser(args.preference_file)).valid:
 # Store the PreferenceParser and FontValidator in the global namespace
 set_preference_parser(pp)
 set_font_validator(FontValidator())
-
-# Validate that ImageMagick is configured correctly
-found = False
-for prefix in ('', 'magick '):
-    pp.use_magick_prefix = 'magick' in prefix
-    imi = ImageMagickInterface(pp.imagemagick_container)
-    font_output = imi.run_get_output(f'convert -list font')
-    if all(_ in font_output for _ in ('Font:', 'family:', 'style:')):
-        log.debug(f'Using "{prefix}" command prefix')
-        found = True
-        break
-
-if not found:
-    log.critical(f"ImageMagick doesn't appear to be installed")
-    exit(1)
 
 # Create and run the manager --run many times
 tcm = None

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -319,12 +319,12 @@ class AnimeTitleCard(CardType):
         width_command = ' '.join([
             f'convert -debug annotate {titled_image.resolve()}',
             *season_text_command_list,
-            ' null: 2>&1 | grep Metrics',
+            ' null: 2>&1',
         ])
 
         # Get the width of the season text (reported twice, get first width)
         metrics = self.image_magick.run_get_output(width_command)
-        width = list(map(int, findall('width: (\d+)', metrics)))[0]
+        width = list(map(int, findall('Metrics:.*width: (\d+)', metrics)))[0]
 
         # Construct command to add season and episode text
         command = ' '.join([

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -317,7 +317,7 @@ class AnimeTitleCard(CardType):
 
         # Construct command for getting the width of the season text
         width_command = ' '.join([
-            f'convert -debug annotate {titled_image.resolve()}',
+            f'convert -debug annotate "{titled_image.resolve()}"',
             *season_text_command_list,
             ' null: 2>&1',
         ])
@@ -328,7 +328,7 @@ class AnimeTitleCard(CardType):
 
         # Construct command to add season and episode text
         command = ' '.join([
-            f'convert {titled_image.resolve()}',
+            f'convert "{titled_image.resolve()}"',
             *season_text_command_list,
             *self.__series_count_text_black_stroke(),
             f'-annotate +{75+width}+90 "{self.episode_text}"',

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -324,7 +324,7 @@ class AnimeTitleCard(CardType):
 
         # Get the width of the season text (reported twice, get first width)
         metrics = self.image_magick.run_get_output(width_command)
-        width = list(map(int, findall('Metrics:.*width: (\d+)', metrics)))[0]
+        width = list(map(int, findall(r'Metrics:.*width:\s+(\d+)', metrics)))[0]
 
         # Construct command to add season and episode text
         command = ' '.join([

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -51,7 +51,7 @@ class DataFileInterface:
             return {}
 
         # Read file 
-        with self.file.open('r') as file_handle:
+        with self.file.open('r', encoding='utf-8') as file_handle:
             try:
                 yaml = safe_load(file_handle)
             except Exception as e:
@@ -75,7 +75,7 @@ class DataFileInterface:
         """
 
         # Write updated data with this entry added
-        with self.file.open('w') as file_handle:
+        with self.file.open('w', encoding='utf-8') as file_handle:
             dump({'data': yaml}, file_handle, allow_unicode=True, width=100)
 
 

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -81,10 +81,15 @@ class ImageMagickInterface:
             command = f'{self.prefix}{command}'
             
         # Split command into list of strings for Popen
-        command_ = command_split(command)
+        cmd = command_split(command)
 
         # Execute, capturing stdout and stderr
-        stdout, stderr = Popen(command_, stdout=PIPE, stderr=PIPE).communicate()
+        try:
+            stdout, stderr = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+        except FileNotFoundError as e:
+            if 'docker' in str(e):
+                log.critical(f'ImageMagick docker container not found')
+                exit(1)
 
         # Add command and output to history for debug
         self.__history.append((command, stdout, stderr))

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -36,6 +36,9 @@ class ImageMagickInterface:
         # Whether to prefix commands with "magick" or not
         self.prefix = 'magick ' if use_magick_prefix else ''
 
+        # Command history for debug purposes
+        self.__history = []
+
 
     @staticmethod
     def escape_chars(string: str) -> str:
@@ -78,10 +81,13 @@ class ImageMagickInterface:
             command = f'{self.prefix}{command}'
             
         # Split command into list of strings for Popen
-        command = command_split(command)
+        command_ = command_split(command)
 
         # Execute, capturing stdout and stderr
-        stdout, stderr = Popen(command, stdout=PIPE, stderr=PIPE).communicate()
+        stdout, stderr = Popen(command_, stdout=PIPE, stderr=PIPE).communicate()
+
+        # Add command and output to history for debug
+        self.__history.append((command, stdout, stderr))
         
         return stdout, stderr
 
@@ -108,4 +114,18 @@ class ImageMagickInterface:
         # Delete (unlink) each image, don't raise FileNotFoundError if DNE
         for image in paths:
             image.unlink(missing_ok=True)
+
+
+    def print_command_history(self) -> None:
+        """
+        Prints the command history of this Interface.
+        """
+
+        for entry in self.__history:
+            command, stdout, stderr = entry
+            sep = '-' * 60
+            log.debug(f'Command: {command}\n\nstdout: {stdout}\n\nstderr: '
+                      f'{stderr}\n{sep}')
+
+
 

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -1,7 +1,6 @@
 from shlex import split as command_split
 from subprocess import Popen, PIPE
 
-import modules.preferences as global_preferences
 from modules.Debug import log
 
 class ImageMagickInterface:
@@ -20,7 +19,8 @@ class ImageMagickInterface:
         -dit -v "/mnt/user/":"/mnt/user/" 'dpokidov/imagemagick'
     """
 
-    def __init__(self, container: str=None) -> None:
+    def __init__(self, container: str=None,
+                 use_magick_prefix: bool=False) -> None:
         """
         Constructs a new instance. If docker_id is None/0/False, then commands
         will not use a docker container.
@@ -34,10 +34,7 @@ class ImageMagickInterface:
         self.use_docker = bool(container)
 
         # Whether to prefix commands with "magick" or not
-        if global_preferences.pp.use_magick_prefix:
-            self.prefix = 'magick '
-        else:
-            self.prefix = ''
+        self.prefix = 'magick ' if use_magick_prefix else ''
 
 
     @staticmethod

--- a/modules/ImageMaker.py
+++ b/modules/ImageMaker.py
@@ -36,7 +36,8 @@ class ImageMaker(ABC):
 
         # All ImageMakers have an instance of an ImageMagickInterface
         self.image_magick = ImageMagickInterface(
-            self.preferences.imagemagick_container
+            self.preferences.imagemagick_container,
+            self.preferences.use_magick_prefix,
         )
 
 

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 from yaml import safe_load
 
 from modules.Debug import log
+from modules.ImageMagickInterface import ImageMagickInterface
 from modules.Show import Show
 from modules.ShowSummary import ShowSummary
 from modules.TitleCard import TitleCard
@@ -67,14 +68,43 @@ class PreferenceParser:
         self.valid = True
         self.__parse_yaml()
 
-        # Whether to use magick prefix, default false
+        # Whether to use magick prefix
         self.use_magick_prefix = False
+        self.__determine_imagemagick_prefix()
 
 
     def __repr__(self) -> str:
         """Returns a unambiguous string representation of the object."""
 
         return f'<PreferenceParser file={self.file}>'
+
+
+    def __determine_imagemagick_prefix(self) -> None:
+        """
+        Determine whether to use the "magick " prefix for ImageMagick commands.
+        If a prefix cannot be determined, a critical message is logged and the
+        program exits with an error.
+        """
+
+        # Try variations of the font list command with/out the "magick " prefix
+        for prefix, use_magick in zip(('', 'magick '), (False, True)):
+            log.debug(prefix, use_magick)
+            # Create ImageMagickInterface object to test font command
+            imi = ImageMagickInterface(self.imagemagick_container, use_magick)
+
+            # Run font list command
+            font_output = imi.run_get_output(f'convert -list font')
+
+            # Check for standard font output to determine if it worked
+            if all(_ in font_output for _ in ('Font:', 'family:', 'style:')):
+                # Font command worked, exit function
+                self.use_magick_prefix = use_magick
+                log.debug(f'Using "{prefix}" ImageMagick command prefix')
+                return None
+
+        # If none of the font commands worked, IM might not be installed
+        log.critical(f"ImageMagick doesn't appear to be installed")
+        exit(1)
 
 
     def __is_specified(self, *attributes: tuple) -> bool:
@@ -338,5 +368,3 @@ class PreferenceParser:
 
         # Return non-zero-padded season name
         return f'Season {season_number}'
-
-

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -88,7 +88,6 @@ class PreferenceParser:
 
         # Try variations of the font list command with/out the "magick " prefix
         for prefix, use_magick in zip(('', 'magick '), (False, True)):
-            log.debug(prefix, use_magick)
             # Create ImageMagickInterface object to test font command
             imi = ImageMagickInterface(self.imagemagick_container, use_magick)
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -34,6 +34,11 @@ class SonarrInterface(WebInterface):
         # Add / if not given
         self.url = url + ('' if url.endswith('/') else '/')
 
+        # If non-api URL, exit
+        if not self.url.endswith(('/api/v3/', '/api/')):
+            log.critical(f'Sonarr URL must be an API url, add /api/')
+            exit(1)
+
         # Warn if a v3 API url has not been provided
         if not self.url.endswith('/v3/'):
             log.warning(f'Provided Sonarr URL ({self.url}) is not v3, add /v3/')
@@ -43,10 +48,8 @@ class SonarrInterface(WebInterface):
         self.__standard_params = {'apikey': api_key}
 
         # Query system status to verify connection to Sonarr
-        url = f'{self.url}system/status'
-        params = self.__standard_params
         try:
-            status = self._get(url, params)
+            status =self._get(f'{self.url}system/status',self.__standard_params)
             if 'error' in status and status['error'] == 'Unauthorized':
                 raise Exception('Invalid API key')
         except Exception as e:

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -278,8 +278,8 @@ class StandardTitleCard(CardType):
 
         # Get text dimensions from the output
         metrics = self.image_magick.run_get_output(command)
-        widths = list(map(int, findall('Metrics:.*width:\s+(\d+)', metrics)))
-        heights = list(map(int, findall('Metrics:.*height:\s+(\d+)', metrics)))
+        widths = list(map(int, findall(r'Metrics:.*width:\s+(\d+)', metrics)))
+        heights = list(map(int, findall(r'Metrics:.*height:\s+(\d+)', metrics)))
 
         # Don't raise IndexError if no dimensions were found
         if len(widths) < 2 or len(heights) < 2:

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -124,6 +124,7 @@ class TitleCard:
         )
         
         # Get filename from the given format string, with illegals removed
+        abs_number = episode_info.abs_number
         filename = TitleCard.__replace_illegal_characters(
             format_string.format(
                 name=series_info.name,
@@ -132,6 +133,7 @@ class TitleCard:
                 season=episode_info.season_number,
                 episode=episode_info.episode_number,
                 title=episode_info.title.full_title,
+                abs_number=abs_number if abs_number != None else 0,
             )
         )
         
@@ -189,6 +191,7 @@ class TitleCard:
         )
 
         # Get filename from the modified format string
+        abs_number = multi_episode.episode_info.abs_number
         filename = TitleCard.__replace_illegal_characters(
             modified_format_string.format(
                 name=series_info.name,
@@ -198,6 +201,7 @@ class TitleCard:
                 episode_start=multi_episode.episode_start,
                 episode_end=multi_episode.episode_end,
                 title=multi_episode.episode_info.title.full_title,
+                abs_number=abs_number if abs_number != None else 0,
             )
         )
 
@@ -221,7 +225,7 @@ class TitleCard:
             # Attempt to format using all the standard keys
             format_string.format(
                 name='TestName', full_name='TestName (2000)', year=2000,
-                season=1, episode=1, title='Episode Title',
+                season=1, episode=1, title='Episode Title', abs_number=1,
             )
             return True
         except Exception as e:

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -248,6 +248,11 @@ class TitleCard:
             
         # Create card, return whether it was successful
         self.maker.create()
+        
+        if self.file.exists():
+            log.debug(f'Created card "{self.file.resolve()}"')
+            return True
 
-        return self.file.exists()
+        log.debug(f'Could not create card "{self.file.resolve()}"')
+        return False
         

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -254,5 +254,7 @@ class TitleCard:
             return True
 
         log.debug(f'Could not create card "{self.file.resolve()}"')
+        self.maker.image_magick.print_command_history()
+        
         return False
         

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -72,7 +72,6 @@ class WebInterface(ABC):
         try:
             with destination.open('wb') as file_handle:
                 file_handle.write(get(image_url).content)
-            log.debug(f'downloaded {image_url} to {destination}')
         except Exception as e:
             log.error(f'Cannot download image, error: "{e}"')
 


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Fixed "magick" command prefix for fixer commands
  - Moved prefix detection logic to `PreferenceParser` class (from main) so that fixer can use correct prefix
- Removed grep dependency from `AnimeTitleCard`
- Fixed `AnimeTitleCard` failing to create some cards if paths had spaces in them
- Set Datafile encoding to `UTF-8` so that unicode can be read/written on Windows
# Minor Changes
- Added some debug messages for failed title card creation
- Added ImageMagick command history printout to help in debugging
- Added logic to detect non `/api/` endpoint in Sonarr URL specification
- Added `abs_number` format specification to card filename formatting
  - Any episode that does not have an absolute number, yet this format key is specified, will use a `0` in place of the number
# Minor Fixes
N/A