### PR TITLE
Faster Plex card loading, retry API requests more, customizable stroke width and kerning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __pycache__/
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
 
 # PEP 582
 __pypackages__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN export MAGICK_HOME="$HOME/ImageMagick-7.1.0" \
 # Install TCM package dependencies
 RUN pip3 install --no-cache-dir --upgrade pipenv
 RUN pipenv install
-RUN rm -f /maker/requirements.txt
 
 # Volumes?
 VOLUME /source

--- a/fixer.py
+++ b/fixer.py
@@ -42,42 +42,46 @@ title_card_group.add_argument(
     help='Create a title card with the given source image, written to the given'
          ' destination')
 title_card_group.add_argument(
+    '--blur',
+    action='store_true',
+    help='Blur the source image for this card')
+title_card_group.add_argument(
     '--episode',
     type=str,
     default='EPISODE',
     metavar='EPISODE_TEXT',
-    help="Specify this card's episode text")
+    help='The episode text for this card')
 title_card_group.add_argument(
     '--season',
     type=str,
     default=None,
     metavar='SEASON_TEXT',
-    help="Specify this card's season text")
+    help='The season text for this card')
 title_card_group.add_argument(
     '--title',
     type=str,
     nargs='+',
     default='',
     metavar=('TITLE_LINE'),
-    help="Specify this card's title text")
+    help="The title text for this card")
 title_card_group.add_argument(
     '--font', '--font-file',
     type=Path,
     default='__default',
     metavar='FONT_FILE',
-    help="Specify this card's custom font")
+    help="A custom font file for this card")
 title_card_group.add_argument(
     '--font-size', '--size',
     type=str,
     default='100%',
     metavar='SCALE%',
-    help='Specify a custom font scale (as percentage)')
+    help='A font scale (as percentage) for this card')
 title_card_group.add_argument(
     '--font-color', '--color',
     type=str, 
     default='__default',
     metavar='#HEX',
-    help='Specify a custom font color to use for this card')
+    help='A custom font color for this card')
 title_card_group.add_argument(
     '--vertical-shift', '--shift',
     type=float,
@@ -192,6 +196,7 @@ if hasattr(args, 'title_card'):
         font_size=float(args.font_size[:-1])/100.0,
         title_color=args.font_color,
         hide_season=(not bool(args.season)),
+        blur=args.blur,
         vertical_shift=args.vertical_shift,
         interline_spacing=args.interline_spacing,
         **arbitrary_data,

--- a/fixer.py
+++ b/fixer.py
@@ -95,6 +95,12 @@ title_card_group.add_argument(
     metavar='PIXELS',
     help='How many pixels to increase the interline spacing of the title text')
 title_card_group.add_argument(
+    '--kerning',
+    type=str,
+    default='100%',
+    metavar='SCALE%',
+    help='Specify the font kerning scale (as percentage)')
+title_card_group.add_argument(
     '--stroke-width', '--stroke',
     type=str,
     default='100%',
@@ -205,6 +211,7 @@ if hasattr(args, 'title_card'):
         blur=args.blur,
         vertical_shift=args.vertical_shift,
         interline_spacing=args.interline_spacing,
+        kerning=float(args.kerning[:-1])/100.0,
         stroke_width=float(args.stroke_width[:-1])/100.0,
         **arbitrary_data,
     ).create()

--- a/fixer.py
+++ b/fixer.py
@@ -93,7 +93,13 @@ title_card_group.add_argument(
     type=float,
     default=0.0,
     metavar='PIXELS',
-    help='How many pixels to increase the interline spacing of for title text')
+    help='How many pixels to increase the interline spacing of the title text')
+title_card_group.add_argument(
+    '--stroke-width', '--stroke',
+    type=str,
+    default='100%',
+    metavar='SCALE%',
+    help='Specify the font black stroke scale (as percentage)')
 
 # Argument group for genre cards
 genre_group = parser.add_argument_group(
@@ -199,6 +205,7 @@ if hasattr(args, 'title_card'):
         blur=args.blur,
         vertical_shift=args.vertical_shift,
         interline_spacing=args.interline_spacing,
+        stroke_width=float(args.stroke_width[:-1])/100.0,
         **arbitrary_data,
     ).create()
 

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from re import match
+from re import compile
 
 from modules.Debug import log
 from modules.TitleCard import TitleCard
