### PR TITLE
Let Maker be run on scheduled interval, optionally disable parts of archive, many minor changes/fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ fonts/
 *._*
 *.yml
 *.yaml
+*.prof

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ fonttools = "*"
 plexapi = "*"
 tenacity = "*"
 tinydb = "*"
+schedule = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "99857f2a957f01c97e5b7f42bbadde0cf9e5d873b483eadc290b4ec9d8feb36d"
+            "sha256": "8a76daea4141158a322800bbaf7c132ffa2a70624cbefd5ea2a2591ebae73786"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -195,6 +195,14 @@
             ],
             "index": "pypi",
             "version": "==2.27.1"
+        },
+        "schedule": {
+            "hashes": [
+                "sha256:617adce8b4bf38c360b781297d59918fbebfb2878f1671d189f4f4af5d0567a4",
+                "sha256:e6ca13585e62c810e13a08682e0a6a8ad245372e376ba2b8679294f377dfc8e4"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "tenacity": {
             "hashes": [

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -101,13 +101,19 @@ class Font:
 
         # Font file
         if (value := self.__yaml.get('file')) != None:
-            if not Path(value).exists():
+            # If specified as direct path, check for existance
+            if (value := Path(value)).exists():
+                self.file = str(value.resolve())
+                self.replacements = {}
+            elif len(matches := tuple(value.parent.glob(f'{value.name}*'))) ==1:
+                # If specified indirectly (or DNE), glob for any extension
+                self.file = str(matches[0].resolve())
+                self.replacements = {}
+            else:
+                # No matching file, error and invalidate
                 log.error(f'Font file "{value}" of series {self.__series_info} '
                           f'not found')
                 self.valid = False
-            else:
-                self.file = str(Path(value).resolve())
-                self.replacements = {} # Reset for manually specified font
 
         # Font replacements
         if (value := self.__yaml.get('replacements')) != None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -53,6 +53,7 @@ class PreferenceParser(YamlReader):
         self.zero_pad_seasons = False
         self.archive_directory = None
         self.create_archive = False
+        self.archive_all_variations = True
         self.create_summaries = True
         self.summary_background_color = ShowSummary.BACKGROUND_COLOR
         self.logo_filename = ShowSummary.LOGO_FILENAME
@@ -159,6 +160,10 @@ class PreferenceParser(YamlReader):
         if (value := self['archive', 'path']):
             self.archive_directory = Path(value)
             self.create_archive = True
+
+        if self._is_specified('archive', 'all_variations'):
+            value = self['archive', 'all_variations']
+            self.archive_all_variations = bool(value)
 
         if self._is_specified('archive', 'summary', 'create'):
             self.create_summaries = bool(self['archive', 'summary', 'create'])

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -184,13 +184,14 @@ class PreferenceParser(YamlReader):
             self.plex_token = value
 
         if (value := self['plex', 'unwatched']):
-            if str(value).lower() not in PlexInterface.VALID_UNWATCHED_ACTIONS:
+            value = str(value).lower().replace(' ', '_')
+            if value not in PlexInterface.VALID_UNWATCHED_ACTIONS:
                 options = '", "'.join(PlexInterface.VALID_UNWATCHED_ACTIONS)
                 log.critical(f'Invalid "unwatched" action, must be one of "'
                              f'{options}"')
                 self.valid = False
             else:
-                self.plex_unwatched = value.lower()
+                self.plex_unwatched = value
 
         if self['sonarr']:
             if not all((self['sonarr', 'url'], self['sonarr', 'api_key'])):

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -3,6 +3,7 @@ from regex import match, IGNORECASE
 from modules.CardType import CardType
 from modules.Debug import log
 from modules.MultiEpisode import MultiEpisode
+import modules.preferences as global_preferences
 
 class Profile:
     """
@@ -39,7 +40,7 @@ class Profile:
         self.__use_custom_font = True
 
 
-    def get_valid_profiles(self, card_class: CardType) -> list:
+    def get_valid_profiles(self, card_class: CardType) -> [dict]:
         """
         Gets the valid applicable profiles for this profile. For example,
         for a profile with only generic attributes, it's invalid to
@@ -61,6 +62,19 @@ class Profile:
 
         # Determine whether this profile uses a custom font
         has_custom_font = card_class.is_custom_font(self.font)
+
+        # If not archiving all variations, return only indicated profile
+        if not global_preferences.pp.archive_all_variations:
+            seasons = 'generic'
+            if self.hide_season_title and card_class.USES_SEASON_TITLE:
+                seasons = 'hidden'
+            elif has_custom_season_titles:
+                seasons = 'custom'
+
+            return [{
+                'seasons': seasons,
+                'font': 'custom' if has_custom_font else 'generic'
+            }]
 
         # Get list of profile strings applicable to this object
         valid_profiles = [{'seasons': 'generic', 'font': 'generic'}]

--- a/modules/RemoteFile.py
+++ b/modules/RemoteFile.py
@@ -36,7 +36,7 @@ class RemoteFile:
         self.remote_source = f'{self.BASE_URL}/{username}/{filename}'
 
         # The font fill will be downloaded and exist in the temporary directory
-        self.local_file = self.TEMP_DIR / f'{username}-{filename}'
+        self.local_file = self.TEMP_DIR / username / filename.rsplit('/')[-1]
 
         # Don't redownload if the file has already been downloaded
         if self.local_file.exists():
@@ -58,6 +58,12 @@ class RemoteFile:
         """
 
         return str(self.local_file.resolve())
+
+
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return f'<RemoteFile {self.remote_source=}, {self.local_file=}>'
 
 
     def resolve(self) -> Path:

--- a/modules/RemoteFile.py
+++ b/modules/RemoteFile.py
@@ -60,6 +60,16 @@ class RemoteFile:
         return str(self.local_file.resolve())
 
 
+    def resolve(self) -> Path:
+        """
+        Get the absolute path of the locally downloaded file.
+        
+        :returns:   Path to the locally downloaded file.
+        """
+
+        return self.local_file.resolve()
+
+
     @retry(stop=stop_after_attempt(3),
            wait=wait_fixed(3)+wait_exponential(min=1, max=16))
     def download(self):

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -579,6 +579,10 @@ class Show(YamlReader):
         :param      plex_interface: PlexInterface object to update.
         """
 
+        # Skip if no library specified
+        if self.library_name == None:
+            return None
+
         # Update Plex
         plex_interface.set_title_cards_for_series(
             self.library_name,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -221,11 +221,12 @@ class Show(YamlReader):
             self.tmdb_sync = bool(self['tmdb_sync'])
 
         if (value := self['unwatched']):
-            if value.lower() not in PlexInterface.VALID_UNWATCHED_ACTIONS:
+            match_value = str(value).lower().replace(' ', '_')
+            if match_value not in PlexInterface.VALID_UNWATCHED_ACTIONS:
                 log.error(f'Invalid unwatched action "{value}" in series {self}')
                 self.valid = False
             else:
-                self.unwatched_action = value.lower()
+                self.unwatched_action = match_value
 
         if self._is_specified('seasons', 'hide'):
             self.hide_seasons = bool(self['seasons', 'hide'])

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -37,7 +37,7 @@ class StandardTitleCard(CardType):
     ARCHIVE_NAME = 'standard'
 
     """Source path for the gradient image overlayed over all title cards"""
-    __GRADIENT_IMAGE: Path = REF_DIRECTORY / 'GRADIENT.png'
+    __GRADIENT_IMAGE = REF_DIRECTORY / 'GRADIENT.png'
 
     """Default fonts and color for series count text"""
     SEASON_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Semibold.otf'
@@ -396,7 +396,9 @@ class StandardTitleCard(CardType):
             or (font.color != StandardTitleCard.TITLE_COLOR)
             or (font.replacements != StandardTitleCard.FONT_REPLACEMENTS)
             or (font.vertical_shift != 0)
-            or (font.interline_spacing != 0))
+            or (font.interline_spacing != 0)
+            or (font.kerning != 1.0)
+            or (font.stroke_width != 1.0))
 
 
     @staticmethod

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -257,7 +257,7 @@ class StandardTitleCard(CardType):
         command = ' '.join([
             f'convert "{titled_image.resolve()}"',
             *self.__series_count_text_global_effects(),
-            f'-font "{self.EPISODE_COUNT_FONT}"',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
             f'-gravity center',
             *self.__series_count_text_black_stroke(),
             f'-annotate +0+697.2 "{self.episode_text}"',
@@ -281,15 +281,15 @@ class StandardTitleCard(CardType):
         command = ' '.join([
             f'convert -debug annotate xc: ',
             *self.__series_count_text_global_effects(),
-            f'-font "{self.SEASON_COUNT_FONT}"',    # Season text
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
             f'-gravity east',
             *self.__series_count_text_effects(),
             f'-annotate +1600+697.2 "{self.season_text} "',
-            f'-font "{self.EPISODE_COUNT_FONT}"',   # Separator dot
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
             f'-gravity center',
             *self.__series_count_text_effects(),
             f'-annotate +0+689.5 "• "',
-            f'-gravity west',                       # Episode text
+            f'-gravity west',
             *self.__series_count_text_effects(),
             f'-annotate +1640+697.2 "{self.episode_text}"',
             f'null: 2>&1'
@@ -330,12 +330,12 @@ class StandardTitleCard(CardType):
             f'-background transparent',
             f'xc:transparent',
             *self.__series_count_text_global_effects(),
-            f'-font "{self.SEASON_COUNT_FONT}"',
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
             *self.__series_count_text_black_stroke(),
             f'-annotate +0+{height-25} "{self.season_text} "',
             *self.__series_count_text_effects(),
             f'-annotate +0+{height-25} "{self.season_text} "',
-            f'-font "{self.EPISODE_COUNT_FONT}"',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
             *self.__series_count_text_black_stroke(),
             f'-annotate +{width1}+{height-25-6.5} "•"',
             *self.__series_count_text_effects(),


### PR DESCRIPTION
# Major Changes
- Add option to globally disable archive sub-profiles
  - Added `all_variations` option to `archive` preferences
  - Closes #120
- Let Maker be scheduled
  - Add `--time` and `--frequency` arguments to schedule the Maker to rerun on an arbitrary interval
  - Added `schedule` module requirement
  - Closes #129
# Major Fixes 
N/A
# Minor Changes
- Allow for extension-less font file specification
  - Closes #118
- Handle bad types for custom font values
  - Closes #125 
- Allow spaces in `unwatched` actions
  - Closes #128
- Added fixer option to delete cards
  - Added `--delete-cards` and `--delete-extension` arguments to fixer to permit deleting old cards from arbitrary directories
  - Closes #116
# Minor Fixes
- Created `RemoteFile.resolve()` method
-  Updated custom font evaluation for `StandardTitleCard` to look at kerning and stroke width