### PR TITLE
Directly load cards into Plex without filename matching, add option to change card extension

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ requests = "*"
 titlecase = "*"
 tqdm = "*"
 fonttools = "*"
+plexapi = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e2c2e51018f359e60129c2fa8702f169aa652b3e14454ade70bd620bf5329bb4"
+            "sha256": "65f060a5923fff1258b355ea5018ed8570aae20eb03d3131535f9a1de8a3576e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,11 +39,11 @@
         },
         "fonttools": {
             "hashes": [
-                "sha256:236b29aee6b113e8f7bee28779c1230a86ad2aac9a74a31b0aedf57e7dfb62a4",
-                "sha256:2df636a3f402ef14593c6811dac0609563b8c374bd7850e76919eb51ea205426"
+                "sha256:59a90de72149893167e3d552ae2402c6874e006b9adc3feaf5f6d706fe20d392",
+                "sha256:b038d1a0dee0079de7ade57071e2e2aced6e35bd697de244ac62938b2b1628c1"
             ],
             "index": "pypi",
-            "version": "==4.31.2"
+            "version": "==4.32.0"
         },
         "idna": {
             "hashes": [
@@ -60,6 +60,14 @@
             ],
             "index": "pypi",
             "version": "==0.5.10"
+        },
+        "plexapi": {
+            "hashes": [
+                "sha256:10a83dd3e7b58778d90b900315dc553b96dc2a7648a3935c6ece61e14251135b",
+                "sha256:e0417eb972ca6a1e01334f32046f5f3feb9210d92a82e9f05ebe628d6c685b68"
+            ],
+            "index": "pypi",
+            "version": "==4.10.1"
         },
         "pyyaml": {
             "hashes": [
@@ -198,11 +206,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:4230a49119a416c88cc47d0d2d32d5d90f1a282d5e497d49801950704e49863d",
-                "sha256:6461b009d6792008d0000e1b0c7ca50195ec78c0e808a3a6b668a56a3236c3a5"
+                "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d",
+                "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"
             ],
             "index": "pypi",
-            "version": "==4.63.1"
+            "version": "==4.64.0"
         },
         "urllib3": {
             "hashes": [

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -48,8 +48,8 @@ class Episode:
     def __repr__(self) -> str:
         """Returns an unambiguous string representation of the object"""
 
-        return (f'<Episode episode_info={self.episode_info}, card_class='
-                f'{self.card_class}, source={self.source}, destination='
-                f'{self.destination}, extras={self.extra_characteristics}>')
+        return (f'<Episode {self.episode_info=}, {self.card_class=}, '
+                f'{self.source=}, {self.destination=}, '
+                f'{self.extra_characteristics=}>')
 
         

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -48,14 +48,13 @@ class EpisodeInfo:
         """Returns an unambiguous string representation of the object."""
 
         # Static information
-        ret = (f'<EpisodeInfo title={self.title}, season_number='
-            f'{self.season_number}, episode_number={self.episode_number}')
+        ret = (f'<EpisodeInfo {self.title=}, {self.season_number=}, '
+               f'{self.episode_number=}')
 
-        ret += '' if self.sonarr_id == None else f', sonarr_id={self.sonarr_id}'
-        ret += '' if self.tvdb_id == None else f', tvdb_id={self.tvdb_id}'
-        ret += '' if self.tmdb_id == None else f', tmdb_id={self.tmdb_id}'
-        if self.abs_number != None:
-            ret += f', abs_number={self.abs_number}'
+        ret += '' if self.sonarr_id == None else f', {self.sonarr_id=}'
+        ret += '' if self.tvdb_id == None else f', {self.tvdb_id=}'
+        ret += '' if self.tmdb_id == None else f', {self.tmdb_id=}'
+        ret += '' if self.abs_number != None else f', {self.abs_number=}'
 
         return f'{ret}>'
 

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -14,6 +14,7 @@ class FontValidator:
 
     """File to the font validation map that persists between runs"""
     FONT_VALIDATION_MAP = Path(__file__).parent / '.objects' / 'fvm.yml'
+    
 
     def __init__(self) -> None:
         """
@@ -26,7 +27,8 @@ class FontValidator:
             try:
                 with self.FONT_VALIDATION_MAP.open('r', encoding='utf-8') as fh:
                     self.__fonts = safe_load(fh)['fonts']
-            except Exception:
+            except Exception as e:
+                log.debug(f'Error reading font validation map - {e}')
                 self.__fonts = {}
         else:
             # Create parent directories if necessary

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -1,9 +1,10 @@
-from xml.etree.ElementTree import fromstring
+from pathlib import Path
 
-from requests import get, put
+from plexapi.server import PlexServer, NotFound
+from tqdm import tqdm
+from yaml import safe_load, dump
 
 from modules.Debug import log
-from modules.SeriesInfo import SeriesInfo
 
 class PlexInterface:
     """
@@ -14,116 +15,197 @@ class PlexInterface:
     https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
     """
 
-    def __init__(self, url: str, x_plex_token: str) -> None:
+    """Filepath to the map of each episode's loaded card size (from os.stat)"""
+    LOADED_CARDS = Path(__file__).parent / '.objects' / 'loaded_cards.yml'
+
+
+    def __init__(self, url: str, x_plex_token: str=None) -> None:
         """
         Constructs a new instance of a Plex Interface.
         
         :param      url:            The url at which Plex is hosted.
-
         :param      x_plex_token:   The x plex token for sending API requests to
                                     if the host device is untrusted.
         """
 
-        # Store base url and parameters to use for most requests
-        url = url + ('' if url.endswith('/') else '/')
-        self.base_url = url + 'library/'
-        self.base_params = {'X-Plex-Token': x_plex_token}
+        # Create PlexServer object with these arguments
+        self.__server = PlexServer(url, x_plex_token)
 
-        # Structure is {library_name: {full_title: ratingKey, ...}, ...}
-        self.library = {}
-        self.parse_plex_library()
+        # Read map of show name, key, and file size (in bytes)
+        if self.LOADED_CARDS.exists():
+            try:
+                with self.LOADED_CARDS.open('r', encoding='utf-8') as fh:
+                    self.__loaded = safe_load(fh)['sizes']
+            except Exception as e:
+                log.debug(f'Error reading loaded card map - {e}')
+                self.__loaded = {}
+        else:
+            # Create parent directories if necessary
+            self.LOADED_CARDS.parent.mkdir(parents=True, exist_ok=True)
+            self.__loaded = {}
 
 
-    def parse_plex_library(self) -> None:
+    def __filter_loaded_cards(self, library_name: str, series_info:'SeriesInfo',
+                              episode_map: dict) -> dict:
         """
-        Parse the associated plex library. This queries Plex to get a list of
-        all libraries, and then stores the content of that library for future
-        reference.
-        """
+        Filter the given episode map and remove all Episode objects without
+        created cards, or whose card's filesizes matches that of the already
+        uploaded card.
+            
+        :param      library_name:   Name of the library containing this series.
+        :param      series_info:    SeriesInfo object for these episodes.
+        :param      episode_map:    Dictionary of Episode objects to filter.
         
-        url = self.base_url + 'sections'
-        params = self.base_params
+        :returns:   Filtered episode map. Episodes without existing cards, or
+                    whose existing card filesizes' match those already loaded
+                    are removed.
+        """
 
-        # Attempt to query Plex, if it errors, the URL was probably wrong, error
+        filtered = {}
+        for key, episode in episode_map.items():
+            # Filter out episodes without cards
+            if not episode.destination or not episode.destination.exists():
+                continue
+
+            # If this library is new, don't filter
+            if not (library_loaded := self.__loaded.get(library_name, {})):
+                filtered[key] = episode
+                continue
+
+            # Check if this episode matches what was loaded for this series
+            if (show_loaded := library_loaded.get(series_info.full_name, {})):
+                # Get the previously loaded filesize (or 0 if never loaded)
+                old_size = show_loaded.get(episode.episode_info.key, 0)
+
+                # If new or different card, don't filter
+                if (not old_size
+                    or episode.destination.stat().st_size != old_size):
+                    filtered[key] = episode
+            else:
+                # If series has never been loaded before, don't filter
+                filtered[key] = episode
+
+        return filtered
+    
+
+    def __get_library(self, library_name: str) -> 'Library':
+        """
+        Get the Library object under the given name.
+        
+        :param      library_name:   The name of the library to get.
+
+        :returns:   The Library object if found, None otherwise.
+        """
+
         try:
-            response = get(url=url, params=params)
-        except Exception as e:
-            log.critical(f'Cannot query Plex - returned error: "{e}"')
-            exit(1)
-
-        library_xml = fromstring(response.text)
-
-        for library in library_xml.findall('Directory'):
-            library_title = library.attrib['title']
-            library_key = int(library.attrib['key'])
-
-            # Make a new request for all contents of this library
-            url = self.base_url + f'sections/{library_key}/all'
-            params = self.base_params
-
-            response = get(url=url, params=params)
-            content_xml = fromstring(response.text)
-
-            # Go through each element (series) of the library
-            content_dict = {}
-            for series in content_xml.findall('Directory'):
-                # Skip content with any missing keys
-                if any(_  not in series.attrib for _ in ('title', 'ratingKey', 'year')):
-                    continue
-
-                series_title = series.attrib['title']
-                series_rating_key = int(series.attrib['ratingKey'])
-                series_year = int(series.attrib['year'])
-
-                # Construct full title for this series
-                if f'({series_year})' in series_title:
-                    full_title = series_title
-                else:
-                    full_title = f'{series_title} ({series_year})'
-
-                content_dict.update({
-                    SeriesInfo.get_matching_title(full_title): series_rating_key
-                })
-
-            # Add this library to the object's dictionary
-            self.library.update({library_title: content_dict})
-
-        libraries = ", ".join(self.library.keys())
-        log.info(f'Found {len(self.library)} Plex libraries ({libraries})')
-
-
-    def refresh_metadata(self, library: str, series_info: SeriesInfo) -> None:
-        """
-        Refresh the given title's (if found in the specified library) metadata.
-        This effectively forces new title cards to be pulled in.
-
-        If the library or full title is not found, no content is refreshed.
-
-        :param      library:        The name of the library where the content
-                                    is. Must be a valid library name matching
-                                    Plex.
-        
-        :param      series_info:    SeriesInfo for the entry.
-        """
-
-        # Invalid library - error and exit
-        if library not in self.library:
+            return self.__server.library.section(library_name)
+        except NotFound:
             log.error(f'Library "{library}" was not found in Plex')
             return None
+
+
+    def __get_series(self, library: 'Library',
+                     series_info: 'SeriesInfo') -> 'Show':
+        """
+        Get the Series object from within the given Library associated with the
+        given SeriesInfo. This tries to match by TVDb ID, TMDb ID, name, and
+        finally full name.
         
-        # Valid library, invalid title - error and exit
-        match_name = f'{series_info.match_name}{series_info.year}'
-        if match_name not in self.library[library]:
+        :param      library:    The Library object to search for within Plex.
+        
+        :returns:   The Series associated with this SeriesInfo object.
+        """
+
+        # Try by TVDb ID
+        try:
+            if series_info.tvdb_id != None:
+                return library.getGuid(f'tvdb://{series_info.tvdb_id}')
+        except NotFound:
+            pass
+
+        # Try by TMDb ID
+        try:
+            if series_info.tmdb_id != None:
+                return library.getGuid(f'tmdb://{series_info.tmdb_id}')
+        except NotFound:
+            pass
+
+        # Try by name
+        try:
+            return library.get(series_info.name)
+        except NotFound:
+            pass
+
+        # Try by full name
+        try:
+            return library.get(series_info.full_name)
+        except NotFound:
             log.error(f'Series "{series_info}" was not found under library '
-                      f'"{library}" in Plex')
+                      f'"{library.title}" in Plex')
             return None
 
-        # Get the plex ratingKey for this title, then PUT a metadata refresh
-        rating_key = self.library[library][match_name]
-        url = self.base_url + f'metadata/{rating_key}/refresh'
-        put(url)
 
-        log.info(f'Refreshed Plex metadata for "{series_info}"')
+    def set_title_cards_for_series(self, library_name: str, 
+                                   series_info: 'SeriesInfo',
+                                   episode_map: dict) -> None:
+        """
+        Set the title cards for the given series. This only updates episodes
+        that have title cards, and those episodes whose card filesizes are
+        different than what has been set previously.
+        
+        :param      library_name:   The name of the library containing the
+                                    series to update.
+        :param      series_info:    The series to update.
+        :param      episodes:       Dictionary of episode keys to Episode
+                                    objects to update the cards of.
+        """
 
+        # Filter episodes without cards, or whose cards have not changed
+        filtered_episodes = self.__filter_loaded_cards(
+            library_name,
+            series_info,
+            episode_map
+        )
+
+        # If no episodes remain, exit
+        if len(filtered_episodes) == 0:
+            return None
+
+        # If no episodes, or the given library cannot be found, exit
+        if not (library := self.__get_library(library_name)):
+            return None
+
+        # Exit if the given series cannot be found in this library
+        if not (series := self.__get_series(library, series_info)):
+            return None
+
+        # Go through each episode within Plex, set title cards
+        for episode in (pbar := tqdm(series.episodes(), leave=False)):
+            # Update progress bar
+            pbar.set_description(f'Updating {episode.seasonEpisode.upper()}')
+
+            # If this Plex episode is among the list of cards to update
+            ep_key = f'{episode.parentIndex}-{episode.index}'
+            if ep_key in filtered_episodes:
+                # Upload card to Plex
+                card_file = filtered_episodes[ep_key].destination
+                episode.uploadPoster(filepath=card_file.resolve())
+                
+                # Update the loaded map with this card's size
+                size = card_file.stat().st_size
+                series_name = series_info.full_name
+
+                # Update loaded map with this entry
+                if library_name in self.__loaded:
+                    if series_name in self.__loaded[library_name]:
+                        self.__loaded[library_name][series_name][ep_key] = size
+                    else:
+                        self.__loaded[library_name][series_name] = {ep_key:size}
+                else:
+                    self.__loaded[library_name] = {series_name: {ep_key: size}}
+
+        # Write updated loaded map to file
+        with self.LOADED_CARDS.open('w', encoding='utf-8') as file_handle:
+            dump({'sizes': self.__loaded}, file_handle, allow_unicode=True)
 
         

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -5,6 +5,7 @@ from yaml import safe_load
 
 from modules.Debug import log
 from modules.ImageMagickInterface import ImageMagickInterface
+from modules.ImageMaker import ImageMaker
 from modules.Show import Show
 from modules.ShowSummary import ShowSummary
 from modules.TitleCard import TitleCard
@@ -44,6 +45,7 @@ class PreferenceParser(YamlReader):
         self.series_files = []
         self.card_type = 'standard'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
+        self.card_extension = TitleCard.DEFAULT_CARD_EXTENSION
         self.validate_fonts = True
         self.zero_pad_seasons = False
         self.archive_directory = None
@@ -135,6 +137,14 @@ class PreferenceParser(YamlReader):
                 self.valid = False
             else:
                 self.card_filename_format = new_format
+
+        if (extension := self['options', 'card_extension']):
+            extension = ('' if extension[0] == '.' else '.') + extension.lower()
+            if extension not in ImageMaker.VALID_IMAGE_EXTENSIONS:
+                log.critical(f'Card extension "{extension}" is invalid')
+                self.valid = False
+            else:
+                self.card_extension = extension
 
         if (value := self['options', 'validate_fonts']):
             self.validate_fonts = bool(value)

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -7,6 +7,7 @@ class SeriesInfo:
 
     """After how many characters to truncate the short name"""
     SHORT_WIDTH = 15
+    
 
     def __init__(self, name: str, year: int) -> None:
         """

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -41,7 +41,7 @@ class Show(YamlReader):
         :param      font_map:           Map of font labels to custom font
                                         descriptions.
         :param      source_directory:   Base source directory this show should
-                                        search for and place source images.
+                                        search for and place source images in.
         """
 
         # Initialize parent YamlReader object
@@ -437,14 +437,12 @@ class Show(YamlReader):
 
 
     def create_missing_title_cards(self,
-                                   tmdb_interface: 'TMDbInterface'=None) ->bool:
+                                   tmdb_interface: 'TMDbInterface'=None) ->None:
         """
         Creates any missing title cards for each episode of this show.
 
         :param      tmdb_interface:     Optional TMDbInterface to download any
                                         missing source images from.
-
-        :returns:   True if any new cards were created, False otherwise.
         """
 
         # If the media directory is unspecified, exit
@@ -452,7 +450,6 @@ class Show(YamlReader):
             return False
 
         # Go through each episode for this show
-        created_new_cards = False
         for _, episode in (pbar := tqdm(self.episodes.items(), leave=False)):
             # Update progress bar
             pbar.set_description(f'Creating {episode}')
@@ -491,7 +488,21 @@ class Show(YamlReader):
                 continue
 
             # Source exists, create the title card
-            created_new_cards |= title_card.create()
+            title_card.create()
 
-        return created_new_cards
+
+    def update_plex(self, plex_interface: 'PlexInterface') -> None:
+        """
+        Update the given PlexInterface with all title cards for all Episodes
+        within this Show.
+
+        :param      plex_interface: PlexInterface object to update.
+        """
+
+        # Update Plex for this library, this show's info and episodes
+        plex_interface.set_title_cards_for_series(
+            self.library_name,
+            self.series_info,
+            self.episodes,
+        )
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -13,8 +13,9 @@ from modules.Profile import Profile
 from modules.SeriesInfo import SeriesInfo
 from modules.TitleCard import TitleCard
 from modules.Title import Title
+from modules.YamlReader import YamlReader
 
-class Show:
+class Show(YamlReader):
     """
     This class describes a show. A show encapsulates the names and preferences
     with a complete series of episodes. Each object inherits many preferences 
@@ -43,23 +44,26 @@ class Show:
                                         search for and place source images.
         """
 
+        # Initialize parent YamlReader object
+        super().__init__(yaml_dict)
+
+        # Get global PreferenceParser object
         self.preferences = global_preferences.pp
         
         # Parse arguments into attribures
-        self.__yaml = yaml_dict
         self.__library_map = library_map
 
         # Set this show's SeriesInfo object with blank year to start
         self.series_info = SeriesInfo(name, 0)
 
         # If year isn't given, skip completely
-        if not self.__is_specified('year'):
+        if not (year := self['year']):
             log.error(f'Series "{name}" is missing the required "year"')
             self.valid = False
             return None
 
         # Year is given, parse and update year/full name of this show
-        if not match(r'^\d{4}$', str(year := self.__yaml['year'])):
+        if not match(r'^\d{4}$', str(year)):
             log.error(f'Year "{year}" of series "{name}" is invalid')
             self.valid = False
             return None
@@ -84,10 +88,10 @@ class Show:
         # Set object attributes based off YAML and update validity
         self.__parse_yaml()
         self.font = Font(
-            self.__yaml.get('font', {}),
+            self._base_yaml.get('font', {}),
             font_map,
             self.card_class,
-            self.series_info
+            self.series_info,
         )
         self.valid = self.font.valid
 
@@ -132,12 +136,12 @@ class Show:
         invalid attributes and update this object's validity.
         """
 
-        if self.__is_specified('name'):
-            self.series_info.update_name(self.__yaml['name'])
+        if (name := self['name']):
+            self.series_info.update_name(name)
 
-        if self.__is_specified('library'):
+        if (library := self['library']):
             # If the given library isn't in libary map, invalid
-            if (library := self.__yaml['library']) not in self.__library_map:
+            if library not in self.__library_map:
                 log.error(f'Library "{library}" of series {self} is not found '
                           f'in libraries list')
                 self.valid = False
@@ -159,62 +163,58 @@ class Show:
                         etf = self.card_class.EPISODE_TEXT_FORMAT
                         self.episode_text_format = etf
 
-        if self.__is_specified('card_type'):
-            if (value := self.__yaml['card_type']) not in TitleCard.CARD_TYPES:
-                log.error(f'Unknown card type "{value}" of series {self}')
+        if (card_type := self['card_type']):
+            if card_type not in TitleCard.CARD_TYPES:
+                log.error(f'Unknown card type "{card_type}" of series {self}')
                 self.valid = False
             else:
-                self.card_class = TitleCard.CARD_TYPES[value]
+                self.card_class = TitleCard.CARD_TYPES[card_type]
                 self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
 
-        if self.__is_specified('media_directory'):
-            self.media_directory = Path(self.__yaml['media_directory'])
+        if (value := self['media_directory']):
+            self.media_directory = Path(value)
 
-        if self.__is_specified('episode_text_format'):  
-            self.episode_text_format = self.__yaml['episode_text_format']
+        if (value := self['episode_text_format']):
+            self.episode_text_format = value
 
-        if self.__is_specified('archive'):
-            self.archive = bool(self.__yaml['archive'])
+        if (value := self['archive']):
+            self.archive = bool(value)
 
-        if self.__is_specified('sonarr_sync'):
-            self.sonarr_sync = bool(self.__yaml['sonarr_sync'])
+        if (value := self['sonarr_sync']):
+            self.sonarr_sync = bool(value)
 
-        if self.__is_specified('sync_specials'):
-            self.sync_specials = bool(self.__yaml['sync_specials'])
+        if (value := self['sync_specials']):
+            self.sync_specials = bool(value)
 
-        if self.__is_specified('tmdb_sync'):
-            self.tmdb_sync = bool(self.__yaml['tmdb_sync'])
+        if (value := self['tmdb_sync']):
+            self.tmdb_sync = bool(value)
 
-        if self.__is_specified('seasons', 'hide'):
-            self.hide_seasons = bool(self.__yaml['seasons']['hide'])
+        if (value := self['seasons', 'hide']):
+            self.hide_seasons = bool(value)
 
-        if (self.__is_specified('translation', 'language')
-            and self.__is_specified('translation', 'key')):
-            key = self.__yaml['translation']['key']
-            if key in ('title', 'abs_number'):
+        if self['translation', 'language'] and self['translation', 'key']:
+            if (key := self['translation', 'key']) in ('title', 'abs_number'):
                 log.error(f'Cannot add translations under the key "{key}" in '
                           f'series {self}')
             else:
-                self.title_language = self.__yaml['translation']
+                self.title_language = self['translation']
 
         # Validate season map & episode range aren't specified at the same time
-        if (self.__is_specified('seasons')
-            and self.__is_specified('episode_ranges')):
-            seasons = self.__yaml['seasons']
+        if (seasons := self['seasons']) and self['episode_ranges']:
             if any(isinstance(key, int) for key in seasons.keys()):
                 log.warning(f'Cannot specify season titles with both "seasons" '
                             f'and "episode_ranges" in series {self}')
                 self.valid = False
 
         # Validate season title map
-        if self.__is_specified('seasons'):
-            for tag in self.__yaml['seasons']:
+        if (seasons := self['seasons']):
+            for tag in seasons:
                 if isinstance(tag, int):
-                    self.__season_map[tag] = self.__yaml['seasons'][tag]
+                    self.__season_map[tag] = self['seasons', tag]
 
         # Validate episode range map
-        if self.__is_specified('episode_ranges'):
-            for episode_range in self.__yaml['episode_ranges']:
+        if (episode_ranges := self['episode_ranges']):
+            for episode_range in episode_ranges:
                 # If the range cannot be parsed, then error and skip
                 try:
                     start, end = map(int, episode_range.split('-'))
@@ -225,38 +225,9 @@ class Show:
                     continue
 
                 # Assign this season title to each episde in the given range
-                this_title = self.__yaml['episode_ranges'][episode_range]
+                this_title = episode_ranges[episode_range]
                 for episode_number in range(start, end+1):
                     self.__episode_range[episode_number] = this_title
-        
-
-    def __is_specified(self, *attributes: tuple) -> bool:
-        """
-        Determines whether the given attribute/sub-attribute has been manually 
-        specified in the show's YAML.
-        
-        :param      attributes: Any number of attributes to check for. Each
-                                subsequent argument is checked for as a sub-
-                                attribute of the prior one.
-        
-        :returns:   True if the given attributes are all specified, False
-                    otherwise.
-        """
-
-        # Start on the top-level series YAML
-        current_level = self.__yaml
-        for attr in attributes:
-            # If this level isn't even a dictionary, or the attribute DNE, FALSE
-            if not isinstance(current_level, dict) or attr not in current_level:
-                return False
-
-            if current_level[attr] == None:
-                return False
-
-            # Move to the next level
-            current_level = current_level[attr]
-
-        return True
 
 
     def __get_destination(self, episode_info: 'EpisodeInfo') -> Path:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -69,7 +69,7 @@ class SonarrInterface(WebInterface):
     def __repr__(self) -> str:
         """Returns an unambiguous string representation of the object."""
 
-        return (f'<SonarrInterface url={self.url}, api_key={self.__api_key}'
+        return (f'<SonarrInterface {self.url=}, {self.__api_key=}'
                 f', mapping of {len(self.__series_ids)} series>')
 
 
@@ -146,7 +146,7 @@ class SonarrInterface(WebInterface):
         """List all the series ID's of all shows used by Sonarr. """
 
         # Construct GET arguments
-        url = f'{self.url}series/'
+        url = f'{self.url}series'
         params = self.__standard_params
         all_series = self._get(url, params)
 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -93,7 +93,7 @@ class TMDbInterface(WebInterface):
     def __repr__(self) -> str:
         """Returns an unambiguous string representation of the object."""
 
-        return f'<TMDbInterface api_key={self.__api_key}>'
+        return f'<TMDbInterface {self.__api_key=}>'
 
 
     def __fix_blacklist(self, blacklist: dict) -> dict:
@@ -311,7 +311,7 @@ class TMDbInterface(WebInterface):
                     has keys 'season' and 'episode'. None if returned if the
                     entry cannot be found.
         """
-
+        
         # If the episode has a TVDb ID, query with that first
         if episode_info.tvdb_id != None:
             # GET parameters and request

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -18,9 +18,11 @@ class TitleCard:
     respective CardType classes.
     """
 
-    """Extensions of the input source image and output title card"""
+    """Extension of the input source image"""
     INPUT_CARD_EXTENSION = '.jpg'
-    OUTPUT_CARD_EXTENSION = '.jpg'
+
+    """Default extension of the output title card"""
+    DEFAULT_CARD_EXTENSION = '.jpg'
 
     """Default filename format for all title cards"""
     DEFAULT_FILENAME_FORMAT = '{full_name} - S{season:02}E{episode:02}'
@@ -138,7 +140,7 @@ class TitleCard:
         )
         
         # Add card extension
-        filename += TitleCard.OUTPUT_CARD_EXTENSION
+        filename += global_preferences.pp.card_extension
         
         return media_directory / season_folder / filename
 
@@ -206,7 +208,7 @@ class TitleCard:
         )
 
         # Add card extension
-        filename += TitleCard.OUTPUT_CARD_EXTENSION
+        filename += global_preferences.pp.card_extension
         
         return media_directory / season_folder / filename
 

--- a/modules/YamlReader.py
+++ b/modules/YamlReader.py
@@ -1,0 +1,96 @@
+from abc import ABC, abstractmethod
+
+from yaml import safe_load
+
+from modules.Debug import log
+
+class YamlReader(ABC):
+    """
+    This abstract class describes some class that reads and parses YAML.
+    """
+    
+    @abstractmethod
+    def __init__(self, yaml: dict={}) -> None:
+        """Initialization function of this class"""
+        self._base_yaml = yaml
+
+
+    def __getitem__(self, attributes):
+        """
+        Main way to get attribute values from YAML. If the given indices exist,
+        then the value is returned, if not then None is returned.
+        
+        :param      attributes: Attributes to get of this YAML.
+        
+        :returns:   The value within YAML indicated by the given attributes, 
+                    None if DNE.
+        """
+
+        # For multi-indexing
+        if isinstance(attributes, tuple):
+            if self._is_specified(*attributes):
+                value = self._base_yaml
+                for attrib in attributes:
+                    value = value[attrib]
+
+                return value
+            return None
+
+        return self._base_yaml.get(attributes, None)
+
+
+    def _is_specified(self, *attributes) -> bool:
+        """
+        Determines whether the given attribute/sub-attribute has been manually 
+        specified in the show's YAML.
+        
+        :param      attributes: Any number of attributes to check for. Each
+                                subsequent argument is checked for as a sub-
+                                attribute of the prior one.
+        
+        :returns:   True if ALL attributes are specified, False otherwise.
+        """
+
+        # Start on the top-level YAML
+        current = self._base_yaml
+
+        for attribute in attributes:
+            # If this level isn't even a dictionary or the attribute DNE - False
+            if not isinstance(current, dict) or attribute not in current:
+                return False
+
+            # If this level has sub-attributes, but is blank (None) - False
+            if current[attribute] == None:
+                return False
+
+            # Move to the next level
+            current = current[attribute]
+
+        # All given attributes have been checked without exit, must be specified
+        return True
+
+
+    @staticmethod
+    def _read_file(file: 'Path') -> dict:
+        """
+        Read the given file and return the contained YAML.
+        
+        :param      file:   Path to the file to read.
+        
+        :returns:   Empty dictionary if the file DNE, otherwise the content of
+                    the file.
+        """
+
+        # If file does not exist, return blank dictionary
+        if not file.exists():
+            return {}
+
+        with file.open('r') as file_handle:
+            try:
+                return safe_load(file_handle)
+            except Exception as e:
+                log.critical(f'Error reading "{file.resolve()}":\n{e}\n')
+                exit(1)
+
+        return {}
+        

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ charset-normalizer==2.0.12
 fonttools==4.30.0
 idna==3.3
 num2words==0.5.6
+PlexAPI==4.10.1
 PyYAML==6.0
 regex==2022.1.18
 requests==2.27.1
 titlecase==2.3
 tqdm==4.62.3
-urllib3==1.26.8
+urllib3==1.26.9


### PR DESCRIPTION
# Major Changes
- Directly load all title cards into Plex, rather than rely on local assets and filename matching
  - Rewrote `PlexInterface` class to use the `plexapi` module
  - Cards are uploaded, and then the loaded card's filesize is stored to compare against future cards
  - Modified `Show.create_missing_title_cards()` method to no longer return whether any cards were created
  - Created new `update_plex()` methods within `Show` and `Manager` classes to do the card uploading
  - Updated pipfile(s) to reflect new `plexapi` requirement
  - Closes #76
    - Instead of needing to better integrate with Plex Meta Manager, the Maker can now directly do the card uploading that *would* otherwise be done by PMM 
  - Closes #56 
# Major Fixes 
N/A
# Minor Changes
- Added global option to change the output title cards' extensions (from `jpg` to whatever)
  - Option is `card_extension` on under `options`
    - Must be one of `jpg`, `jpeg`, `png`, `tiff`, `gif`
    - Could add more extensions going forward, if desired
  - Closes #84 
- Created abstract `YamlParser` class, of which `PreferenceParser` and `Show` are both subclasses of
  - Entirely a behind-the-scenes change to improve ease of adding/reading YAML 
# Minor Fixes
N/A