@@ -11,11 +11,15 @@ class Font:
     it's color, size, file, replacements, case function, vertical offset, and 
     interline spacing.
     """
+    
+    """Compiled regex to identify percentage values"""
+    _PERCENT_REGEX = compile(r'^-?\d+\.?\d*%$')
+    _PERCENT_REGEX_POSITIVE = compile(r'^\d+\.\d*%$')
 
     __slots__ = ('valid', '__yaml', '__card_class','__font_map','__series_info',
                  '__validator', '__validate', 'color', 'size', 'file',
                  'replacements', 'case_name', 'case', 'vertical_shift',
-                 'interline_spacing', 'stroke_width')
+                 'interline_spacing', 'kerning', 'stroke_width')
     
 
     def __init__(self, yaml, font_map: dict, card_class: 'CardType',
@@ -72,11 +76,11 @@ class Font:
         """Parse this object's YAML and update the validity and attributes."""
 
         # Whether to validate for this font
-        if (value := self.__yaml.get('validate', None)):
+        if (value := self.__yaml.get('validate')) != None:
             self.__validate = bool(value)
 
         # Font case
-        if (value := self.__yaml.get('case', '').lower()):
+        if (value := self.__yaml.get('case', '').lower()) != '':
             if value not in self.__card_class.CASE_FUNCTIONS:
                 log.error(f'Font case "{value}" of series {self.__series_info} '
                           f'is invalid')
@@ -86,7 +90,7 @@ class Font:
                 self.case = self.__card_class.CASE_FUNCTIONS[value]
 
         # Font color
-        if (value := self.__yaml.get('color', None)):
+        if (value := self.__yaml.get('color')) != None:
             if not bool(match('^#[a-fA-F0-9]{6}$', value)):
                 log.error(f'Font color "{value}" of series {self.__series_info}'
                           f' is invalid - specify as "#xxxxxx"')
@@ -95,7 +99,7 @@ class Font:
                 self.color = value
 
         # Font file
-        if (value := self.__yaml.get('file', None)):
+        if (value := self.__yaml.get('file')) != None:
             if not Path(value).exists():
                 log.error(f'Font file "{value}" of series {self.__series_info} '
                           f'not found')
@@ -105,7 +109,7 @@ class Font:
                 self.replacements = {} # Reset for manually specified font
 
         # Font replacements
-        if (value := self.__yaml.get('replacements', None)):
+        if (value := self.__yaml.get('replacements')) != None:
             if any(len(key) != 1 for key in value.keys()):
                 log.error(f'Font replacements of series {self.__series_info} is'
                           f' invalid - must only be 1 character')
@@ -118,8 +122,8 @@ class Font:
                 self.replacements = value
 
         # Font Size
-        if (value := self.__yaml.get('size', None)):
-            if not bool(match(r'^\d+%$', value)):
+        if (value := self.__yaml.get('size')) != None:
+            if not bool(self._PERCENT_REGEX_POSITIVE.match(value)):
                 log.error(f'Font size "{value}" of series {self.__series_info} '
                           f'is invalid - specify as "x%"')
                 self.valid = False
@@ -127,7 +131,7 @@ class Font:
                 self.size = float(value[:-1]) / 100.0
 
         # Vertical shift
-        if (value := self.__yaml.get('vertical_shift', None)):
+        if (value := self.__yaml.get('vertical_shift')) != None:
             if not isinstance(value, int):
                 log.error(f'Font vertical shift "{value}" of series '
                           f'{self.__series_info} is invalid - must be integer.')
