### PR TITLE
Fix for SW cards with spaces, bad encoding on Windows, added colorless runtime option

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 try:
-    from modules.Debug import log
+    from modules.Debug import log, apply_no_color_formatter
     from modules.FontValidator import FontValidator
     from modules.PreferenceParser import PreferenceParser
     from modules.preferences import set_preference_parser, set_font_validator
@@ -41,12 +41,18 @@ parser.add_argument(
     choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
     default='INFO',
     help='Level of logging verbosity to use')
+parser.add_argument(
+    '-nc', '--no-color',
+    action='store_true',
+    help='Whether to omit color from all print messages')
 
 # Parse given arguments
 args = parser.parse_args()
 
-# Set log level
+# Set global log level and coloring
 log.setLevel(args.log)
+if args.no_color:
+    apply_no_color_formatter(log)
 
 # Check if preference file exists
 if not args.preference_file.exists():

--- a/modules/Debug.py
+++ b/modules/Debug.py
@@ -14,10 +14,8 @@ class LogHandler(Handler):
             self.handleError(record)
             
 
-class LogFormatter(Formatter):
-    """
-    Taken/modified from SO: https://stackoverflow.com/a/56944256
-    """
+class LogFormatterColor(Formatter):
+    """Taken/modified from SO: https://stackoverflow.com/a/56944256"""
 
     GRAY =     '\x1b[1;30m'
     CYAN =     '\033[96m'
@@ -42,11 +40,39 @@ class LogFormatter(Formatter):
 
         return formatter_obj.format(record)
 
+
+class LogFormatterNoColor(Formatter):
+    format_layout = '[%(levelname)s] %(message)s'
+
+    LEVEL_FORMATS = {
+        DEBUG: f'{format_layout}',
+        INFO: f'{format_layout}',
+        WARNING: f'{format_layout}',
+        ERROR: f'{format_layout}',
+        CRITICAL: f'{format_layout}',
+    }
+
+    def format(self, record):
+        format_string = self.LEVEL_FORMATS[record.levelno]
+        formatter_obj = Formatter(format_string)
+
+        return formatter_obj.format(record)
+
+
 # Create global logger
 log = getLogger('TitleCardMaker')
 log.setLevel(DEBUG)
 
 # Add TQDM handler and color formatter to the logger
 handler = LogHandler()
-handler.setFormatter(LogFormatter())
+handler.setFormatter(LogFormatterColor())
 log.addHandler(handler)
+
+def apply_no_color_formatter(log_object: 'Logger') -> None:
+    # Create colorless Formatter
+    handler = LogHandler()
+    handler.setFormatter(LogFormatterNoColor())
+
+    # Delete existing Handler, add new one
+    log.removeHandler(log.handlers[0])
+    log.addHandler(handler)

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -23,8 +23,8 @@ class FontValidator:
 
         # Attept to read existing font file if it exists
         if self.FONT_VALIDATION_MAP.exists():
-            with self.FONT_VALIDATION_MAP.open('r') as file_handle:
-                self.__fonts = safe_load(file_handle)['fonts']
+            with self.FONT_VALIDATION_MAP.open('r', encoding='utf-8') as fh:
+                self.__fonts = safe_load(fh)['fonts']
         else:
             # Create parent directories if necessary
             self.FONT_VALIDATION_MAP.parent.mkdir(parents=True, exist_ok=True)
@@ -73,8 +73,8 @@ class FontValidator:
             }
 
         # Write updated map to file
-        with self.FONT_VALIDATION_MAP.open('w') as file_handle:
-            dump({'fonts': self.__fonts}, file_handle, allow_unicode=True)
+        with self.FONT_VALIDATION_MAP.open('w', encoding='utf-8') as fh:
+            dump({'fonts': self.__fonts}, fh, allow_unicode=True)
 
 
     def __has_character(self, font_filepath: str, character: str) -> bool:

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -23,8 +23,11 @@ class FontValidator:
 
         # Attept to read existing font file if it exists
         if self.FONT_VALIDATION_MAP.exists():
-            with self.FONT_VALIDATION_MAP.open('r', encoding='utf-8') as fh:
-                self.__fonts = safe_load(fh)['fonts']
+            try:
+                with self.FONT_VALIDATION_MAP.open('r', encoding='utf-8') as fh:
+                    self.__fonts = safe_load(fh)['fonts']
+            except Exception:
+                self.__fonts = {}
         else:
             # Create parent directories if necessary
             self.FONT_VALIDATION_MAP.parent.mkdir(parents=True, exist_ok=True)
@@ -68,9 +71,7 @@ class FontValidator:
         if font_filepath in self.__fonts:
             self.__fonts[font_filepath][character] = status
         else:
-            self.__fonts[font_filepath] = {
-                character: status, ' ': True,
-            }
+            self.__fonts[font_filepath] = {character: status, ' ': True}
 
         # Write updated map to file
         with self.FONT_VALIDATION_MAP.open('w', encoding='utf-8') as fh:

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -372,12 +372,10 @@ class StandardTitleCard(CardType):
         :returns:   True if a custom font is indicated, False otherwise.
         """
 
-        default_case = StandardTitleCard.DEFAULT_FONT_CASE
         return ((font.file != StandardTitleCard.TITLE_FONT)
             or (font.size != 1.0)
             or (font.color != StandardTitleCard.TITLE_COLOR)
             or (font.replacements != StandardTitleCard.FONT_REPLACEMENTS)
-            or (font.case != StandardTitleCard.CASE_FUNCTIONS[default_case])
             or (font.vertical_shift != 0)
             or (font.interline_spacing != 0))
 

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -212,7 +212,7 @@ class StarWarsTitleCard(CardType):
         """
 
         command = ' '.join([
-            f'convert {gradient_source.resolve()}',
+            f'convert "{gradient_source.resolve()}"',
             *self.__add_title_text(),
             *self.__add_episode_prefix(),
             *self.__add_episode_number_text(),


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Fixed poorly escaped filepath in for `StarWarsTitleCard`
- Set encoding to UTF-8 for font validation map, doesn't default to UTF-8 on Windows
# Minor Changes
- Added no-color option to command-line when executing Maker (for shells without color output)
  - Option is `-nc` or `--no-color`
# Minor Fixes
- Updated `StandardTitleCard` custom font detection to ignore font case, as the default font has identical upper/lowercase glyphs