### PR TITLE
Use remote card types from GitHub, skip series in Plex after 3 failed episodes, minor fixes

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -130,9 +130,9 @@ genre_group.add_argument(
     help='Create all genre cards for images in the given directory based on '
          'their file names')
 
-# Argument group for ShowSummary creation
-summary_group = parser.add_argument_group('ShowSummary')
-summary_group.add_argument(
+# Argument group for Miscelanneous functions
+misc_group = parser.add_argument_group('Miscellaneous')
+misc_group.add_argument(
     '--show-summary',
     type=Path,
     nargs=2,

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -123,8 +123,8 @@ class DataFileInterface:
             # Iterate through each episode of this season
             for episode_number, episode_data in season_data.items():
                 # If the 'title' key is missing (or no subkeys at all..) error
-                if ('title' not in episode_data
-                    or not isinstance(episode_data, dict)):
+                if (not isinstance(episode_data, dict)
+                    or 'title' not in episode_data):
                     log.error(f'Season {season_number}, Episode {episode_number}'
                               f' of "{self.file.resolve()}" is missing title')
                     continue

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -149,7 +149,7 @@ class Font:
             else:
                 self.interline_spacing = value
                 
-	# Kerning
+        # Kerning
         if (value := self.__yaml.get('kerning')) != None:
             if not bool(self._PERCENT_REGEX.match(value)):
                 log.error(f'Font kerning "{value}" of series '
@@ -160,7 +160,7 @@ class Font:
 
         # Stroke width
         if (value := self.__yaml.get('stroke_width')) != None:
-            if not bool(self._PERCENT_REGEX.match(value)):
+            if not bool(self._PERCENT_REGEX_POSITIVE.match(value)):
                 log.error(f'Font stroke width "{value}" of series '
                           f'{self.__series_info} is invalid - specify as "x%"')
                 self.valid = False

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -265,10 +265,12 @@ class Manager:
                         show_dict[str(episode)] = {}
                     show_dict[str(episode)]['card'] = episode.destination.name
 
-            if (self.preferences.create_summaries
-                and self.preferences.create_archive and not show.logo.exists()):
+            # Report missing logo if archives and summaries are enabled
+            if (show.archive and self.preferences.create_summaries
+                and not show.logo.exists()):
                 show_dict['logo'] = show.logo.name
 
+            # If this show is missing at least one thing, add to missing dict
             if len(show_dict.keys()) > 0:
                 missing[str(show)] = show_dict
 
@@ -277,7 +279,7 @@ class Manager:
 
         # Write updated data with this entry added
         with file.open('w', encoding='utf-8') as file_handle:
-            dump(missing, file_handle, allow_unicode=True, width=120)
+            dump(missing, file_handle, allow_unicode=True, width=160)
 
         log.info(f'Wrote missing assets to "{file.name}"')
 

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -266,7 +266,7 @@ class Manager:
                     show_dict[str(episode)]['card'] = episode.destination.name
 
             if (self.preferences.create_summaries
-                and self.preferences.create_archive not show.logo.exists()):
+                and self.preferences.create_archive and not show.logo.exists()):
                 show_dict['logo'] = show.logo.name
 
             if len(show_dict.keys()) > 0:

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -265,7 +265,8 @@ class Manager:
                         show_dict[str(episode)] = {}
                     show_dict[str(episode)]['card'] = episode.destination.name
 
-            if not show.logo.exists():
+            if (self.preferences.create_summaries
+                and self.preferences.create_archive not show.logo.exists()):
                 show_dict['logo'] = show.logo.name
 
             if len(show_dict.keys()) > 0:

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -182,6 +182,8 @@ class PlexInterface:
         return filtered
     
 
+    @retry(stop=stop_after_attempt(5),
+           wait=wait_fixed(3)+wait_exponential(min=1, max=32))
     def __get_library(self, library_name: str) -> 'Library':
         """
         Get the Library object under the given name.
@@ -198,6 +200,8 @@ class PlexInterface:
             return None
 
 
+    @retry(stop=stop_after_attempt(5),
+           wait=wait_fixed(3)+wait_exponential(min=1, max=32))
     def __get_series(self, library: 'Library',
                      series_info: 'SeriesInfo') -> 'Show':
         """

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -14,15 +14,18 @@ class PlexInterface:
     title card images.
     """
 
+    """Action to take for unwatched episodes"""
+    VALID_UNWATCHED_ACTIONS = ('ignore', 'blur', 'art', 'blur_all', 'art_all')
+    DEFAULT_UNWATCHED_ACTION = 'ignore'
+
     """Directory for all temporary objects"""
     TEMP_DIR = Path(__file__).parent / '.objects'
 
     """Filepath to the database of each episode's loaded card characteristics"""
     LOADED_DB = TEMP_DIR / 'loaded.json'
 
-    """Action to take for unwatched episodes"""
-    VALID_UNWATCHED_ACTIONS = ('ignore', 'blur', 'art', 'blur_all', 'art_all')
-    DEFAULT_UNWATCHED_ACTION = 'ignore'
+    """How many failed episodes result in skipping a series"""
+    SKIP_SERIES_THRESHOLD = 3
 
 
     def __init__(self, url: str, x_plex_token: str=None) -> None:
@@ -380,7 +383,14 @@ class PlexInterface:
             return None
 
         # Go through each episode within Plex, set title cards
+        error_count = 0
         for pl_episode in (pbar := tqdm(series.episodes(), **TQDM_KWARGS)):
+            # If error count is too high, skip this series
+            if error_count >= self.SKIP_SERIES_THRESHOLD:
+                log.error(f'Failed to upload {error_count} episodes, skipping '
+                          f'"{series_info}" for now')
+                break
+
             # Skip episodes that aren't in list of cards to update
             ep_key = f'{pl_episode.parentIndex}-{pl_episode.index}'
             if not (episode := filtered_episodes.get(ep_key)):
@@ -393,9 +403,10 @@ class PlexInterface:
             try:
                 self.__retry_upload(pl_episode, episode.destination.resolve())
             except Exception as e:
-                log.error(f'Unable to upload {episode.destination.resolve()} '
-                          f'to {series_info} - Plex returned "{e}"')
-                continue
+                error_count += 1
+                log.warning(f'Unable to upload {episode.destination.resolve()} '
+                            f'to {series_info} - Plex returned "{e}"')
+                return None
             
             # Update the loaded map with this card's size
             size = episode.destination.stat().st_size

--- a/modules/RemoteCardType.py
+++ b/modules/RemoteCardType.py
@@ -1,0 +1,73 @@
+import sys
+from importlib.util import spec_from_file_location, module_from_spec
+
+from pathlib import Path
+from requests import get
+
+from modules.Debug import log
+
+class RemoteCardType:
+    """
+    This class defines a remote CardType. This is an encapsulation of a CardType
+    class that, rather than being defined locally, queries the Maker GitHub for
+    Python classes to dynamically inject in the modules namespace. These 
+    """
+
+    """Base URL for all remote Card Type files to download"""
+    URL_BASE = ('https://raw.githubusercontent.com/CollinHeist/'
+                'TitleCardMaker-CardTypes/master')
+
+    """Temporary directory all card types are written to"""
+    TEMP_DIR = Path(__file__).parent / '.objects'
+
+    __slots__ = ('card_class', 'valid')
+
+
+    def __init__(self, remote: str) -> None:
+        """
+        Construct a new RemoteCardType. This downloads the source file at the
+        specified location and loads it as a class in the global modules, under
+        the interpreted class name.
+        
+        :param      remote: URL to remote card to inject. Should omit repo base.
+                            Should be specified like {username}/{class_name}.
+        """
+
+        # Make GET request for the contents of the specified value
+        url = f'{self.URL_BASE}/{remote}.py'
+        if (response := get(url)).status_code >= 400:
+            log.error(f'Cannot identify remote Card Type "{remote}"')
+            return False
+
+        # Succesful request (i.e. file remotely exists)
+        # Get username and class name from the git specification
+        username = remote.split('/')[0]
+        class_name = remote.split('/')[-1]  
+
+        # Download and write the CardType class into a temporary file
+        file_name = self.TEMP_DIR / f'{username}-{class_name}.py'
+        file_name.parent.mkdir(parents=True, exist_ok=True)
+
+        # Download file, import as module
+        try:
+            # Write remote file contents to temporary class
+            with (file_name).open('wb') as fh:
+                fh.write(response.content)
+            log.debug(f'Wrote {class_name}.py to {file_name.resolve()}')
+
+            # Create module for newly loaded file
+            spec = spec_from_file_location(class_name, file_name)
+            module = module_from_spec(spec)
+            sys.modules[class_name] = module
+            spec.loader.exec_module(module)
+
+            # Get class from module namespace
+            self.card_class = module.__dict__[class_name]
+            log.info(f'Loaded Remote Card Type "{remote}"')
+            self.valid = True
+        except Exception as e:
+            # Some error in loading, set object as invalid
+            log.error(f'Cannot load Remote Card Type "{remote}", returned "{e}"')
+            self.card_class = None
+            self.valid = False
+

--- a/modules/RemoteFile.py
+++ b/modules/RemoteFile.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from requests import get
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_exponential
+
+from modules.Debug import log
+
+class RemoteFile:
+    """
+    This class describes a RemoteFile. A RemoteFile is a file that is loaded
+    from the TCM Card Types repository, and is necessary to allow card types to
+    utilize non-standard files that can be downloaded at runtime alongside
+    CardType classes. This class has no real executable methods, and
+    upon initialization attempts to download the remote file if it DNE.
+    """
+
+    """Base URL to look for remote content at"""
+    BASE_URL = ('https://github.com/CollinHeist/TitleCardMaker-CardTypes/'
+                'raw/master')
+
+    """Temporary directory all files will be downloaded into"""
+    TEMP_DIR = Path(__file__).parent / '.objects'
+
+
+    def __init__(self, username: str, filename: str) -> None:
+        """
+        Construct a new RemoteFont object. This downloads the file for the given
+        user and file into the temporary directory of the Maker.
+        
+        :param      username:   Username containing the RemoteFont.
+        :param      filename:   Filename of the file within the user's folder
+                                to download.
+        """
+        
+        # Remote font will be stored at github/username/filename
+        self.remote_source = f'{self.BASE_URL}/{username}/{filename}'
+
+        # The font fill will be downloaded and exist in the temporary directory
+        self.local_file = self.TEMP_DIR / f'{username}-{filename}'
+
+        # Don't redownload if the file has already been downloaded
+        if self.local_file.exists():
+            return None
+
+        # Download the remote font for use locally
+        try:
+            self.download()
+            log.info(f'Downloaded RemoteFile({username}/{filename})')
+        except Exception as e:
+            log.error(f'Could not download RemoteFile({username}/{filename}), '
+                      f'returned "{e}"')
+
+
+    def __str__(self) -> str:
+        """
+        Returns a string representation of the object. This is just the complete
+        filepath for the locally downloaded file.
+        """
+
+        return str(self.local_file.resolve())
+
+
+    @retry(stop=stop_after_attempt(3),
+           wait=wait_fixed(3)+wait_exponential(min=1, max=16))
+    def download(self):
+        """
+        Download the specified remote file from the TCM CardTypes github, and
+        write it to a temporary local file.
+        """
+
+        # Create parent folder structure if necessary
+        self.local_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Attempt to download remote font
+        with self.local_file.open('wb') as file_handle:
+            file_handle.write(get(self.remote_source).content)
+

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -85,10 +85,10 @@ class Show(YamlReader):
         self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
         self.library_name = None
         self.library = None
-        self.archive = True
-        self.sonarr_sync = True
+        self.archive = self.preferences.create_archive
+        self.sonarr_sync = self.preferences.use_sonarr
         self.sync_specials = self.preferences.sonarr_sync_specials
-        self.tmdb_sync = True
+        self.tmdb_sync = self.preferences.use_tmdb
         self.unwatched_action = self.preferences.plex_unwatched
         self.hide_seasons = False
         self.__episode_range = {}

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -10,6 +10,7 @@ from modules.MultiEpisode import MultiEpisode
 import modules.preferences as global_preferences
 from modules.PlexInterface import PlexInterface
 from modules.Profile import Profile
+from modules.RemoteCardType import RemoteCardType
 from modules.SeriesInfo import SeriesInfo
 from modules.TitleCard import TitleCard
 from modules.Title import Title
@@ -144,7 +145,7 @@ class Show(YamlReader):
 
     def __copy__(self) -> 'Show':
         """
-        Copy the given Show.
+        Copy this Show object into a new (identical) Show.
         
         :returns:   A newly constructed Show object.
         """
@@ -164,7 +165,7 @@ class Show(YamlReader):
 
         if (library := self['library']):
             # If the given library isn't in libary map, invalid
-            if not (this_library := self.__library_map.get(library, None)):
+            if not (this_library := self.__library_map.get(library)):
                 log.error(f'Library "{library}" of series {self} is not found '
                           f'in libraries list')
                 self.valid = False
@@ -175,23 +176,31 @@ class Show(YamlReader):
                 self.media_directory = self.library /self.series_info.legal_path
 
                 # If card type was specified for this library, set that
-                if (card_type := this_library.get('card_type', None)):
-                    if card_type not in TitleCard.CARD_TYPES:
-                        log.error(f'Unknown card type "{card_type}" of series '
-                                  f'{self}')
-                        self.valid = False
-                    else:
+                if (card_type := this_library.get('card_type')):
+                    if card_type in TitleCard.CARD_TYPES:
                         self.card_class = TitleCard.CARD_TYPES[card_type]
                         etf = self.card_class.EPISODE_TEXT_FORMAT
                         self.episode_text_format = etf
+                    elif (remote_card_type := RemoteCardType(card_type)).valid:
+                        self.card_class = remote_card_type.card_class
+                        etf = self.card_class.EPISODE_TEXT_FORMAT
+                        self.episode_text_format = etf
+                    else:
+                        log.error(f'Unknown card type "{card_type}" of series '
+                                  f'{self}')
+                        self.valid = False
 
         if (card_type := self['card_type']):
-            if card_type not in TitleCard.CARD_TYPES:
-                log.error(f'Unknown card type "{card_type}" of series {self}')
-                self.valid = False
-            else:
+            # If known card type, set right away, otherwise check remote repo
+            if card_type in TitleCard.CARD_TYPES:
                 self.card_class = TitleCard.CARD_TYPES[card_type]
                 self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
+            elif (remote_card_type := RemoteCardType(card_type)).valid:
+                self.card_class = remote_card_type.card_class
+                self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
+            else:
+                log.error(f'Unknown card type "{card_type}" of series {self}')
+                self.valid = False
 
         if (value := self['media_directory']):
             self.media_directory = Path(value)

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -27,7 +27,8 @@ class StandardTitleCard(CardType):
     TITLE_COLOR = '#EBEBEB'
 
     """Default characters to replace in the generic font"""
-    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-'}
+    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
+                         '…': '...'}
 
     """Whether this CardType uses season titles for archival purposes"""
     USES_SEASON_TITLE = True

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -49,10 +49,10 @@ class StandardTitleCard(CardType):
     __GRADIENT_WITH_TITLE = CardType.TEMP_DIR / 'gradient_title.png'
     __SERIES_COUNT_TEXT = CardType.TEMP_DIR / 'series_count_text.png'
 
-    __slots__ = ('souce_file', 'output_file', 'title', 'season_text',
+    __slots__ = ('source_file', 'output_file', 'title', 'season_text',
                  'episode_text', 'font', 'font_size', 'title_color',
-                 'hide_season', 'vertical_shift', 'kerning',
-                 'interline_spacing')
+                 'hide_season', 'blur', 'vertical_shift', 'interline_spacing',
+                 'kerning', 'stroke_width')
 
 
     def __init__(self, source: Path, output_file: Path, title: str,

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -721,8 +721,8 @@ class TMDbInterface(WebInterface):
     def delete_blacklist() -> None:
         """Delete the blacklist file referenced by this class."""
 
-        TMDbInterface.__BLACKLIST.unlink(missing_ok=True)
+        TMDbInterface.__BLACKLIST_DB.unlink(missing_ok=True)
         log.info(f'Deleted blacklist file '
-                 f'"{TMDbInterface.__BLACKLIST.resolve()}"')
+                 f'"{TMDbInterface.__BLACKLIST_DB.resolve()}"')
 
 

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -3,7 +3,7 @@ from re import match, sub, IGNORECASE
 from modules.Debug import log
 import modules.preferences as global_preferences
 
-# CardType classes
+# Default CardType classes
 from modules.AnimeTitleCard import AnimeTitleCard
 from modules.StandardTitleCard import StandardTitleCard
 from modules.StarWarsTitleCard import StarWarsTitleCard

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -1,11 +1,9 @@
-from abc import ABC, abstractmethod
-
 from requests import get
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_exponential
 
 from modules.Debug import log
 
-class WebInterface(ABC):
+class WebInterface:
     """
     Abstract class that defines a WebInterface, which is a type of interface
     that makes GET requests and returns some JSON result. 
@@ -15,7 +13,6 @@ class WebInterface(ABC):
     CACHE_LENGTH = 10
     
     
-    @abstractmethod
     def __init__(self) -> None:
         """
         Constructs a new instance of a WebInterface. This creates creates a 


### PR DESCRIPTION
# Major Changes
-  Add ability to specify card types hosted on GitHub
   - Looks for cards in the format `{username}/{card_type}` - i.e. `CollinHeist/BetterStandardTitleCard`
     - Created  example card [here](https://github.com/CollinHeist/TitleCardMaker-CardTypes/tree/master/CollinHeist)
   - Created `RemoteFile` and `RemoteCardType` "classes" which download a remote asset from the card type GitHub, then use that asset locally
   - Modified `Show` class to attempt to create remote card type if defined `card_type` isn't locally defined
   - Looks for cards and assets hosted on sister repository [here](https://github.com/CollinHeist/TitleCardMaker-CardTypes)
   - Closes #122
# Major Fixes 
- Hotfix for loading cards into Plex
# Minor Changes
- Retry all Plex API requests (was just card-loading)
-  Skip series in Plex if 3 episodes fail (was retrying each episode)
   - To avoid retrying repeatedly for longer series, a series is skipped if 3 or more cards fail for a given series
- Don't report missing logo if archive or summary disabled 
  - Closes #121
-  Change default `Show` values based on global setting
  - Set default `Show` archiving, Sonarr+TMDb syncing based of global preferences (from True)
- `WebInterface` no longer an abstract class
# Minor Fixes
- Don't permit negative stroke width scalar 
- Add font replacement for ellipses character in `StandardTitleCard`
  - Closes #119 
- Fix for `--delete-blacklist` fixer argument using old file name 