@@ -136,17 +140,26 @@ class Font:
                 self.vertical_shift = value
 
         # Interline spacing
-        if (value := self.__yaml.get('interline_spacing', None)):
+        if (value := self.__yaml.get('interline_spacing')) != None:
             if not isinstance(value, int):
                 log.error(f'Font interline spacing "{value}" of series '
                           f'{self.__series_info} is invalid - must be integer.')
                 self.valid = False
             else:
                 self.interline_spacing = value
+                
+	# Kerning
+        if (value := self.__yaml.get('kerning')) != None:
+            if not bool(self._PERCENT_REGEX.match(value)):
+                log.error(f'Font kerning "{value}" of series '
+                          f'{self.__series_info} is invalid - specify as "x%"')
+                self.valid = False
+            else:
+                self.kerning = float(value[:-1]) / 100.0
 
         # Stroke width
-        if (value := self.__yaml.get('stroke_width', None)):
-            if not bool(match(r'^\d+%$', value)):
+        if (value := self.__yaml.get('stroke_width')) != None:
+            if not bool(self._PERCENT_REGEX.match(value)):
                 log.error(f'Font stroke width "{value}" of series '
                           f'{self.__series_info} is invalid - specify as "x%"')
                 self.valid = False
@@ -169,6 +182,7 @@ class Font:
         self.case = self.__card_class.CASE_FUNCTIONS[self.case_name]
         self.vertical_shift = 0
         self.interline_spacing = 0
+        self.kerning = 1.0
         self.stroke_width = 1.0
 
 
@@ -185,6 +199,7 @@ class Font:
             'font': self.file,
             'vertical_shift': self.vertical_shift,
             'interline_spacing': self.interline_spacing,
+            'kerning': self.kerning,
             'stroke_width': self.stroke_width,
         }
 

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from re import compile
+from re import match
+from re import compile as re_compile
 
 from modules.Debug import log
 from modules.TitleCard import TitleCard
@@ -13,8 +14,8 @@ class Font:
     """
     
     """Compiled regex to identify percentage values"""
-    _PERCENT_REGEX = compile(r'^-?\d+\.?\d*%$')
-    _PERCENT_REGEX_POSITIVE = compile(r'^\d+\.\d*%$')
+    _PERCENT_REGEX = re_compile(r'^-?\d+\.?\d*%$')
+    _PERCENT_REGEX_POSITIVE = re_compile(r'^\d+\.?\d*%$')
 
     __slots__ = ('valid', '__yaml', '__card_class','__font_map','__series_info',
                  '__validator', '__validate', 'color', 'size', 'file',

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -15,7 +15,7 @@ class Font:
     __slots__ = ('valid', '__yaml', '__card_class','__font_map','__series_info',
                  '__validator', '__validate', 'color', 'size', 'file',
                  'replacements', 'case_name', 'case', 'vertical_shift',
-                 'interline_spacing')
+                 'interline_spacing', 'stroke_width')
     
 
     def __init__(self, yaml, font_map: dict, card_class: 'CardType',
@@ -144,6 +144,15 @@ class Font:
             else:
                 self.interline_spacing = value
 
+        # Stroke width
+        if (value := self.__yaml.get('stroke_width', None)):
+            if not bool(match(r'^\d+%$', value)):
+                log.error(f'Font stroke width "{value}" of series '
+                          f'{self.__series_info} is invalid - specify as "x%"')
+                self.valid = False
+            else:
+                self.stroke_width = float(value[:-1]) / 100.0
+
 
     def set_default(self) -> None:
         """Reset this object's attributes to its default values."""
@@ -160,6 +169,7 @@ class Font:
         self.case = self.__card_class.CASE_FUNCTIONS[self.case_name]
         self.vertical_shift = 0
         self.interline_spacing = 0
+        self.stroke_width = 1.0
 
 
     def get_attributes(self) -> dict:
