### PR TITLE
Implement YAML templates, ignore aired status of downloaded episodes

### DIFF
--- a/modules/Debug.py
+++ b/modules/Debug.py
@@ -3,8 +3,11 @@ from logging import NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL
 from tqdm import tqdm
 
 """TQDM bar format string"""
-TQDM_BAR = ('{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} '
-            '[{elapsed}, {rate_fmt}{postfix}]')
+TQDM_KWARGS = {
+    'bar_format': ('{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} '
+                   '[{elapsed}, {rate_fmt}{postfix}]'),
+    'leave': False,
+}
 
 class LogHandler(Handler):
     """Handler subclass to integrate logging messages with TQDM"""

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -1,7 +1,7 @@
 from yaml import dump
 from tqdm import tqdm
 
-from modules.Debug import log, TQDM_BAR
+from modules.Debug import log, TQDM_KWARGS
 from modules.PlexInterface import PlexInterface
 import modules.preferences as global_preferences
 from modules.Show import Show
@@ -93,7 +93,7 @@ class Manager:
             return None
 
         # For each show in the Manager, add translation
-        for show in (pbar := tqdm(self.shows, bar_format=TQDM_BAR)):
+        for show in (pbar := tqdm(self.shows, **TQDM_KWARGS)):
             pbar.set_description(f'Adding translations for '
                                  f'"{show.series_info.short_name}"')
             show.add_translations(self.tmdb_interface)
@@ -105,13 +105,14 @@ class Manager:
         for all Show and ShowArchives, and also looks for multipart episodes.
         """
 
-        for show in tqdm(self.shows, desc='Reading source files',
-                         bar_format=TQDM_BAR):
+        # Read source files for Show objects
+        for show in tqdm(self.shows, desc='Reading source files',**TQDM_KWARGS):
             show.read_source()
             show.find_multipart_episodes()
 
+        # Read source files for ShowSummary objects
         for archive in tqdm(self.archives, desc='Reading archive source files',
-                            bar_format=TQDM_BAR):
+                            **TQDM_KWARGS):
             archive.read_source()
             archive.find_multipart_episodes()
 
@@ -128,7 +129,7 @@ class Manager:
 
         # Go through each show in the Manager and query Sonarr
         for show in tqdm(self.shows + self.archives, desc='Querying Sonarr',
-                         bar_format=TQDM_BAR):
+                         **TQDM_KWARGS):
             show.query_sonarr(self.sonarr_interface)
 
 
@@ -139,7 +140,7 @@ class Manager:
         """
 
         # Go through every show in the Manager, create cards
-        for show in (pbar := tqdm(self.shows, bar_format=TQDM_BAR)):
+        for show in (pbar := tqdm(self.shows, **TQDM_KWARGS)):
             # Update progress bar
             pbar.set_description(f'Creating Title Cards for '
                                  f'"{show.series_info.short_name}"')
@@ -163,7 +164,7 @@ class Manager:
             return None
 
         # Go through each show in the Manager, update Plex
-        for show in (pbar := tqdm(self.shows, bar_format=TQDM_BAR)):
+        for show in (pbar := tqdm(self.shows, **TQDM_KWARGS)):
             # Update progress bar
             pbar.set_description(f'Updating Plex for '
                                  f'"{show.series_info.short_name}"')
@@ -181,7 +182,7 @@ class Manager:
         if not self.preferences.create_archive:
             return None
 
-        for show_archive in (pbar := tqdm(self.archives, bar_format=TQDM_BAR)):
+        for show_archive in (pbar := tqdm(self.archives, **TQDM_KWARGS)):
             # Update progress bar
             pbar.set_description(f'Updating archive for '
                                  f'"{show_archive.series_info.short_name}"')
@@ -202,7 +203,7 @@ class Manager:
         if not self.preferences.create_summaries:
             return None
 
-        for show_archive in (pbar := tqdm(self.archives, bar_format=TQDM_BAR)):
+        for show_archive in (pbar := tqdm(self.archives, **TQDM_KWARGS)):
             # Update progress bar
             pbar.set_description(f'Creating ShowSummary for "'
                                  f'{show_archive.series_info.short_name}"')

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -100,7 +100,7 @@ class PlexInterface:
         try:
             return self.__server.library.section(library_name)
         except NotFound:
-            log.error(f'Library "{library}" was not found in Plex')
+            log.error(f'Library "{library_name}" was not found in Plex')
             return None
 
 

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tqdm import tqdm
 from yaml import safe_load
 
