### PR TITLE
Minor fixes

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -21,7 +21,7 @@ parser.add_argument('-p', '--preference-file', type=Path,
 
 # Argument group for 'manual' title card creation
 title_card_group = parser.add_argument_group('Title Cards',
-                                             'Manual title card creation')
+                                             'Manual TitleCardMaker interaction')
 title_card_group.add_argument(
     '--card-type',
     type=str,
@@ -36,7 +36,7 @@ title_card_group.add_argument(
     default=SUPPRESS,
     metavar=('SOURCE', 'DESTINATION'),
     help='Create a title card with the given source image, written to the given'
-         'destination')
+         ' destination')
 title_card_group.add_argument(
     '--episode',
     type=str,

--- a/fixer.py
+++ b/fixer.py
@@ -1,13 +1,17 @@
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
 from pathlib import Path
 
-from modules.DataFileInterface import DataFileInterface
-from modules.GenreMaker import GenreMaker
-from modules.PreferenceParser import PreferenceParser
-from modules.preferences import set_preference_parser
-from modules.SonarrInterface import SonarrInterface
-from modules.TitleCard import TitleCard
-from modules.TMDbInterface import TMDbInterface
+try:
+    from modules.DataFileInterface import DataFileInterface
+    from modules.GenreMaker import GenreMaker
+    from modules.PreferenceParser import PreferenceParser
+    from modules.preferences import set_preference_parser
+    from modules.SonarrInterface import SonarrInterface
+    from modules.TitleCard import TitleCard
+    from modules.TMDbInterface import TMDbInterface
+except ImportError:
+    print(f'Required Python packages are missing - execute "pipenv install"')
+    exit(1)
 
 parser = ArgumentParser(description='Manual fixes for the TitleCardMaker')
 parser.add_argument('-p', '--preference-file', type=Path, 

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -19,7 +19,7 @@ class Episode:
         :param      base_source:    The base source directory to look for source
                                     images within.
         :param      destination:    The destination for the title card
-                                    associated with this episode.
+                                    associated with this Episode.
         :param      extras:         Additional characteristics to pass to the
                                     creation of the TitleCard from this Episode.
         """

--- a/modules/GenreMaker.py
+++ b/modules/GenreMaker.py
@@ -55,9 +55,9 @@ class GenreMaker(ImageMaker):
 
         command = ' '.join([
             f'convert "{self.source.resolve()}"',
-            f'-resize 946x1446^',
+            f'-resize "946x1446^"',
             f'-gravity center',
-            f'-extent 946x1446',
+            f'-extent "946x1446"',
             f'"{self.__RESIZED_SOURCE.resolve()}"',
         ])
 
@@ -105,7 +105,7 @@ class GenreMaker(ImageMaker):
             f'-bordercolor white',
             f'-border 27x27',
             f'-fill white',
-            f'-pointsize {self.font_size * 159}',
+            f'-pointsize {self.font_size * 159.0}',
             f'-kerning 2.25',
             f'-annotate +0+564 "{self.genre}"',
             f'"{self.output.resolve()}"',
@@ -134,9 +134,12 @@ class GenreMaker(ImageMaker):
         # Add gradient overlay to the image
         source_with_gradient = self.__add_gradient(resized_source)
 
+        # Create the output directory and any necessary parents 
+        self.output.parent.mkdir(parents=True, exist_ok=True)
+
         # Add genre text and outer border, result is the genre card
         output = self.__add_text_and_border(source_with_gradient)
-
+        
         # Delete intermediate files
         self.image_magick.delete_intermediate_images(
             resized_source,

--- a/modules/ImageMaker.py
+++ b/modules/ImageMaker.py
@@ -40,6 +40,9 @@ class ImageMaker(ABC):
             self.preferences.use_magick_prefix,
         )
 
+        # Create temporary directory if DNE
+        self.TEMP_DIR.mkdir(parents=True, exist_ok=True)
+
 
     @abstractmethod
     def create(self) -> None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -29,6 +29,7 @@ class PreferenceParser(YamlReader):
         :param      file:   The preference file to parse.
         """
 
+        # Initialize parent YamlReader object
         super().__init__()
         
         # Store and read file
@@ -81,7 +82,7 @@ class PreferenceParser(YamlReader):
     def __repr__(self) -> str:
         """Returns a unambiguous string representation of the object."""
 
-        return f'<PreferenceParser {self.file=}>'
+        return f'<PreferenceParser {self.file=}, {self.valid=}>'
 
 
     def __determine_imagemagick_prefix(self) -> None:
@@ -171,7 +172,7 @@ class PreferenceParser(YamlReader):
             try:
                 self.summary_minimum_episode_count = int(value)
             except ValueError:
-                log.critical(f'Invalid summary minimum count "{value}"')
+                log.critical(f'Invalid summary minimum episode count "{value}"')
                 self.valid = False
 
         if (value := self['plex', 'url']):

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -7,6 +7,19 @@ class SeriesInfo:
 
     """After how many characters to truncate the short name"""
     SHORT_WIDTH = 15
+
+    """Mapping of illegal filename characters and their replacements"""
+    __ILLEGAL_CHARACTERS = {
+        '?': '!',
+        '<': '',
+        '>': '',
+        ':':' -',
+        '"': '',
+        '/': '+',
+        '\\': '+',
+        '|': '',
+        '*': '-',
+    }
     
 
     def __init__(self, name: str, year: int) -> None:
@@ -59,6 +72,7 @@ class SeriesInfo:
         else:
             self.name = str(name)
 
+        # Set full name
         self.full_name = f'{self.name} ({self.year})'
         
         # Set short name
@@ -67,9 +81,13 @@ class SeriesInfo:
         else:
             self.short_name = self.name
             
-        # Set match name
+        # Set match names
         self.match_name = self.get_matching_title(self.name)
         self.full_match_name = self.get_matching_title(self.full_name)
+
+        # Set folder-safe name
+        translation = str.maketrans(self.__ILLEGAL_CHARACTERS)
+        self.legal_path = self.full_name.translate(translation)
 
 
     def set_sonarr_id(self, sonarr_id: int) -> None:

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -95,14 +95,14 @@ class Show(YamlReader):
         self.valid = self.font.valid
 
         # Update derived attributes
-        self.source_directory = source_directory / self.series_info.full_name
+        self.source_directory = source_directory / self.series_info.legal_path
         self.logo = self.source_directory / self.preferences.logo_filename
 
         # Create DataFileInterface fo this show
         self.file_interface = DataFileInterface(
             self.source_directory / DataFileInterface.GENERIC_DATA_FILE_NAME
         )
-
+        
         # Create the profile for this show
         self.profile = Profile(
             self.font,

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -47,6 +47,7 @@ class TitleCard:
         '|': '',
         '*': '-',
     }
+    
 
     def __init__(self, episode: 'Episode', profile: 'Profile',
                  title_characteristics: dict,


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
N/A
# Minor Changes
N/A
# Minor Fixes
- Added fix for series names with illegal characters
  - Maker would fail during datafile parent directory creation, now uses new `SeriesInfo.legal_path` attribute 
- Add "friendly" message for running fixer without all installed modules 
-  Fix for running fixer without running main beforehand
  - If temporary .objects directory wasn't created by running main, then the fixer would fail to create anything as the intermediate files couldn't be created
- Added fix for creating genre cards in output directory does not exist