@@ -175,6 +185,7 @@ class Font:
             'font': self.file,
             'vertical_shift': self.vertical_shift,
             'interline_spacing': self.interline_spacing,
+            'stroke_width': self.stroke_width,
         }
 
 

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -85,18 +85,25 @@ class PlexInterface:
 
 
     def __get_condition(self, library_name: str, series_info: 'SeriesInfo',
-                        episode: 'Episode') -> 'QueryInstance':
+                        episode: 'Episode'=None) -> 'QueryInstance':
         """
         Get the tinydb query condition for the given entry.
         
         :param      library_name:   The name of the library containing the
                                     series to get the details of.
         :param      series_info:    The series to get the details of.
-        :param      episode:        The Episode object to get the details of.
+        :param      episode:        Optional Episode object to get details of.
         
         :returns:   The condition that matches the given library, series, and
-                    Episode season+episode number.
+                    Episode season+episode number if provided.
         """
+
+        # If no episode was given, get condition for entire series
+        if episode == None:
+            return (
+                (where('library') == library_name) &
+                (where('series') == series_info.full_name)
+            )
 
         return (
             (where('library') == library_name) &
@@ -104,6 +111,29 @@ class PlexInterface:
             (where('season') == episode.episode_info.season_number) &
             (where('episode') == episode.episode_info.episode_number)
         )