-from modules.Debug import log, TQDM_BAR
+from modules.Debug import log, TQDM_KWARGS
 from modules.ImageMagickInterface import ImageMagickInterface
 from modules.ImageMaker import ImageMaker
 from modules.Show import Show
@@ -243,7 +243,7 @@ class PreferenceParser(YamlReader):
         """
 
         # For each file in the cards list
-        for file in (pbar := tqdm(self.series_files, bar_format=TQDM_BAR)):
+        for file in (pbar := tqdm(self.series_files, **TQDM_KWARGS)):
             # Create Path object for this file
             file_object = Path(file)
 
@@ -276,8 +276,8 @@ class PreferenceParser(YamlReader):
             font_map = file_yaml.get('fonts', {})
 
             # Go through each series in this file
-            for show_name in tqdm(file_yaml['series'], leave=False,
-                                  desc='Creating Shows', bar_format=TQDM_BAR):
+            for show_name in tqdm(file_yaml['series'], desc='Creating Shows',
+                                  **TQDM_KWARGS):
                 # Yield the Show object created from this entry
                 yield Show(
                     show_name,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -62,11 +62,11 @@ class Show(YamlReader):
             return None
 
         # Year is given, parse and update year/full name of this show
-        if not isinstance(year, int) or year <= 0:
+        if not isinstance(year, int) or year < 0:
             log.error(f'Year "{year}" of series "{name}" is invalid')
             self.valid = False
             return None
-
+            
         # Setup default values that can be overwritten by YAML
         self.series_info = SeriesInfo(name, year)
         self.media_directory = None

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from re import match
 
 from tqdm import tqdm
 
@@ -63,7 +62,7 @@ class Show(YamlReader):
             return None
 
         # Year is given, parse and update year/full name of this show
-        if not match(r'^\d{4}$', str(year)):
+        if not isinstance(year, int) or year <= 0:
             log.error(f'Year "{year}" of series "{name}" is invalid')
             self.valid = False
             return None
@@ -81,7 +80,7 @@ class Show(YamlReader):
         self.tmdb_sync = True
         self.hide_seasons = False
         self.__episode_range = {}
-        self.__season_map = {n: f'Season {n}' for n in range(1, 1000)}
+        self.__season_map = {n: f'Season {n}' for n in range(1, 100)}
         self.__season_map[0] = 'Specials'
         self.title_language = {}
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -183,7 +183,7 @@ class SonarrInterface(WebInterface):
         # Go through each episode and get its season/episode number, and title
         for episode in all_episodes:
             # Unaired episodes (such as specials) won't have airDateUtc key
-            if 'airDateUtc' in episode:
+            if 'airDateUtc' in episode and not episode['hasFile']:
                 # Verify this episode has already aired, skip if not
                 air_datetime = datetime.strptime(
                     episode['airDateUtc'],

--- a/modules/Template.py
+++ b/modules/Template.py
@@ -1,0 +1,154 @@
+from re import findall
+
+from modules.Debug import log
+
+class Template:
+    """
+    This class describes a template. A Template is a fallback YAML object that
+    can be "filled in" with values, or just outright contain them. Variable
+    data is encoded in the form <<{key}>>. When applied to some series YAML
+    dictionary, the template'd YAML is applied to the series, unless both have
+    instances of the data, in which the series data takes priority.
+    """
+
+    def __init__(self, name: str, template: dict) -> None:
+        """
+        Construct a new Template object with the given name, and with the given
+        template dictionary. Keys of the form <<{key}>> are search for through
+        this template.
+        
+        :param      name:       The template name/identifier. For logging only.
+        :param      template:   The template YAML to implement.
+        """
+
+        self.name = name
+        self.__template = template
+        self.__keys = self.__identify_template_keys(self.__template, set())
+
+
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return f'<Template {self.name=}, {self.__keys=}, {self.__template=}>'
+
+
+    def __identify_template_keys(self, template: dict, keys: set) -> set:
+        """
+        Identify the required template keys to use this template. This looks for
+        all unique values like "<<{key}>>". This is a recursive function, and
+        searches through all sub-dictionaries of template.
+        
+        :param      template:   The template dictionary to search through.
+        :param      keys:       The existing keys identified, only used for
+                                recursion.
+        
+        :returns:   Set of keys required by the given template.
+        """
+
+        for _, value in template.items():
+            # If this attribute value is just a string, add keys to set
+            if (isinstance(value, str)
+                and (new_keys := findall(r'<<(.+?)>>', value))):
+                keys.update(new_keys)
+            elif isinstance(value, dict):
+                # Recurse through this sub-attribute
+                keys.update(self.__identify_template_keys(value, keys))
+
+        return keys
+
+
+    def __apply_value_to_key(self, template: dict, key: str, value) -> None:
+        """
+        Apply the given value to all instances of the given key in the template.
+        This looks for <<{key}>>, and puts value in place. This function is
+        recursive, so if any values of template are dictionaries, those are
+        applied as well. For example:
+
+        >>> temp = {'year': <<year>>, 'b': {'b1': False, 'b2': 'Hey <<year>>'}}
+        >>> __apply_value_to_key(temp, 'year', 1234)
+        >>> temp
+        {'year': 1234, 'b': 'b1': False, 'b2': 'Hey 1234'}
+        
+        :param      template:   The dictionary to modify any instances of
+                                <<{key}>> within. Modified in-place.
+        :param      key:        The key to search/replace for.
+        :param      value:      The value to replace the key with.
+        """
+
+        for t_key, t_value in template.items():
+            # log.info(f'template[{t_key}]={t_value}, {type(t_value)=}')
+            if isinstance(t_value, str):
+                # If the templated value is JUST the replacement, just copy over
+                if t_value == f'<<{key}>>':
+                    template[t_key] = value
+                else:
+                    template[t_key] = t_value.replace(f'<<{key}>>', str(value))
+            elif isinstance(t_value, dict):
+                # Template'd value is dictionary, recurse
+                self.__apply_value_to_key(template[t_key], key, value)
+
+
+    def __recurse_priority_union(self, base_yaml: dict,
+                                 template_yaml: dict) -> None:
+        """
+        Construct the union of the two dictionaries, with all key/values of
+        template_yaml being ADDED to the first, priority dictionary IF that
+        specific key is not already present. This is a recurisve function that
+        applies to any arbitrary set of nested dictionaries. For example:
+
+        >>> base_yaml = {'a': 123, 'c': {'c1': False}}
+        >>> t_yaml = {'a': 999, 'b': 234, 'c': {'c2': True}}
+        >>> __recurse_priority_union(base_yaml, )
+        >>> base_yaml
+        {'a': 123, 'b': 234, 'c': {'c1': False, 'c2': True}}
+        
+        :param      base_yaml:      The base - i.e. higher priority, YAML that 
+                                    forms the basis of the union of these
+                                    dictionaries. Modified in-place.
+        :param      template_yaml:  The templated - i.e. lower priority - YAML.
+        """
+
+        # Go through each key in template and add to priority YAML if not present
+        for t_key, t_value in template_yaml.items():
+            if t_key in base_yaml:
+                if isinstance(t_value, dict):
+                    # Both have this dictionary, recurse on keys of dictionary
+                    self.__recurse_priority_union(base_yaml[t_key], t_value)
+            else:
+                # Key is not present in base, carryover template value
+                base_yaml[t_key] = t_value
+
+
+    def apply_to_series(self, series_name: str, series_yaml: dict) -> bool:
+        """
+        Apply this Template object to the given series YAML, modifying it
+        to include the templated values. This function assumes that the given
+        series YAML has a template attribute, and that it applies to this object
+        
+        :param      series_name:    The name of the series being modified.
+        :param      series_yaml:    The series YAML to modify. Must have
+                                    'template' key. Modified in-place.
+
+        :returns:   True if the given series contained all the required template
+                    variables for application, False if it did not.
+        """
+        
+        # If not all required template keys are specified, warn and exit
+        if not set(series_yaml['template'].keys()).issuperset(self.__keys):
+            log.warning(f'Missing template data for "{series_name}"')
+            return False
+
+        # Take given template values, fill in template object
+        modified_template = self.__template.copy()
+        for key, value in series_yaml['template'].items():
+            self.__apply_value_to_key(modified_template, key, value)
+
+        # Delete the template section from the series YAML
+        del series_yaml['template']
+
+        # Construct union of series and filled-in template YAML
+        self.__recurse_priority_union(series_yaml, modified_template)
+
+        return True
+
+


### PR DESCRIPTION
# Major Changes
- Implemented "templates" for series YAML files
  - Created Template class which defines a series YAML template
  - Modified PreferenceParser to read/apply templates when reading/yielding Show objects
  - Templates look to substitute variables of the form `<<{key}>>`
  - Does not currently support optional arguments
  - Closes #90 
- When querying Sonarr, episode air-date/time is ignored if the episode file is present
  - Closes #89 
# Major Fixes 
N/A
# Minor Changes
- Standardized progress bars to all disappear
- Changed default season map size to 100 seasons (from 1000)
# Minor Fixes
- Typo fix in error message for missing libraries 