### PR TITLE
Add optional spoiler-free card creation, use TinyDB instead of YAML for temporary objects

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ tqdm = "*"
 fonttools = "*"
 plexapi = "*"
 tenacity = "*"
+tinydb = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b0ae20bcff416b121c374a21d1208becbac2a17fefa043a5c8e7fa8a40f0a63c"
+            "sha256": "99857f2a957f01c97e5b7f42bbadde0cf9e5d873b483eadc290b4ec9d8feb36d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -203,6 +203,14 @@
             ],
             "index": "pypi",
             "version": "==8.0.1"
+        },
+        "tinydb": {
+            "hashes": [
+                "sha256:357eb7383dee6915f17b00596ec6dd2a890f3117bf52be28a4c516aeee581100",
+                "sha256:e2cdf6e2dad49813e9b5fceb3c7943387309a8738125fbff0b58d248a033f7a9"
+            ],
+            "index": "pypi",
+            "version": "==4.7.0"
         },
         "titlecase": {
             "hashes": [

--- a/fixer.py
+++ b/fixer.py
@@ -237,9 +237,12 @@ if hasattr(args, 'read_all_series'):
     with args.read_all_series.open('w', encoding='utf-8') as file_handle:
         dump(yaml, file_handle, allow_unicode=True)
 
+    print(f'\nWrote {len(yaml["series"])} series to '
+          f'{args.read_all_series.resolve()}')
+
 if args.sonarr_list_ids:
     if not pp.use_sonarr:
-        log.warning("Cannot print Sonarr ID's if Sonarr is disabled")
+        print("Cannot print Sonarr ID's if Sonarr is disabled")
     else:
         SonarrInterface(pp.sonarr_url, pp.sonarr_api_key).list_all_series_id()
 

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -62,7 +62,7 @@ class AnimeTitleCard(CardType):
     
     def __init__(self, source: Path, output_file: Path, title: str, 
                  season_text: str, episode_text: str, hide_season: bool,
-                 kanji: str=None, *args: tuple, **kwargs: dict) -> None:
+                 kanji: str=None, blur: bool=False, *args, **kwargs) -> None:
         """
         Constructs a new instance.
         
@@ -75,6 +75,7 @@ class AnimeTitleCard(CardType):
                                         card.
         :param      kanji:              Optional kanji text to place above the
                                         episode title on this card.
+        :param      blur:               Whether to blur the source image.
         :param      args and kwargs:    Unused arguments to permit generalized
                                         function calls for any CardType.
         """
@@ -97,6 +98,7 @@ class AnimeTitleCard(CardType):
         self.season_text = self.image_magick.escape_chars(season_text.upper())
         self.episode_text = self.image_magick.escape_chars(episode_text.upper())
         self.hide_season = hide_season
+        self.blur = blur
 
 
     def __title_text_global_effects(self) -> list:
@@ -219,9 +221,11 @@ class AnimeTitleCard(CardType):
 
         command = ' '.join([
             f'convert "{image.resolve()}"',
-            f'-gravity center', # For images that aren't 4x3, center crop
+            f'-profile "*"',
+            f'-gravity center',
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
             f'"{self.__GRADIENT_IMAGE.resolve()}"',
             f'-background None',
             f'-layers Flatten',

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -36,6 +36,9 @@ class CardType(ImageMaker):
     """Standard size for all title cards"""
     TITLE_CARD_SIZE = '3200x1800'
 
+    """Blur effects to apply to spoiler-free images"""
+    BLUR_PROFILE = '0x60'
+
     @property
     @abstractmethod
     def TITLE_CHARACTERISTICS(self) -> dict:

--- a/modules/Debug.py
+++ b/modules/Debug.py
@@ -1,5 +1,6 @@
 from logging import Formatter, Handler, getLogger
 from logging import NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL
+
 from tqdm import tqdm
 
 """TQDM bar format string"""

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -10,8 +10,9 @@ class Episode:
     map that info to a source and destination file.
     """
 
-    __slots__ = ('episode_info', 'card_class', 'source', 'destination',
-                 'extra_characteristics')
+    __slots__ = ('episode_info', 'card_class', 'source', 'destination', 'blur',
+                 'extra_characteristics', 'spoiler', '_spoil_type')
+    
 
     def __init__(self, episode_info: 'EpisodeInfo', card_class: 'CardType',
                  base_source: Path, destination: Path, **extras: dict) -> None:
@@ -41,6 +42,11 @@ class Episode:
         # Store extra characteristics
         self.extra_characteristics = extras
 
+        # Episodes are spoilers and not blurred until updated
+        self.spoiler = True
+        self.blur = False
+        self._spoil_type = 'spoiled'
+
 
     def __str__(self) -> str:
         """Returns a string representation of the object."""
@@ -52,7 +58,36 @@ class Episode:
         """Returns an unambiguous string representation of the object"""
 
         return (f'<Episode {self.episode_info=}, {self.card_class=}, '
-                f'{self.source=}, {self.destination=}, '
-                f'{self.extra_characteristics=}>')
+                f'{self.source=}, {self.destination=}, {self.spoiler=},'
+                f'{self.blur=}, {self.extra_characteristics=}>')
+
+
+    def delete_card(self) -> None:
+        """Delete the title card for this Episode."""
+
+        self.destination.unlink(missing_ok=True)
+
+
+    def make_spoiler_free(self, action: str) -> None:
+        """
+        Modify this Episode to be spoiler-free according to the given spoil
+        action. This updates the spoiler and blur attribute flags, and changes
+        the source Path for the Episode if art is the specified action.
+        
+        :param      action: Spoiler action to update according to.
+        """
+
+        # Return if action isn't blur or art
+        if action == 'ignore':
+            return None
+
+        # Update spoiler and blur attributes
+        self.spoiler = False
+        self.blur = action in ('blur', 'blur_all')
+        self._spoil_type = 'art' if 'art' in action else 'blur'
+
+        # Blurring, set source to blurred source in 
+        if action in ('art', 'art_all'):
+            self.source = self.source.parent / 'backdrop.jpg'
 
         

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -12,7 +12,7 @@ class Font:
     interline spacing.
     """
 
-    __slots__ = ('valid', '__yaml', '__card_class', '__series_info',
+    __slots__ = ('valid', '__yaml', '__card_class','__font_map','__series_info',
                  '__validator', '__validate', 'color', 'size', 'file',
                  'replacements', 'case_name', 'case', 'vertical_shift',
                  'interline_spacing')
@@ -49,6 +49,7 @@ class Font:
         # Store arguments
         self.__yaml = yaml
         self.__card_class = card_class
+        self.__font_map = font_map
         self.__series_info = series_info
 
         # Use the global FontValidator object

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -14,7 +14,8 @@ class Font:
 
     __slots__ = ('valid', '__yaml', '__card_class', '__series_info',
                  '__validator', '__validate', 'color', 'size', 'file',
-                 'replacements', 'case', 'vertical_shift', 'interline_spacing')
+                 'replacements', 'case_name', 'case', 'vertical_shift',
+                 'interline_spacing')
     
 
     def __init__(self, yaml, font_map: dict, card_class: 'CardType',
@@ -80,6 +81,7 @@ class Font:
                           f'is invalid')
                 self.valid = False
             else:
+                self.case_name = value
                 self.case = self.__card_class.CASE_FUNCTIONS[value]
 
         # Font color
@@ -153,9 +155,8 @@ class Font:
         self.size = 1.0
         self.file = self.__card_class.TITLE_FONT
         self.replacements = self.__card_class.FONT_REPLACEMENTS
-        self.case = self.__card_class.CASE_FUNCTIONS[
-            self.__card_class.DEFAULT_FONT_CASE
-        ]
+        self.case_name = self.__card_class.DEFAULT_FONT_CASE
+        self.case = self.__card_class.CASE_FUNCTIONS[self.case_name]
         self.vertical_shift = 0
         self.interline_spacing = 0
 

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -209,7 +209,8 @@ class Manager:
         """
 
         # If summaries aren't enabled, skip
-        if not self.preferences.create_summaries:
+        if (not self.preferences.create_archive
+            or not self.preferences.create_summaries):
             return None
 
         # Go through each archive and create summaries

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -145,6 +145,14 @@ class Manager:
             pbar.set_description(f'Creating Title Cards for '
                                  f'"{show.series_info.short_name}"')
 
+            # Modify unwatched episodes based on Plex watch status
+            if self.preferences.use_plex:
+                if self.preferences.use_tmdb:
+                    show.modify_unwatched_episodes(self.plex_interface,
+                                                   self.tmdb_interface)
+                else:
+                    show.modify_unwatched_episodes(self.plex_interface)
+
             # Pass the TMDbInterface to the show if globally enabled
             if self.preferences.use_tmdb:
                 show.create_missing_title_cards(self.tmdb_interface)
@@ -200,9 +208,11 @@ class Manager:
         calls ShowArchive.create_summary() if summaries are globally enabled.
         """
 
+        # If summaries aren't enabled, skip
         if not self.preferences.create_summaries:
             return None
 
+        # Go through each archive and create summaries
         for show_archive in (pbar := tqdm(self.archives, **TQDM_KWARGS)):
             # Update progress bar
             pbar.set_description(f'Creating ShowSummary for "'

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -310,6 +310,10 @@ class PreferenceParser(YamlReader):
 
             # Get library map for this file; error+skip missing library paths
             if (library_map := file_yaml.get('libraries', {})):
+                if not isinstance(library_map, dict):
+                    log.error(f'Invalid library specification for series file '
+                              f'"{file.resolve()}"')
+                    continue
                 if not all('path' in library_map[lib] for lib in library_map):
                     log.error(f'Libraries are missing required "path" in series'
                               f' file "{file.resolve()}"')

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -54,7 +54,7 @@ class PreferenceParser(YamlReader):
         self.zero_pad_seasons = False
         self.archive_directory = None
         self.create_archive = False
-        self.create_summaries = False
+        self.create_summaries = True
         self.summary_background_color = ShowSummary.BACKGROUND_COLOR
         self.logo_filename = ShowSummary.LOGO_FILENAME
         self.summary_minimum_episode_count = 1

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -7,6 +7,7 @@ from yaml import safe_load
 from modules.Debug import log, TQDM_KWARGS
 from modules.ImageMagickInterface import ImageMagickInterface
 from modules.ImageMaker import ImageMaker
+from modules.PlexInterface import PlexInterface
 from modules.Show import Show
 from modules.ShowSummary import ShowSummary
 from modules.Template import Template
@@ -60,6 +61,7 @@ class PreferenceParser(YamlReader):
         self.use_plex = False
         self.plex_url = None
         self.plex_token = 'NA'
+        self.plex_unwatched = PlexInterface.DEFAULT_UNWATCHED_ACTION
         self.use_sonarr = False
         self.sonarr_url = None
         self.sonarr_api_key = None
@@ -181,6 +183,15 @@ class PreferenceParser(YamlReader):
 
         if (value := self['plex', 'token']):
             self.plex_token = value
+
+        if (value := self['plex', 'unwatched']):
+            if str(value).lower() not in PlexInterface.VALID_UNWATCHED_ACTIONS:
+                options = '", "'.join(PlexInterface.VALID_UNWATCHED_ACTIONS)
+                log.critical(f'Invalid "unwatched" action, must be one of "'
+                             f'{options}"')
+                self.valid = False
+            else:
+                self.plex_unwatched = value.lower()
 
         if self['sonarr']:
             if not all((self['sonarr', 'url'], self['sonarr', 'api_key'])):

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -280,7 +280,8 @@ class Profile:
         return title_text if len(finalized_title) == 0 else finalized_title
 
 
-    def convert_title(self, title_text: str) -> str:
+    def convert_title(self, title_text: str,
+                      manually_specified: bool=False) -> str:
         """
         Convert the given title text through this profile's settings. This is
         any combination of text substitutions, case functions, and optionally
@@ -291,7 +292,9 @@ class Profile:
         and the given `title_text` was 'Chapter 1: Pilot', then the returned
         text (excluding any replacements or case mappings) would be 'Pilot'.
         
-        :param      title_text: The title text to convert.
+        :param      title_text:         The title text to convert.
+        :param      manually_specified: Whether the given title text has been
+                                        manually specified.
         
         :returns:   The processed text.
         """
@@ -307,7 +310,11 @@ class Profile:
         # Apply translation table to this text
         translated_text = title_text.translate(translation)
 
-        # Apply this profile's font function to the translated text
+        # Apply this profile's font function to the translated text, unless
+        # this is a manually specified title and we're apply title casing
+        if manually_specified and self.font.case_name in ('title', 'source'):
+            return translated_text
+
         return self.font.case(translated_text)
 
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -8,6 +8,7 @@ from modules.Episode import Episode
 from modules.Font import Font
 from modules.MultiEpisode import MultiEpisode
 import modules.preferences as global_preferences
+from modules.PlexInterface import PlexInterface
 from modules.Profile import Profile
 from modules.SeriesInfo import SeriesInfo
 from modules.TitleCard import TitleCard
@@ -23,12 +24,15 @@ class Show(YamlReader):
     exception of Interface objects (such as Sonarr and TMDb).
     """
 
+    """Filename to the backdrop for a series"""
+    BACKDROP_FILENAME = 'backdrop.jpg'
+
     __slots__ = ('preferences', '__library_map', 'series_info', 'valid',
                  'media_directory', 'card_class', 'episode_text_format',
                  'library_name', 'library', 'archive', 'sonarr_sync',
                  'sync_specials', 'tmdb_sync', 'hide_seasons','__episode_range',
                  '__season_map', 'title_language', 'font', 'source_directory',
-                 'logo', 'file_interface', 'profile', 'episodes')
+                 'logo', 'backdrop', 'file_interface', 'profile', 'episodes')
 
 
     def __init__(self, name: str, yaml_dict: dict, library_map: dict, 
@@ -85,6 +89,7 @@ class Show(YamlReader):
         self.sonarr_sync = True
         self.sync_specials = self.preferences.sonarr_sync_specials
         self.tmdb_sync = True
+        self.unwatched_action = self.preferences.plex_unwatched
         self.hide_seasons = False
         self.__episode_range = {}
         self.__season_map = {n: f'Season {n}' for n in range(1, 100)}
@@ -194,6 +199,13 @@ class Show(YamlReader):
 
         if self._is_specified('tmdb_sync'):
             self.tmdb_sync = bool(self['tmdb_sync'])
+
+        if (value := self['unwatched']):
+            if value.lower() not in PlexInterface.VALID_UNWATCHED_ACTIONS:
+                log.error(f'Invalid unwatched action "{value}" in series {self}')
+                self.valid = False
+            else:
+                self.unwatched_action = value.lower()
 
         if self._is_specified('seasons', 'hide'):
             self.hide_seasons = bool(self['seasons', 'hide'])
@@ -442,6 +454,43 @@ class Show(YamlReader):
             self.read_source()
 
 
+    def modify_unwatched_episodes(self, plex_interface: PlexInterface,
+                                  tmdb_interface: 'TMDbInterface'=None) -> None:
+        """
+        Modify this series' Episode objects based on their watched status in the
+        given PlexInterface. If a backdrop is requested, and TMDb is enabled,
+        then one is downloaded if it DNE.
+        
+        :param      plex_interface: The PlexInterface used to modify the
+                                    Episode objects based on the watched status
+                                    of.
+        :param      tmdb_interface: Optional TMDbInterface to query for a
+                                    backdrop if one is needed and DNE.
+        """
+
+        # Modify episodes based off Plex watched status
+        plex_interface.modify_unwatched_episodes(
+            self.library_name,
+            self.series_info,
+            self.episodes,
+            self.unwatched_action,
+        )
+
+        # If spoiler hiding uses art method..
+        if self.preferences.plex_unwatched in ('art', 'art_all'):
+            # Exit if backdrop exists, or cannot sync to TMDb
+            if (self.backdrop.exists()
+                or not (self.tmdb_sync and tmdb_interface)):
+                return None
+
+            # Query TMDb for the best backdrop
+            backdrop_url = tmdb_interface.get_series_backdrop(self.series_info)
+
+            # Download background art 
+            if backdrop_url:
+                tmdb_interface.download_image(backdrop_url, self.backdrop)
+
+
     def create_missing_title_cards(self,
                                    tmdb_interface: 'TMDbInterface'=None) ->None:
         """
@@ -466,6 +515,7 @@ class Show(YamlReader):
 
             # If the title card source images doesn't exist and can query TMDb..
             if (self.tmdb_sync and tmdb_interface
+                and episode.source != self.backdrop
                 and not episode.source.exists()):
                 # Query TMDbInterface for image
                 image_url = tmdb_interface.get_source_image(
@@ -497,7 +547,7 @@ class Show(YamlReader):
             title_card.create()
 
 
-    def update_plex(self, plex_interface: 'PlexInterface') -> None:
+    def update_plex(self, plex_interface: PlexInterface) -> None:
         """
         Update the given PlexInterface with all title cards for all Episodes
         within this Show.

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -142,6 +142,17 @@ class Show(YamlReader):
         return f'<Show "{self.series_info}" with {len(self.episodes)} Episodes>'
 
 
+    def __copy__(self) -> 'Show':
+        """
+        Copy the given Show.
+        
+        :returns:   A newly constructed Show object.
+        """
+
+        return Show(self.series_info.name, self._base_yaml, self.__library_map,
+                    self.font._Font__font_map, self.source_directory.parent)
+
+
     def __parse_yaml(self):
         """
         Parse the show's YAML and update this object's attributes. Error on any
@@ -467,6 +478,10 @@ class Show(YamlReader):
         :param      tmdb_interface: Optional TMDbInterface to query for a
                                     backdrop if one is needed and DNE.
         """
+
+        # If no library is set, don't update Episode objects
+        if self.library_name == None:
+            return None
 
         # Modify episodes based off Plex watched status
         plex_interface.modify_unwatched_episodes(

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -104,6 +104,7 @@ class Show(YamlReader):
         # Update derived attributes
         self.source_directory = source_directory / self.series_info.legal_path
         self.logo = self.source_directory / self.preferences.logo_filename
+        self.backdrop = self.source_directory / self.BACKDROP_FILENAME
 
         # Create DataFileInterface fo this show
         self.file_interface = DataFileInterface(
@@ -464,8 +465,8 @@ class Show(YamlReader):
                 continue
 
             # If the title card source images doesn't exist and can query TMDb..
-            if (not episode.source.exists()
-                and self.tmdb_sync and tmdb_interface):
+            if (self.tmdb_sync and tmdb_interface
+                and not episode.source.exists()):
                 # Query TMDbInterface for image
                 image_url = tmdb_interface.get_source_image(
                     self.series_info,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -185,8 +185,8 @@ class Show(YamlReader):
         if (value := self['media_directory']):
             self.media_directory = Path(value)
 
-        if (value := self['episode_text_format']):
-            self.episode_text_format = value
+        if self._is_specified('episode_text_format'):
+            self.episode_text_format = self['episode_text_format']
 
         if self._is_specified('archive'):
             self.archive = bool(self['archive'])

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 
 from modules.Debug import log
 from modules.ShowSummary import ShowSummary
@@ -65,7 +65,7 @@ class ShowArchive:
         # Go through each valid profile
         for profile_attributes in valid_profiles:
             # Create show object for this profile
-            new_show = deepcopy(base_show)
+            new_show = copy(base_show)
 
             # Update media directory
             profile_directory = self.PROFILE_DIRECTORY_MAP[

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -56,8 +56,8 @@ class StandardTitleCard(CardType):
     def __init__(self, source: Path, output_file: Path, title: str,
                  season_text: str, episode_text: str, font: str,
                  font_size: float, title_color: str, hide_season: bool,
-                 vertical_shift: int=0, interline_spacing: int=0,
-                 *args: tuple, **kwargs: dict) -> None:
+                 blur: bool=False, vertical_shift: int=0,
+                 interline_spacing: int=0, *args, **kwargs) -> None:
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
@@ -76,6 +76,9 @@ class StandardTitleCard(CardType):
         :param  title_color:        Color to use for the episode title.
         :param  hide_season:        Whether to omit the season text (and joining
                                     character) from the title card completely.
+        :param  blur:               Whether to blur the source image.
+        :param  vertical_shift:     Pixels to adjust title vertical shift by.
+        :param  interline_spacing:  Pixels to adjust title interline spacing by.
         :param  args and kwargs:    Unused arguments to permit generalized calls
                                     for any CardType.
         """
@@ -95,6 +98,7 @@ class StandardTitleCard(CardType):
         self.font_size = font_size
         self.title_color = title_color
         self.hide_season = hide_season
+        self.blur = blur
         self.vertical_shift = vertical_shift
         self.interline_spacing = interline_spacing
 
@@ -187,10 +191,11 @@ class StandardTitleCard(CardType):
 
         command = ' '.join([
             f'convert "{self.source_file.resolve()}"',
-            f'+profile "*"',    # To avoid profile conversion warnings
-            f'-gravity center', # For images that aren't 4x3, center crop
+            f'+profile "*"',
+            f'-gravity center',
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
             f'"{self.__GRADIENT_IMAGE.resolve()}"',
             f'-background None',
             f'-layers Flatten',

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -53,7 +53,7 @@ class StarWarsTitleCard(CardType):
 
     
     def __init__(self, source: Path, output_file: Path, title: str,
-                 episode_text: str, *args: tuple, **kwargs: dict) -> None:
+                 episode_text: str, blur: bool=False, *args, **kwargs) -> None:
         """
         Constructs a new instance.
         
@@ -61,6 +61,7 @@ class StarWarsTitleCard(CardType):
         :param      output_file:        Output filepath for this card.
         :param      title:              The title for this card.
         :param      episode_text:       The episode text for this card.
+        :param      blur:               Whether to blur the source image.
         :param      args and kwargs:    Unused arguments to permit generalized
                                         function calls for any CardType.
         """
@@ -81,6 +82,9 @@ class StarWarsTitleCard(CardType):
         self.episode_text = self.image_magick.escape_chars(
             self.__modify_episode_text(episode_text)
         )
+
+        # Store blur flag
+        self.blur = blur
 
 
     def __modify_episode_text(self, text: str) -> str:
@@ -134,10 +138,11 @@ class StarWarsTitleCard(CardType):
 
         command = ' '.join([
             f'convert "{source.resolve()}"',
-            f'+profile "*"',    # To avoid profile conversion warnings
-            f'-gravity center', # For images that aren't in 4x3, center crop
+            f'+profile "*"',
+            f'-gravity center',
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
             f'"{self.__STAR_GRADIENT_IMAGE.resolve()}"',
             f'-background None',
             f'-layers Flatten',

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from pathlib import Path
-from yaml import dump, safe_load
+from tinydb import TinyDB, where
+from yaml import safe_load
 
 from modules.Debug import log
 from modules.EpisodeInfo import EpisodeInfo
@@ -49,11 +50,11 @@ class TMDbInterface(WebInterface):
     }
 
     """Filename for where to store blacklisted entries"""
-    __BLACKLIST_FILE = Path(__file__).parent / '.objects' / 'db_blacklist.yml'
-    __EMPTY_BLACKLIST = {'image': {}, 'title': {}, 'logo': {}, 'backdrop': {}}
+    __BLACKLIST_DB = Path(__file__).parent / '.objects' / 'tmdb_blacklist.json'
 
     """Filename where mappings of series full titles to TMDB ids is stored"""
-    __ID_MAP: Path = Path(__file__).parent / '.objects' / 'db_id_map.yml'
+    __ID_DB = Path(__file__).parent / '.objects' / 'tmdb_ids.json'
+
 
     def __init__(self, api_key: str) -> None:
         """
@@ -67,27 +68,20 @@ class TMDbInterface(WebInterface):
 
         self.preferences = global_preferences.pp
 
-        # Create objects directory if it does not exist
-        self.__ID_MAP.parent.mkdir(parents=True, exist_ok=True)
-        self.__BLACKLIST_FILE.parent.mkdir(parents=True, exist_ok=True)
+        # Create/read blacklist database
+        self.__BLACKLIST_DB.parent.mkdir(parents=True, exist_ok=True)
+        self.__blacklist = TinyDB(self.__BLACKLIST_DB)
 
-        # Attempt to read existing ID map
-        if self.__ID_MAP.exists():
-            with self.__ID_MAP.open('r', encoding='utf-8') as file_handle:
-                self.__id_map = safe_load(file_handle)
-        else:
-            self.__id_map = {'name': {}, 'id': {}}
-
-        # Attempt to read existing blacklist, if DNE, create blank one
-        if self.__BLACKLIST_FILE.exists():
-            with self.__BLACKLIST_FILE.open('r', encoding='utf-8') as fh:
-                self.__blacklist = self.__fix_blacklist(safe_load(fh))
-        else:
-            self.__blacklist = self.__EMPTY_BLACKLIST
+        # Create/read series ID database
+        self.__ID_DB.parent.mkdir(parents=True, exist_ok=True)
+        self.__id_map = TinyDB(self.__ID_DB)
         
         # Store API key
         self.__api_key = api_key
         self.__standard_params = {'api_key': api_key}
+
+        # Import old blacklist if it exists
+        self.__import_old_blacklist()
 
 
     def __repr__(self) -> str:
@@ -96,47 +90,77 @@ class TMDbInterface(WebInterface):
         return f'<TMDbInterface {self.__api_key=}>'
 
 
-    def __fix_blacklist(self, blacklist: dict) -> dict:
+    def __import_old_blacklist(self) -> None:
         """
-        Fix the given blacklist dictionary. This validates required query types
-        are present, that each query type leads to a dictionary, and that each
-        item within those queries has a failure and next key.
-
-        :param      blacklist:  Blacklist to be fixed.
-
-        :returns:   Modified blacklist, with entries fixed.
+        Import old loaded database into new TinyDB. This reads the file and then
+        deletes it.
         """
 
-        # Blacklist isn't a dictionary, set to empty blacklist
-        if not isinstance(blacklist, dict):
-            return self.__EMPTY_BLACKLIST
+        # If old file DNE, return
+        old_file = Path(__file__).parent / '.objects' / 'db_blacklist.yml'
+        if not old_file.exists():
+            return None
 
-        # Missing query type section or section isn't a dictionary?
-        for query_type in ('image', 'title', 'logo', 'backdrop'):
-            if (query_type not in blacklist
-                or not isinstance(blacklist[query_type], dict)):
-                blacklist[query_type] = {}
+        # Load old file
+        try:
+            with old_file.open('r', encoding='utf-8') as fh:
+                old_yaml = safe_load(fh)
+        except Exception:
+            return None
 
-        # Verify each query sub-item is a dictionary with valid values
-        for qt in blacklist:
-            for key in blacklist[qt]:
-                if not isinstance(blacklist[qt][key], dict):
-                    blacklist[qt][key] = {'failures': 1, 'next': datetime.now()}
-                    log.debug(f'Reset blacklist entry for "{qt}" {key}')
-                elif 'failures' not in blacklist[qt][key]:
-                    blacklist[qt][key]['failures'] = 1
-                    log.debug(f'Reset failures for blacklist entry {key}')
-                elif not isinstance(blacklist[qt][key]['failures'], int):
-                    blacklist[qt][key]['failures'] = 1
-                    log.debug(f'Reset failures for blacklist entry {key}')
-                elif 'next' not in blacklist[qt][key]:
-                    blacklist[qt][key]['next'] = datetime.now()
-                    log.debug(f'Reset next for blacklist entry {key}')
-                elif not isinstance(blacklist[qt][key]['next'],datetime):
-                    blacklist[qt][key]['next'] = datetime.now()
-                    log.debug(f'Reset next for blacklist entry {key}')
+        entries = []
+        for query_type, query in old_yaml.items():
+            for entry_key, blacklist in query.items():
+                if query_type in ('logo', 'backdrop'):
+                    entries.append({
+                        'query': query_type,
+                        'series': entry_key,
+                        'failures': blacklist['failures'],
+                        'next': blacklist['next'].timestamp(), 
+                    })
+                else:
+                    series, season, episode = entry_key.rsplit('-', 2)
+                    entries.append({
+                        'query': query_type,
+                        'series': series,
+                        'season': int(season),
+                        'episode': int(episode),
+                        'failures': blacklist['failures'],
+                        'next': blacklist['next'].timestamp(), 
+                    })
 
-        return blacklist
+        # Add entries to DB
+        self.__blacklist.insert_multiple(entries)
+        
+        # Delete old file
+        old_file.unlink()
+
+
+    def __get_condition(self, query_type: str, series_info: SeriesInfo,
+                        episode_info: EpisodeInfo) -> 'QueryInstance':
+        """
+        Get the tinydb query condition for the given query.
+        
+        :param      series_info:    SeriesInfo for the request.
+        :param      episode_info:   EpisodeInfo for the request.
+        :param      query_type:     The type of request being updated.
+        
+        :returns:   The condition that matches the given query type, series, and
+                    Episode season+episode number.and episode.
+        """
+
+        if query_type in ('logo', 'backdrop'):
+            return (
+                (where('query') == query_type) &
+                (where('series') == series_info.full_name)
+            )
+
+        return (
+            (where('query') == query_type) &
+            (where('series') == series_info.full_name) &
+            (where('season') == episode_info.season_number) &
+            (where('episode') == episode_info.episode_number)
+        )
 
 
     def __update_blacklist(self, series_info: SeriesInfo,
@@ -151,28 +175,29 @@ class TMDbInterface(WebInterface):
         :param      query_type:     The type of request being updated.
         """
 
-        # Key for this entry based on the query type
-        if query_type in ('logo', 'backdrop'):
-            key = series_info.full_name
-        else:
-            key = f'{series_info.full_name}-{episode_info.key}'
+        # Get the entry for this request
+        condition = self.__get_condition(query_type, series_info, episode_info)
+        entry = self.__blacklist.get(condition)
 
         # If previously indexed and next has passed, increase count and set next
-        later = datetime.now() + timedelta(days=1)
-        if key in self.__blacklist.get(query_type, {}):
-            if datetime.now() >= self.__blacklist[query_type][key]['next']:
-                # One day has passed, and still failed, increment count
-                self.__blacklist[query_type][key]['failures'] += 1
-                self.__blacklist[query_type][key]['next'] = later
-            else:
-                return None
-        else:
-            # Add new entry to blacklist with 1 failure, next time is in one day
-            self.__blacklist[query_type][key] = {'failures': 1, 'next': later}
+        later = (datetime.now() + timedelta(days=1)).timestamp()
 
-        # Write latest version of blacklist to file
-        with self.__BLACKLIST_FILE.open('w', encoding='utf-8') as file_handle:
-            dump(self.__blacklist, file_handle)
+        # If this entry exists, check that next has passed
+        if entry:
+            if datetime.now().timestamp() >= entry['next']:
+                self.__blacklist.update(
+                    {'failures': entry['failures']+1, 'next': later},
+                    condition
+                )
+        else:
+            self.__blacklist.insert({
+                'query': query_type,
+                'series': series_info.full_name,
+                'season': episode_info.season_number,
+                'episode': episode_info.episode_number,
+                'failures': 1,
+                'next': later,
+            })
 
 
     def __is_blacklisted(self, series_info: SeriesInfo,
@@ -188,48 +213,21 @@ class TMDbInterface(WebInterface):
         :returns:   True if the entry is blacklisted, False otherwise.
         """
 
-        # Skip imediately if this query type has no entries
-        if query_type not in self.__blacklist:
+        # Get the blacklist entry for this request
+        entry = self.__blacklist.get(
+            self.__get_condition(query_type, series_info, episode_info)
+        )
+
+        # If request hasn't been blacklisted, not blacklisted
+        if entry == None:
             return False
 
-        # Key for this entry based on the query type
-        if query_type in ('logo', 'backdrop'):
-            key = series_info.full_name
-        else:
-            key = f'{series_info.full_name}-{episode_info.key}'
-
-        # If never indexed before, skip failure check
-        if key not in self.__blacklist[query_type]:
-            return False
-
-        # Has been indexed before, check if past failure count threshold
-        failures = self.__blacklist[query_type][key]['failures']
-        if failures > self.preferences.tmdb_retry_count:
+        # If too many failures, blacklisted
+        if entry['failures'] > self.preferences.tmdb_retry_count:
             return True
 
-        # If we haven't passed next time, then treat as temporary blacklist
-        # i.e. before next is blacklisted, after next is not
-        return datetime.now() < self.__blacklist[query_type][key]['next']
-
-
-    def __add_id_to_map(self, series_info: SeriesInfo) -> None:
-        """
-        Adds a mapping of this full title to the corresponding TheMovieDB ID. If
-        a TVDb ID was provided, map that as well
-        
-        :param      series_info:    SeriesInfo for the entry.
-        """
-
-        # Map full title to the TMDb id
-        self.__id_map['name'][series_info.full_name] = series_info.tmdb_id
-
-        # If TVDb ID is available, map TVDb ID to the TMDb ID
-        if series_info.tvdb_id != None:
-            self.__id_map['id'][series_info.tvdb_id] = series_info.tmdb_id
-
-        # Write updated map to file
-        with self.__ID_MAP.open('w', encoding='utf-8') as file_handle:
-            dump(self.__id_map, file_handle)
+        # If next hasn't passed, treat as temporary blacklist
+        return datetime.now().timestamp() < entry['next']
 
 
     def __set_tmdb_id(self, series_info: SeriesInfo) -> None:
@@ -242,14 +240,14 @@ class TMDbInterface(WebInterface):
         """
 
         # If TVDb ID is available and is mapped, set that ID
-        if (series_info.tvdb_id != None
-            and series_info.tvdb_id in self.__id_map['id']):
-            series_info.set_tmdb_id(self.__id_map['id'][series_info.tvdb_id])
+        if (series_info.tvdb_id and
+            (val := self.__id_map.get(where('tvdb_id') == series_info.tvdb_id))):
+            series_info.set_tmdb_id(val['tmdb_id'])
             return None
 
         # If already mapped, set that ID
-        if (id_ := self.__id_map['name'].get(series_info.full_name, None)):
-            series_info.set_tmdb_id(id_)
+        if (entry := self.__id_map.get(where('name') == series_info.full_name)):
+            series_info.set_tmdb_id(entry['tmdb_id'])
             return None
 
         # Match by TVDB ID if available
@@ -269,8 +267,9 @@ class TMDbInterface(WebInterface):
                 # Get the TMDb ID for this series, set for object and add to map
                 tmdb_id = results[0]['id']
                 series_info.set_tmdb_id(tmdb_id)
-                self.__add_id_to_map(series_info)
-
+                self.__id_map.insert({'tvdb_id': series_info.tvdb_id,
+                                      'tmdb_id': tmdb_id,
+                                      'name': series_info.full_name})
                 return None
 
         # Match by title and year if no ID was given
@@ -288,7 +287,9 @@ class TMDbInterface(WebInterface):
 
         # Get the TMDb ID for this series, set for object and add to map
         series_info.set_tmdb_id(results['results'][0]['id'])
-        self.__add_id_to_map(series_info)
+        self.__id_map.insert({'tvdb_id': series_info.tvdb_id,
+                              'tmdb_id': series_info.tmdb_id,
+                              'name': series_info.full_name})
 
 
     def __find_episode(self, series_info: SeriesInfo,

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -131,7 +131,7 @@ class TMDbInterface(WebInterface):
 
         # Add entries to DB
         self.__blacklist.insert_multiple(entries)
-        
+
         # Delete old file
         old_file.unlink()
 
@@ -190,14 +190,22 @@ class TMDbInterface(WebInterface):
                     condition
                 )
         else:
-            self.__blacklist.insert({
-                'query': query_type,
-                'series': series_info.full_name,
-                'season': episode_info.season_number,
-                'episode': episode_info.episode_number,
-                'failures': 1,
-                'next': later,
-            })
+            if query_type in ('logo', 'backdrop'):
+                self.__blacklist.insert({
+                    'query': query_type,
+                    'series': series_info.full_name,
+                    'failures': 1,
+                    'next': later,    
+                })
+            else:
+                self.__blacklist.insert({
+                    'query': query_type,
+                    'series': series_info.full_name,
+                    'season': episode_info.season_number,
+                    'episode': episode_info.episode_number,
+                    'failures': 1,
+                    'next': later,
+                })
 
 
     def __is_blacklisted(self, series_info: SeriesInfo,

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -207,12 +207,12 @@ class Title:
         # If manually specified, apply the profile to each line, skip splitting
         if self.__manually_specified:
             return '\n'.join(list(map(
-                lambda line: profile.convert_title(line),
+                lambda line: profile.convert_title(line, True),
                 self.__title_lines
             )))
 
         # Title lines weren't manually specified - apply profile, make new Title
-        new_title = Title(profile.convert_title(self.full_title))
+        new_title = Title(profile.convert_title(self.full_title, False))
 
         # Call split on the new title, join those lines
         return '\n'.join(new_title.split(**title_characteristics))

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -85,6 +85,7 @@ class TitleCard:
             season_text=profile.get_season_text(episode.episode_info),
             episode_text=profile.get_episode_text(episode),
             hide_season=profile.hide_season_title,
+            blur=episode.blur,
             **profile.font.get_attributes(),
             **extra_characteristics,
         )


### PR DESCRIPTION
# Major Changes
- Added automatic spoiler-free card creation
  - Modified `Manager` to modify unwatched episodes prior to calling `create_missing_title_cards()` method
  - Updated `PlexInterface` to tracks file size and spoil status of loaded cards
  - `Created PlexInterface.modify_unwatched_episodes()` method to detect unwatched episodes within Plex to update `Episode` objects and delete old cards based on requested spoil action
  - Updated `PreferenceParser` class to look for 'unwatched' attribute within plex section
  - Updated `Show` class to look for 'unwatched' attribute to override Plex default
  - Example of this implementation with blurring:
  - <img src="https://user-images.githubusercontent.com/17693271/167269762-4566c8c1-1533-47e4-81be-7686ce6a3ae5.jpg" width="600"/>
  - Closes #94 
- Added `TMDbInterface` method to get series backdrop
- Added optional blur argument to all card types
  - If enabled, `CardType.BLUR_PROFILE` (`0x60`) is applied to source image post-resize
- Rewrote `FontValidator`, `PlexInterface`, and `TMDbInterface` classes to use `tinydb` databases instead of YAML objects
  - These database operations are atomic and much faster (and extensible) than nested dictionaries in YAML
    - Prevents temporary file corruption if quitting the Maker during a R/W operation
  - Added `tinydb` as dependency
  - Don't `deepcopy` `Show` object
    - Couldn't pickle new TinyDB objects, so deep copying is no longer used by `ShowArchive` class
  - Closes #110 
# Major Fixes 
N/A
# Minor Changes
- Update Plex progress bar after episode existence check 
  - Has minor performance improvement as frequent progress bar updates are slow
- Print results of `--read-all-series` argument
- Don't apply title casing to manually specified titles 
  - Closes #109 
- Enabled summary creation by default
- Store initialization `font_map` within `Font` object
# Minor Fixes
- Handle bad libraries specification within series YAML files
- Properly parse completely empty episode text format strings 