+
+
+    def __get_loaded_episode(self, loaded_series: [dict],
+                             episode: 'Episode') -> dict:
+        """
+        Get the loaded details of the given Episode from the given list of
+        loaded series details.
+        
+        :param      loaded_series:  Filtered List from the loaded database to
+                                    look through.
+        :param      episode:        The Episode to get the details of.
+
+        :returns:   Loaded details for the specified episode. None if an episode
+                    of that index DNE in the given list.
+        """
+        
+        for index, entry in enumerate(loaded_series):
+            # Check index 
+            if (entry['season'] == episode.episode_info.season_number and
+                entry['episode'] == episode.episode_info.episode_number):
+                return entry
+
+        return None
 
 
     def __filter_loaded_cards(self, library_name: str, series_info:'SeriesInfo',
@@ -122,24 +152,30 @@ class PlexInterface:
                     are removed.
         """
 
+        # Get all loaded details for this series
+        series=self.__db.search(self.__get_condition(library_name, series_info))
+
         filtered = {}
         for key, episode in episode_map.items():
             # Filter out episodes without cards
             if not episode.destination or not episode.destination.exists():
                 continue
 
-            # Get current details of this episode
-            details = self.__db.get(
-                self.__get_condition(library_name, series_info, episode)
-            )
-
-            # If this episode has never been loaded, add
-            if details == None:
+            # If no cards have been loaded, add all episodes with cards
+            if not series:
                 filtered[key] = episode
                 continue
 
-            # If the loaded filesize is different, add
-            if details['filesize'] != episode.destination.stat().st_size:
+            # Get current details of this episode
+            found = False
+            if (entry := self.__get_loaded_episode(series, episode)):
+                # Episode found, check filesize
+                found = True
+                if entry['filesize'] != episode.destination.stat().st_size:
+                    filtered[key] = episode
+
+            # If this episode has never been loaded, add
+            if not found:
                 filtered[key] = episode
 
         return filtered
@@ -243,6 +279,11 @@ class PlexInterface:
         else:
             spoil_type = 'art' if 'art' in unwatched else 'blur'
 
+        # Get loaded characteristics of the series
+        loaded_series = self.__db.search(
+            self.__get_condition(library_name, series_info)
+        )
+
         # Go through each episode within Plex and update Episode spoiler status
         for plex_episode in series.episodes():
             # If this Plex episode doesn't have Episode object(?) skip
@@ -250,40 +291,39 @@ class PlexInterface:
             if not (episode := episode_map.get(ep_key)):
                 continue
 
-            # Get loaded card characteristics for this episode, skip if unloaded
-            condition = self.__get_condition(library_name, series_info, episode)
-            if (loaded := self.__db.get(condition)) == None:
-                continue
+            # Get loaded card characteristics for this episode
+            details = self.__get_loaded_episode(loaded_series, episode)
+            loaded = details != None
 
             # Spoil characteristics for this card            
             spoiler_free = (unwatched != 'ignore'
                             and not plex_episode.isWatched)
             spoiler = plex_episode.isWatched and not all_spoiler_free
-            spoiler_status = loaded['spoiler']
+            spoiler_status = details['spoiler'] if loaded else None
 
-            # If episode needs to be spoiler-free
+            # If Episode needs to be spoiler-free
             delete_and_reset = False
             if all_spoiler_free or spoiler_free:
                 # Update episode source
                 episode.make_spoiler_free(unwatched)
 
-                # If loaded card is spoiler, or wrong style
-                if (spoiler_status == 'spoiled'
-                    or spoiler_status != spoil_type):
+                # If loaded card is spoiler, or wrong style, mark for deletion
+                if spoiler_status == 'spoiled' or spoiler_status != spoil_type:
                     delete_and_reset = True
-                    log.debug(f'Deleted card for "{series_info}" {episode}, '
-                              f'want spoiler-free card')
 
-            # If episode needs to be a spoiler and has been loaded already
+            # If episode needs to become spoiler, mark for deletion
             if (all_spoiler or spoiler) and spoiler_status != 'spoiled':
                 delete_and_reset = True
-                log.debug(f'Deleted card for "{series_info}" {episode}, want '
-                          f'spoiler card')
 
             # Delete card, reset size in loaded map to force reload
-            if delete_and_reset:
+            if delete_and_reset and loaded:
                 episode.delete_card()
-                self.__db.update({'filesize': 0}, condition)
+                log.debug(f'Deleted card for "{series_info}" {episode}, '
+                          f'updating spoil status')
+                self.__db.update(
+                    {'filesize': 0},
+                    self.__get_condition(library_name, series_info, episode)
+                )
 
 
     def set_title_cards_for_series(self, library_name: str, 

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -39,7 +39,6 @@ class PreferenceParser(YamlReader):
 
         # Check for required source directory
         if not (source_directory := self['options', 'source']):
-            breakpoint()
             log.critical(f'Preference file missing required options/source '
                          f'attribute')
             exit(1)

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -50,15 +50,16 @@ class StandardTitleCard(CardType):
 
     __slots__ = ('souce_file', 'output_file', 'title', 'season_text',
                  'episode_text', 'font', 'font_size', 'title_color',
-                 'hide_season', 'vertical_shift', 'interline_spacing')
+                 'hide_season', 'vertical_shift', 'kerning',
+                 'interline_spacing')
 
 
     def __init__(self, source: Path, output_file: Path, title: str,
                  season_text: str, episode_text: str, font: str,
                  font_size: float, title_color: str, hide_season: bool,
                  blur: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, stroke_width: float=1.0,
-                 *args, **kwargs) -> None:
+                 interline_spacing: int=0, kerning: float=1.0,
+                 stroke_width: float=1.0, *args, **kwargs) -> None:
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
@@ -80,6 +81,7 @@ class StandardTitleCard(CardType):
         :param  blur:               Whether to blur the source image.
         :param  vertical_shift:     Pixels to adjust title vertical shift by.
         :param  interline_spacing:  Pixels to adjust title interline spacing by.
+        :param  kerning:            Scalar to apply to kerning of the title text.
         :param  stroke_width:       Scalar to apply to black stroke of the title
                                     text.
         :param  args and kwargs:    Unused arguments to permit generalized calls
@@ -104,6 +106,7 @@ class StandardTitleCard(CardType):
         self.blur = blur
         self.vertical_shift = vertical_shift
         self.interline_spacing = interline_spacing
+        self.kerning = kerning
         self.stroke_width = stroke_width
 
 
@@ -117,10 +120,11 @@ class StandardTitleCard(CardType):
 
         font_size = 157.41 * self.font_size
         interline_spacing = -22 + self.interline_spacing
+        kerning = -1.25 * self.kerning
 
         return [
             f'-font "{self.font}"',
-            f'-kerning -1.25',
+            f'-kerning {kerning}',
             f'-interword-spacing 50',
             f'-interline-spacing {interline_spacing}',
             f'-pointsize {font_size}',

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -57,7 +57,8 @@ class StandardTitleCard(CardType):
                  season_text: str, episode_text: str, font: str,
                  font_size: float, title_color: str, hide_season: bool,
                  blur: bool=False, vertical_shift: int=0,
-                 interline_spacing: int=0, *args, **kwargs) -> None:
+                 interline_spacing: int=0, stroke_width: float=1.0,
+                 *args, **kwargs) -> None:
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
@@ -79,6 +80,8 @@ class StandardTitleCard(CardType):
         :param  blur:               Whether to blur the source image.
         :param  vertical_shift:     Pixels to adjust title vertical shift by.
         :param  interline_spacing:  Pixels to adjust title interline spacing by.
+        :param  stroke_width:       Scalar to apply to black stroke of the title
+                                    text.
         :param  args and kwargs:    Unused arguments to permit generalized calls
                                     for any CardType.
         """
@@ -101,6 +104,7 @@ class StandardTitleCard(CardType):
         self.blur = blur
         self.vertical_shift = vertical_shift
         self.interline_spacing = interline_spacing
+        self.stroke_width = stroke_width
 
 
     def __title_text_global_effects(self) -> list:
@@ -131,10 +135,12 @@ class StandardTitleCard(CardType):
         :returns:   List of ImageMagick commands.
         """
 
+        stroke_width = 3.0 * self.stroke_width
+
         return [
             f'-fill black',
             f'-stroke black',
-            f'-strokewidth 3', #def:3, euphoria:0.5, the wire:1, punisher:1.5, pll:1
+            f'-strokewidth {stroke_width}',
         ]
 
 

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from requests import get
-from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_exponential
 
 from modules.Debug import log
 
@@ -27,7 +27,8 @@ class WebInterface(ABC):
         self.__cached_results = []
 
 
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3) + wait_random(0, 2))
+    @retry(stop=stop_after_attempt(10),
+           wait=wait_fixed(3)+wait_exponential(min=1, max=32))
     def __retry_get(self, url: str, params: dict) -> dict:
         """
         Retry the given GET request until successful (or really fails).


### PR DESCRIPTION
# Major Changes
- Speed up loading cards into Plex
  - Vastly speed up `PlexInterface` operations by querying `TinyDB` once per series (from once per episode)
  - About 20 times faster (scales with number of episodes for each series)
# Major Fixes 
N/A
# Minor Changes
- Retry all API requests (namely TMDb) more before quitting
  - API (and all GET) requests are tried up to 10 times with exponentially increasing delay (from max 3 with random delay)
- Retry uploading cards to Plex before erroring
  - Automatically retry card uploads up to 5 times with exponentially increasing delay (from once and error)
- Added `--blur` argument to fixer manual title card creation
- Add option to adjust stroke width of font
  - Added parsing for `stroke_width` font attribute to specify stroke width scalar (like font size) to adjust black stroke width
  - Added stroke width adjustment to `StandardTitleCard` class
  - Added `--stroke-width`/`--stroke` argument to fixer manual title card creation
  - Closes #105
- Add option to adjust kerning of font
  - Added parsing of `kerning` key for custom font specification (scalar like stroke size)
  - Added `--kerning` argument to fixer manual title card creation
  - Added kerning argument to `StandardTitleCard` to adjust font kerning
  - Closs #106
- Modified font size parsing to accept floats
# Minor Fixes
- Remove extraneous breakpoint
  - Closes #114 
- Fixed error in print message causing early exit for failed card uploads
- Fix for font validation not properly being disabled 