### PR TITLE
Import archives, split fixer, manually specify source images, customize font size in AnimeTitleCard, minor changes+fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Set base image
-FROM python:3.10-slim
+FROM python:3.9-slim
 
 # Set working directory
 WORKDIR /maker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Set base image
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 # Set working directory
 WORKDIR /maker
@@ -24,12 +24,6 @@ RUN export MAGICK_HOME="$HOME/ImageMagick-7.1.0" \
 # Install TCM package dependencies
 RUN pip3 install --no-cache-dir --upgrade pipenv
 RUN pipenv install
-
-# Volumes?
-VOLUME /source
-VOLUME /archive
-VOLUME /fonts
-VOLUME /config
 
 # Entrypoint
 ENTRYPOINT ["/bin/bash"]

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ schedule = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.9"
+python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ fonttools = "*"
 plexapi = "*"
 tenacity = "*"
 tinydb = "*"
+schedule = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ schedule = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.10"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "99857f2a957f01c97e5b7f42bbadde0cf9e5d873b483eadc290b4ec9d8feb36d"
+            "sha256": "8a76daea4141158a322800bbaf7c132ffa2a70624cbefd5ea2a2591ebae73786"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -195,6 +195,14 @@
             ],
             "index": "pypi",
             "version": "==2.27.1"
+        },
+        "schedule": {
+            "hashes": [
+                "sha256:617adce8b4bf38c360b781297d59918fbebfb2878f1671d189f4f4af5d0567a4",
+                "sha256:e6ca13585e62c810e13a08682e0a6a8ad245372e376ba2b8679294f377dfc8e4"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "tenacity": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a76daea4141158a322800bbaf7c132ffa2a70624cbefd5ea2a2591ebae73786"
+            "sha256": "860d7c14f98c299c718ff38bfda695b556872dd7c82d27a38eadf33e3f008412"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.10"
         },
         "sources": [
             {
@@ -18,10 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:6ae10321df3e464305a46e997da41ea56c1d311fb9ff1dd4e04d6f14653ec63a",
+                "sha256:8d15a5a7fde18536a249c49e07e8e462b8fc13de21b3c80e8a68315dfa227c99"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.5'",
+            "version": "==2022.5.18"
         },
         "charset-normalizer": {
             "hashes": [
@@ -63,11 +64,11 @@
         },
         "plexapi": {
             "hashes": [
-                "sha256:10a83dd3e7b58778d90b900315dc553b96dc2a7648a3935c6ece61e14251135b",
-                "sha256:e0417eb972ca6a1e01334f32046f5f3feb9210d92a82e9f05ebe628d6c685b68"
+                "sha256:40324ea6e471c1756c57d28ee0faa57d0e4db3fcc8b754897f8ce09493e65a8c",
+                "sha256:6d12283fe58177a70f4096f567afd203f07979ddea08ba1a3f8defde2f1f2228"
             ],
             "index": "pypi",
-            "version": "==4.10.1"
+            "version": "==4.11.0"
         },
         "pyyaml": {
             "hashes": [
@@ -241,7 +242,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.9"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -242,7 +242,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.9"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "860d7c14f98c299c718ff38bfda695b556872dd7c82d27a38eadf33e3f008412"
+            "sha256": "8a76daea4141158a322800bbaf7c132ffa2a70624cbefd5ea2a2591ebae73786"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:6ae10321df3e464305a46e997da41ea56c1d311fb9ff1dd4e04d6f14653ec63a",
-                "sha256:8d15a5a7fde18536a249c49e07e8e462b8fc13de21b3c80e8a68315dfa227c99"
+                "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
+                "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2022.5.18"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.5.18.1"
         },
         "charset-normalizer": {
             "hashes": [
@@ -64,11 +64,11 @@
         },
         "plexapi": {
             "hashes": [
-                "sha256:40324ea6e471c1756c57d28ee0faa57d0e4db3fcc8b754897f8ce09493e65a8c",
-                "sha256:6d12283fe58177a70f4096f567afd203f07979ddea08ba1a3f8defde2f1f2228"
+                "sha256:1f74ab75b25da9cae05edd2b563ffabfe0f5b80bcf5f95df30b2b168f2ae67bd",
+                "sha256:b335138a9411d03b9ea850f508629b297c88c0fc650e176d78a7ca72aa850b01"
             ],
             "index": "pypi",
-            "version": "==4.11.0"
+            "version": "==4.11.1"
         },
         "pyyaml": {
             "hashes": [
@@ -242,7 +242,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.9"
         }
     },

--- a/fixer.py
+++ b/fixer.py
@@ -112,7 +112,7 @@ if hasattr(args, 'import_archive'):
     class Episode:
         destination: Path
         episode_info: EpisodeInfo
-        _spoil_type: str
+        spoil_type: str
         
     # Create PlexInterface
     if not pp.use_plex:
@@ -135,6 +135,7 @@ if hasattr(args, 'import_archive'):
     # Get all images from import archive
     if len(all_images := list(archive.glob('**/*.jpg'))) == 0:
         log.warning(f'No images to import')
+        exit(1)
     
     # For each image, fill out episode map to load into Plex
     episode_map = {}

--- a/fixer.py
+++ b/fixer.py
@@ -20,6 +20,8 @@ except ImportError:
     print(f'Required Python packages are missing - execute "pipenv install"')
     exit(1)
 
+OLD_COMMANDS = ('--title-card', '--genre-card', '--show-summary')
+
 # Create ArgumentParser object 
 parser = ArgumentParser(description='Manual fixes for the TitleCardMaker')
 parser.add_argument('-p', '--preference-file', type=Path, 
@@ -94,6 +96,8 @@ tmdb_group.add_argument(
 
 # Parse given arguments
 args, unknown = parser.parse_known_args()
+if any(old_arg in unknown for old_arg in OLD_COMMANDS):
+    log.warning(f'Manual card creation has moved to "mini_maker.py"')
 
 # Parse preference file for options that might need it
 pp = PreferenceParser(args.preference_file)

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ parser.add_argument(
     action='store_true',
     help='Run the TitleCardMaker')
 parser.add_argument(
-    '--time', '--runtime',
+    '-t', '--time', '--runtime',
     dest='runtime',
     type=runtime,
     default=SUPPRESS,

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -137,6 +137,12 @@ show_summary_group.add_argument(
     default=SUPPRESS,
     metavar=('IMAGE_DIRECTORY', 'LOGO'),
     help='Create a ShowSummary for the given directory')
+show_summary_group.add_argument(
+    '--background-color',
+    type=str,
+    default=ShowSummary.BACKGROUND_COLOR,
+    metavar='COLOR',
+    help='Specify background color for the created ShowSummary')
          
 # Parse given arguments
 args, unknown = parser.parse_known_args()
@@ -217,4 +223,4 @@ if hasattr(args, 'show_summary'):
     show = Show(args.show_summary[1], args.show_summary[0], episodes)
 
     # Create ShowSummary
-    ShowSummary(show).create()
+    ShowSummary(show, args.background_color).create()

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -23,13 +23,6 @@ parser.add_argument('-p', '--preference-file', type=Path,
 title_card_group = parser.add_argument_group('Title Cards',
                                              'Manual TitleCardMaker interaction')
 title_card_group.add_argument(
-    '--card-type',
-    type=str,
-    default='standard',
-    choices=TitleCard.CARD_TYPES.keys(),
-    metavar='TYPE',
-    help='Create a title card of a specific type')
-title_card_group.add_argument(
     '--title-card',
     type=Path,
     nargs=2,
@@ -37,6 +30,13 @@ title_card_group.add_argument(
     metavar=('SOURCE', 'DESTINATION'),
     help='Create a title card with the given source image, written to the given'
          ' destination')
+title_card_group.add_argument(
+    '--card-type',
+    type=str,
+    default='standard',
+    choices=TitleCard.CARD_TYPES.keys(),
+    metavar='TYPE',
+    help='Create a title card of a specific type')
 title_card_group.add_argument(
     '--blur',
     action='store_true',

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -62,7 +62,8 @@ class AnimeTitleCard(CardType):
     
     def __init__(self, source: Path, output_file: Path, title: str, 
                  season_text: str, episode_text: str, hide_season: bool,
-                 kanji: str=None, blur: bool=False, *args, **kwargs) -> None:
+                 kanji: str=None, blur: bool=False, font_size: float=1.0,
+                 *args, **kwargs) -> None:
         """
         Constructs a new instance.
         
@@ -76,6 +77,7 @@ class AnimeTitleCard(CardType):
         :param      kanji:              Optional kanji text to place above the
                                         episode title on this card.
         :param      blur:               Whether to blur the source image.
+        :param      font_size:          Scalar to apply to the title font size.
         :param      args and kwargs:    Unused arguments to permit generalized
                                         function calls for any CardType.
         """
@@ -100,6 +102,17 @@ class AnimeTitleCard(CardType):
         self.hide_season = hide_season
         self.blur = blur
 
+        # Font customizations
+        self.font_size = font_size
+
+
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return (f'<AnimeTitleCard {self.source_file=}, {self.output_file=}, '
+                f'{self.title=}, {self.kanji=}, {self.season_text=}, '
+                f'{self.episode_text=}, {self.blur=}, {self.font_size=}>')
+
 
     def __title_text_global_effects(self) -> list:
         """
@@ -113,7 +126,7 @@ class AnimeTitleCard(CardType):
             f'-font "{self.TITLE_FONT}"',
             f'-kerning 2',
             f'-interline-spacing -30',
-            f'-pointsize 150',
+            f'-pointsize {150 * self.font_size}',
             f'-gravity southwest',
         ]
 
@@ -272,8 +285,10 @@ class AnimeTitleCard(CardType):
                     text, and kanji added.
         """
 
-        # Shift kanji text up based on the number of lines in this 
-        kanji_offset = 375 + (165 * (len(self.title.split('\n'))-1))
+        # Shift kanji text up based on the number of lines in the title
+        base_offset = 175
+        variable_offset = 200 + (165 * (len(self.title.split('\n'))-1))
+        kanji_offset = base_offset + variable_offset * self.font_size
 
         command = ' '.join([
             f'convert "{gradient_image.resolve()}"',
@@ -284,7 +299,7 @@ class AnimeTitleCard(CardType):
             f'-annotate +75+175 "{self.title}"',
             f'-font "{self.KANJI_FONT.resolve()}"',
             *self.__title_text_black_stroke(),
-            f'-pointsize 85',
+            f'-pointsize {85 * self.font_size}',
             f'-annotate +75+{kanji_offset} "{self.kanji}"',
             *self.__title_text_effects(),
             f'-annotate +75+{kanji_offset} "{self.kanji}"',
@@ -384,8 +399,8 @@ class AnimeTitleCard(CardType):
                     'title', False otherwise.
         """
 
-        default_case = AnimeTitleCard.DEFAULT_FONT_CASE
-        return font.case != AnimeTitleCard.CASE_FUNCTIONS[default_case]
+        return ((font.case_name != AnimeTitleCard.DEFAULT_FONT_CASE)
+            or (font.font_size != 1.0))
 
 
     @staticmethod

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -417,8 +417,10 @@ class AnimeTitleCard(CardType):
         :returns:   True if custom season titles are indicated, False otherwise.
         """
 
+        standard_etf = AnimeTitleCard.EPISODE_TEXT_FORMAT.upper()
+        
         return (custom_episode_map or
-                episode_text_format.upper() != self.EPISODE_TEXT_FORMAT.upper())
+                episode_text_format.upper() != standard_etf)
 
 
     def create(self) -> None:

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -400,7 +400,7 @@ class AnimeTitleCard(CardType):
         """
 
         return ((font.case_name != AnimeTitleCard.DEFAULT_FONT_CASE)
-            or (font.font_size != 1.0))
+            or (font.size != 1.0))
 
 
     @staticmethod

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -404,37 +404,21 @@ class AnimeTitleCard(CardType):
 
 
     @staticmethod
-    def is_custom_season_titles(season_map: dict, episode_range: dict, 
+    def is_custom_season_titles(custom_episode_map: bool, 
                                 episode_text_format: str) -> bool:
         """
         Determines whether the given attributes constitute custom or generic
         season titles.
         
-        :param      season_map:           The season map in use.
-        :param      episode_range:        The episode range in use.
-        :param      episode_text_format:  The episode text format in use.
+        :param      custom_episode_map:     Whether the EpisodeMap was
+                                            customized.
+        :param      episode_text_format:    The episode text format in use.
         
         :returns:   True if custom season titles are indicated, False otherwise.
         """
 
-        # Nonstandard episode text format
-        if episode_text_format != 'EPISODE {episode_number}':
-            return True
-
-        # Nonstandard episode range
-        if episode_range != {}:
-            return True
-
-        # If any season title isn't standard, 
-        for number, title in season_map.items():
-            if number == 0:
-                if title.lower() != 'specials':
-                    return True
-            else:
-                if title.lower() != f'season {number}':
-                    return True
-
-        return False
+        return (custom_episode_map or
+                episode_text_format.upper() != self.EPISODE_TEXT_FORMAT.upper())
 
 
     def create(self) -> None:

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from modules.Title import Title
+from modules.Debug import log
 from modules.TitleCard import TitleCard
 
 class Episode:
@@ -11,8 +11,8 @@ class Episode:
     """
 
     __slots__ = ('episode_info', 'card_class', '__base_source', 'source',
-                 'destination', 'blur', 'extra_characteristics', 'spoiler',
-                 '_spoil_type')
+                 'destination', 'downloadable_source', 'extra_characteristics',
+                 'watched', 'blur', 'spoil_type', )
     
 
     def __init__(self, episode_info: 'EpisodeInfo', card_class: 'CardType',
@@ -40,14 +40,15 @@ class Episode:
                        f'{TitleCard.INPUT_CARD_EXTENSION}')
         self.source = base_source / source_name
         self.destination = destination
+        self.downloadable_source = True
 
         # Store extra characteristics
         self.extra_characteristics = extras
 
-        # Episodes are spoilers and not blurred until updated
-        self.spoiler = True
+        # Episodes are watched, not blurred, and spoiled - until updated
+        self.watched = True
         self.blur = False
-        self._spoil_type = 'spoiled'
+        self.spoil_type = 'spoiled'
 
 
     def __str__(self) -> str:
@@ -60,50 +61,71 @@ class Episode:
         """Returns an unambiguous string representation of the object"""
 
         return (f'<Episode {self.episode_info=}, {self.card_class=}, '
-                f'{self.source=}, {self.destination=}, {self.spoiler=},'
+                f'{self.source=}, {self.destination=}, {self.watched=},'
                 f'{self.blur=}, {self.extra_characteristics=}>')
 
 
-    def update_source(self, new_source: str=None) -> None:
+    def update_statuses(self, watched: bool, watched_style: str, 
+                        unwatched_style: str) -> None:
         """
-        { function_description }
+        Update the statuses of this Episode. In particular the watched and
+        spoil type statuses.
         
-        :param      source:  The source
+        :param      watched:          New watched status for this Episode.
+        :param      watched_style:    Watched style to assign spoil type from.
+        :param      unwatched_style:  Unwatched style to assign spoil tyle from.
         """
 
-        if new_source != None:
-            if isinstance(new_source, Path):
-                self.source = new_source
-            else:
-                self.source = self.__base_source / new_source
+        # Update watched attribute
+        self.watched = watched
+
+        # Update spoil type based on given style and new watch status
+        SPOIL_TYPE_STYLE_MAP={'unique': 'spoiled', 'art': 'art', 'blur': 'blur'}
+        if self.watched:
+            self.spoil_type = SPOIL_TYPE_STYLE_MAP[watched_style]
+        else:
+            self.spoil_type = SPOIL_TYPE_STYLE_MAP[unwatched_style]
+
+
+    def update_source(self, new_source, *, downloadable: bool) -> bool:
+        """
+        Update the source image for this Episode, as well as the downloadable
+        flag for the source.
+        
+        :param      new_source:     New source file.
+        :type       new_source:     If Path, then source is taken as-is. If a
+                                    str, the the file is looked for within this
+                                    Episode's base source directory. If that
+                                    file doesn't exist under the base source,
+                                    then the string source is taken as a Path
+                                    and converted. If None nothing happens.
+        :param      downloadable:   Keyword-only argument for whether the new
+                                    source is downloadable or not.
+
+        :returns:   True if a new non-None source was provided, False otherwise.
+        """
+
+        # If no actual new source was provided, return
+        if new_source == None:
+            return False
+
+        # Update source path based on input (Path/str of filename in source,etc)
+        if isinstance(new_source, Path):
+            self.source = new_source
+        elif (self.__base_source / new_source).exists():
+            self.source = self.__base_source / new_source
+        else:
+            self.source = Path(new_source)
+
+        # Set the downloadable flag for the new source
+        self.downloadable_source = downloadable
+
+        return True
 
 
     def delete_card(self) -> None:
         """Delete the title card for this Episode."""
 
         self.destination.unlink(missing_ok=True)
-
-
-    def make_spoiler_free(self, action: str) -> None:
-        """
-        Modify this Episode to be spoiler-free according to the given spoil
-        action. This updates the spoiler and blur attribute flags, and changes
-        the source Path for the Episode if art is the specified action.
-        
-        :param      action: Spoiler action to update according to.
-        """
-
-        # Return if action isn't blur or art
-        if action == 'ignore':
-            return None
-
-        # Update spoiler and blur attributes
-        self.spoiler = False
-        self.blur = action in ('blur', 'blur_all')
-        self._spoil_type = 'art' if 'art' in action else 'blur'
-
-        # Blurring, set source to blurred source in 
-        if action in ('art', 'art_all'):
-            self.source = self.source.parent / 'backdrop.jpg'
 
         

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -10,8 +10,9 @@ class Episode:
     map that info to a source and destination file.
     """
 
-    __slots__ = ('episode_info', 'card_class', 'source', 'destination', 'blur',
-                 'extra_characteristics', 'spoiler', '_spoil_type')
+    __slots__ = ('episode_info', 'card_class', '__base_source', 'source',
+                 'destination', 'blur', 'extra_characteristics', 'spoiler',
+                 '_spoil_type')
     
 
     def __init__(self, episode_info: 'EpisodeInfo', card_class: 'CardType',
@@ -33,6 +34,7 @@ class Episode:
         self.card_class = card_class
 
         # Set source/destination paths
+        self.__base_source = base_source
         source_name = (f's{episode_info.season_number}'
                        f'e{episode_info.episode_number}'
                        f'{TitleCard.INPUT_CARD_EXTENSION}')
@@ -60,6 +62,20 @@ class Episode:
         return (f'<Episode {self.episode_info=}, {self.card_class=}, '
                 f'{self.source=}, {self.destination=}, {self.spoiler=},'
                 f'{self.blur=}, {self.extra_characteristics=}>')
+
+
+    def update_source(self, new_source: str=None) -> None:
+        """
+        { function_description }
+        
+        :param      source:  The source
+        """
+
+        if new_source != None:
+            if isinstance(new_source, Path):
+                self.source = new_source
+            else:
+                self.source = self.__base_source / new_source
 
 
     def delete_card(self) -> None:

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -89,6 +89,7 @@ class EpisodeMap:
             # Parse title/source mapping
             if isinstance(mapping, str):
                 self.__titles[season_number] = mapping
+                self.is_custom = True
             elif isinstance(mapping, dict):
                 if (value := mapping.get('title')):
                     self.__titles[season_number] = value
@@ -97,6 +98,7 @@ class EpisodeMap:
                     self.__sources[season_number] = value
                 if (value := mapping.get('source_applies_to', '').lower()):
                     if value not in ('all', 'unwatched'):
+                        # Invalid applies, error and exit
                         log.error(f'Source applies to "{value}" of season '
                                   f'{season_number} is invalid')
                         self.valid = False
@@ -125,6 +127,7 @@ class EpisodeMap:
             for episode_number in range(start, end+1):
                 if isinstance(mapping, str):
                     self.__titles[episode_number] = mapping
+                    self.is_custom = True
                 elif isinstance(mapping, dict):
                     if (value := mapping.get('title')):
                         self.__titles[episode_number] = value
@@ -133,6 +136,7 @@ class EpisodeMap:
                         self.__sources[episode_number] = value
                     if (value := mapping.get('source_applies_to', '').lower()):
                         if value not in ('all', 'unwatched'):
+                            # Invalid applies, error and exit
                             log.error(f'Source applies to "{value}" of episodes '
                                       f'{episode_range} is invalid')
                             self.valid = False

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -1,7 +1,14 @@
 from modules.Debug import log
 
 class EpisodeMap:
+    """
+    This class describes an EpisodeMap. In particular a mapping of episode
+    indices to manually specified season titles or sources. This object
+    basically contains the `seasons` and `episode_ranges` attributes for a given
+    Show.
+    """
     
+    """How to apply manual source if not explicitly stated"""
     DEFAULT_APPLIES_TO = 'all'
 
 
@@ -82,7 +89,7 @@ class EpisodeMap:
             # Parse title/source mapping
             if isinstance(mapping, str):
                 self.__titles[season_number] = mapping
-            elif isinstance(value, dict):
+            elif isinstance(mapping, dict):
                 if (value := mapping.get('title')):
                     self.__titles[season_number] = value
                     self.is_custom = True
@@ -142,7 +149,7 @@ class EpisodeMap:
     
     def get_generic_season_title(self, episode_info: 'EpisodeInfo') -> str:
         """
-        Get the generic season title associated with the given Episode.
+        Get the generic season title associated with the given Episode index.
         
         :param      episode_info:   EpisodeInfo to the get season title of.
         
@@ -174,7 +181,7 @@ class EpisodeMap:
         if which == 'season_title':
             target = self.__titles
         elif which == 'source':
-            target == self.__sources
+            target = self.__sources
         else:
             target = self.__applies
 

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -1,0 +1,164 @@
+class EpisodeMap:
+    
+    DEFAULT_APPLIES_TO = 'all'
+    
+    def __init__(self, seasons: dict=None,
+                 episode_ranges: dict=None) -> dict:
+        
+        # Assume object is valid until invalidated
+        self.valid = True
+        
+        # Default indexing is by season number
+        self.__index_by = 'season'
+        
+        # If no custom seasons/episode ranges, generate defaults
+        self.__titles, self.__sources, self.__applies = {}, {}, {}
+        if not seasons and not episode_ranges:
+            return None
+        
+        # If both mappings are provided, invalidate 
+        if seasons and episode_ranges:
+            print(f'Cannot specify both seasons and episode ranges')
+            self.valid = False
+            return None
+        
+        # Validate type of provided mapping
+        if seasons and not isinstance(seasons, dict):
+            print(f'Invalid "seasons"')
+            self.valid = False
+            return None
+        if episode_ranges and not isinstance(episode_ranges, dict):
+            print(f'Invalid "episode_ranges"')
+            self.valid = False
+            return None
+        
+        if seasons:
+            self.__index_by = 'season'
+            self.__parse_seasons(seasons)
+        elif episode_ranges:
+            self.__index_by = 'episode'
+            self.__parse_episode_ranges(episode_ranges)
+            
+    
+    def __parse_seasons(self, seasons: dict) -> None:
+        """
+        
+        """
+        
+        # Go through each season of mapping
+        for season_number, mapping in seasons.items():
+            # Ensure season number is a number
+            if not isinstance(season_number, int):
+                print(f'Invalid season "{season_number}"')
+                self.valid = False
+                return None
+            
+            if isinstance(mapping, str):
+                self.__titles[season_number] = mapping
+            elif isinstance(value, dict):
+                if (value := mapping.get('title')):
+                    self.__titles[season_number] = value
+                if (value := mapping.get('source')):
+                    self.__sources[season_number] = value
+                if (value := mapping.get('source_applies_to', '').lower()):
+                    if value not in ('all', 'unwatched'):
+                        log.error(f'Source applies to "{value}" of season '
+                                  f'{season_number} is invalid')
+                        self.valid = False
+                        return None
+                    self.__applies[season_number] = value
+        
+        
+    def __parse_episode_ranges(self, episode_ranges: dict) -> None:
+        """
+        
+        """
+        
+        # Go through each episode range of mapping
+        for episode_range, mapping in episode_ranges.items():
+            try:
+                start, end = map(int, episode_range.split('-'))
+            except Exception:
+                log.error(f'Invalid episode range "{episode_range}"')
+                return None
+            
+            # Assign title for every episode in this range
+            for episode_number in range(start, end+1):
+                if isinstance(mapping, str):
+                    self.__titles[episode_number] = mapping
+                elif isinstance(mapping, dict):
+                    if (value := mapping.get('title'))
+                        self.__titles[episode_number] = value
+                    if (value := mapping.get('source')):
+                        self.__sources[episode_number] = value
+                    if (value := mapping.get('source_applies_to', '').lower()):
+                        if value not in ('all', 'unwatched'):
+                            log.error(f'Source applies to "{value}" of episodes '
+                                      f'{episode_range} is invalid')
+                            self.valid = False
+                            return None
+                        self.__applies[episode_number] = value
+                    
+                    
+    def __repr__(self) -> str:
+        return (f'<EpisodeRange {self.__titles=}, {self.__sources=}, '
+               f'{self.__applies=}>')
+    
+    
+    def __get_generic_season_title(self, episode_info: 'EpisodeInfo') -> str:
+        """
+        Get the generic season title associated with the given Episode.
+        
+        :param      episode_info:   EpisodeInfo to the get season title of.
+        
+        :returns:   'Specials' for season 0 episodes, 'Season {n}' otherwise.
+        """
+        
+        season = episode_number.season_number
+        return 'Specials' if season == 0 else f'Season {season}'
+    
+    
+    def get_season_title(self, episode_info: 'EpisodeInfo') -> str:
+        """
+        
+        """
+        
+        # Index by season, return matching season title
+        if self.__index_by == 'season':
+            if episode_info.season_number in self.__titles:
+                return self.__titles[episode_info.season_number]
+            return self.__get_generic_season_title(episode_info)
+        
+        # Index by absolute episode number
+        if episode_info.abs_number == None:
+            # Episode has no absolute number
+            if episode_info.season_number != 0:
+                log.warning(f'Episode range specified, but {episode_info} '
+                            f'has no absolute episode number')
+
+            return self.__get_generic_season_title(episode_info)
+        elif episode_info.abs_number not in self.__titles:
+            log.warning(f'{episode_info} does not fall into specified '
+                        f'episode range')
+            return self.__get_generic_season_title(episode_info)
+        
+        return self.__titles[episode_info.abs_number]
+    
+    
+    def get_applies_to(self, episode_info: 'EpisodeInfo') -> str:
+        """
+        
+        """
+        
+        # Index by season
+        if self.__index_by == 'season':
+            if episode_info.season_number in self.__applies:
+                return self.__applies[episode_info.season_number]
+            return self.DEFAULT_APPLIES_TO
+        
+        # Index by absolute episode number
+        if (episode_info.abs_number == None
+            or episode_info.abs_number not in self.__applies):
+            return self.DEFAULT_APPLIES_TO
+        
+        return self.__applies[episode_info.abs_number]

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -34,19 +34,19 @@ class EpisodeMap:
         if not seasons and not episode_ranges:
             return None
         
-        # If both mappings are provided, invalidate 
-        if seasons and episode_ranges:
-            log.error(f'Cannot specify both seasons and episode ranges')
-            self.valid = False
-            return None
-        
         # Validate type of provided mapping
         if seasons and not isinstance(seasons, dict):
             log.error(f'Season map "{seasons}" is invalid')
             self.valid = False
             return None
         if episode_ranges and not isinstance(episode_ranges, dict):
-            print(f'Episode ranges "{episode_ranges}" is invalid')
+            log.error(f'Episode ranges "{episode_ranges}" is invalid')
+            self.valid = False
+            return None
+
+        # If both mappings are provided, invalidate 
+        if seasons and episode_ranges:
+            log.error(f'Cannot specify both seasons and episode ranges')
             self.valid = False
             return None
         
@@ -74,8 +74,8 @@ class EpisodeMap:
                 continue
 
             # Ensure season number is a number
-            if isinstance(season_number, int):
-                print(f'Invalid season "{season_number}"')
+            if not isinstance(season_number, int):
+                log.warning(f'Invalid season number "{season_number}"')
                 self.valid = False
                 return None
             

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -148,10 +148,12 @@ class Manager:
             # Modify unwatched episodes based on Plex watch status
             if self.preferences.use_plex:
                 if self.preferences.use_tmdb:
-                    show.modify_unwatched_episodes(self.plex_interface,
-                                                   self.tmdb_interface)
+                    show.select_source_images(self.plex_interface,
+                                              self.tmdb_interface)
                 else:
-                    show.modify_unwatched_episodes(self.plex_interface)
+                    show.select_source_images(self.plex_interface)
+            else:
+                show.select_source_images()
 
             # Pass the TMDbInterface to the show if globally enabled
             if self.preferences.use_tmdb:
@@ -269,6 +271,11 @@ class Manager:
             if (show.archive and self.preferences.create_summaries
                 and not show.logo.exists()):
                 show_dict['logo'] = show.logo.name
+
+            # Report missing backdrop if art style is used
+            if (show.watched_style == 'art' or show.unwatched_style == 'art'
+                and not show.backdrop.exists()):
+                show_dict['backdrop'] = show.backdrop.name
 
             # If this show is missing at least one thing, add to missing dict
             if len(show_dict.keys()) > 0:

--- a/modules/MultiEpisode.py
+++ b/modules/MultiEpisode.py
@@ -11,9 +11,7 @@ class MultiEpisode:
     """
 
     __slots__ = ('season_number', 'episode_start', 'episode_end', 'abs_start',
-                 'abs_end', 'episode_info', 'card_class', 'source',
-                 'extra_characteristics', 'destination', 'spoiler', 'blur',
-                 '_spoil_type')
+                 'abs_end', '_first_episode', 'episode_info', 'destination')
 
 
     def __init__(self, episodes: ['Episode'], title: 'Title') -> None:
@@ -56,23 +54,15 @@ class MultiEpisode:
         # Get the first episde in the set
         for episode in episodes:
             if episode.episode_info.episode_number == self.episode_start:
-                first_episode = episode
+                self._first_episode = episode
                 break
                    
         # Set object attributes from first episode
-        self.episode_info = deepcopy(first_episode.episode_info)
-        self.card_class = first_episode.card_class
-        self.source = first_episode.source
-        self.extra_characteristics = first_episode.extra_characteristics
+        self.episode_info = deepcopy(self._first_episode.episode_info)
 
         # Override title, set blank destination
         self.episode_info.title = title
         self.destination = None
-
-        # Episodes are spoilers and not blurred until updated
-        self.spoiler = first_episode.spoiler
-        self.blur = first_episode.blur
-        self._spoil_type = first_episode._spoil_type
 
 
     def __str__(self) -> str:
@@ -83,7 +73,7 @@ class MultiEpisode:
 
 
     def __repr__(self) -> str:
-        """Returns a unambiguous string representation of the object"""
+        """Returns an unambiguous string representation of the object"""
 
         ret = (f'<MultiEpisode episode_start={self.episode_start}, episode_end='
                f'{self.episode_end}, title={self.episode_info.title}, '
@@ -92,6 +82,31 @@ class MultiEpisode:
         ret += f', abs_end={self.abs_end}' if self.abs_end != None else ''
 
         return f'{ret}>'
+
+
+    def __getattr__(self, attribute):
+        """
+        Get an attribute from the first episode of this object.
+        
+        :param      attribute:  The attribute to get from the first Episode.
+        """
+
+        return getattr(self._first_episode, attribute)
+
+
+    def __setattr__(self, attribute, value) -> None:
+        """
+        Set an attribute of the first episode of this object.
+        
+        :param      attribute:  The attribute to set on the first Episode.
+        :param      value:      The value to set on the attribute.
+        """
+
+        # If an attribute of this object, set, otherwise set on first Episode
+        if attribute in self.__slots__:
+            object.__setattr__(self, attribute, value)
+        else:
+            setattr(self._first_episode, attribute, value)
         
         
     @staticmethod

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -62,7 +62,8 @@ class PreferenceParser(YamlReader):
         self.use_plex = False
         self.plex_url = None
         self.plex_token = 'NA'
-        self.plex_unwatched = PlexInterface.DEFAULT_UNWATCHED_ACTION
+        self.global_watched_style = 'unique'
+        self.global_unwatched_style = 'unique'
         self.use_sonarr = False
         self.sonarr_url = None
         self.sonarr_api_key = None
@@ -196,15 +197,28 @@ class PreferenceParser(YamlReader):
         if (value := self['plex', 'token']):
             self.plex_token = value
 
-        if (value := self['plex', 'unwatched']):
-            value = str(value).lower().replace(' ', '_')
-            if value not in PlexInterface.VALID_UNWATCHED_ACTIONS:
-                options = '", "'.join(PlexInterface.VALID_UNWATCHED_ACTIONS)
-                log.critical(f'Invalid "unwatched" action, must be one of "'
-                             f'{options}"')
+        if (value := self['plex', 'watched_style']):
+            if str(value).lower() not in Show.VALID_STYLES:
+                options = '", "'.join(Show.VALID_STYLES)
+                log.critical(f'Invalid watched style, must be one of "{opts}"')
                 self.valid = False
             else:
-                self.plex_unwatched = value
+                self.global_watched_style = str(value).lower()
+
+        if (value := self['plex', 'unwatched_style']):
+            if str(value).lower() == 'ignore':
+                log.critical(f'Unwatched style "ignore" is now "unique"')
+                self.valid = False
+            elif str(value).lower() not in Show.VALID_STYLES:
+                opts = '", "'.join(Show.VALID_STYLES)
+                log.critical(f'Invalid unwatched style, must be one of "{opts}"')
+                self.valid = False
+            else:
+                self.global_unwatched_style = str(value).lower()
+
+        if self['plex', 'unwatched']:
+            log.warning(f'Plex "unwatched" setting has been renamed to '
+                        f'"unwatched_style"')
 
         if self['sonarr']:
             if not all((self['sonarr', 'url'], self['sonarr', 'api_key'])):

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -177,7 +177,7 @@ class PreferenceParser(YamlReader):
         if self._is_specified('archive', 'summary', 'create'):
             self.create_summaries = bool(self['archive', 'summary', 'create'])
 
-        if (value := self['arhive', 'summary', 'background_color']):
+        if (value := self['archive', 'summary', 'background_color']):
             self.summary_background_color = value
 
         if (value := self['archive', 'summary', 'logo_filename']):

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -53,6 +53,7 @@ class PreferenceParser(YamlReader):
         self.zero_pad_seasons = False
         self.archive_directory = None
         self.create_archive = False
+        self.archive_all_variations = True
         self.create_summaries = True
         self.summary_background_color = ShowSummary.BACKGROUND_COLOR
         self.logo_filename = ShowSummary.LOGO_FILENAME
@@ -159,6 +160,10 @@ class PreferenceParser(YamlReader):
         if (value := self['archive', 'path']):
             self.archive_directory = Path(value)
             self.create_archive = True
+
+        if self._is_specified('archive', 'all_variations'):
+            value = self['archive', 'all_variations']
+            self.archive_all_variations = bool(value)
 
         if self._is_specified('archive', 'summary', 'create'):
             self.create_summaries = bool(self['archive', 'summary', 'create'])

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -47,6 +47,7 @@ class PreferenceParser(YamlReader):
         # Setup default values that can be overwritten by YAML
         self.series_files = []
         self.card_type = 'standard'
+        self.style = 'unique'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.card_extension = TitleCard.DEFAULT_CARD_EXTENSION
         self.validate_fonts = True
@@ -132,10 +133,17 @@ class PreferenceParser(YamlReader):
 
         if (value := self['options', 'card_type']):
             if value not in TitleCard.CARD_TYPES:
-                log.critical(f'Default card type "{value}" is unrecognized')
+                log.critical(f'Default card type "{value}" is invalid')
                 self.valid = False
             else:
                 self.card_type = value
+
+        if (value := self['options', 'style']):
+            if str(value).lower() not in Show.VALID_STYLES:
+                log.critical(f'Default card style "{value}" is invalid')
+                self.valid = False
+            else:
+                self.style = str(value).lower()
 
         if (new_format := self['options', 'filename_format']):
             if not TitleCard.validate_card_format_string(new_format):

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -3,6 +3,7 @@ from regex import match, IGNORECASE
 from modules.CardType import CardType
 from modules.Debug import log
 from modules.MultiEpisode import MultiEpisode
+import modules.preferences as global_preferences
 
 class Profile:
     """
@@ -39,7 +40,7 @@ class Profile:
         self.__use_custom_font = True
 
 
-    def get_valid_profiles(self, card_class: CardType) -> list:
+    def get_valid_profiles(self, card_class: CardType) -> [dict]:
         """
         Gets the valid applicable profiles for this profile. For example,
         for a profile with only generic attributes, it's invalid to
@@ -61,6 +62,19 @@ class Profile:
 
         # Determine whether this profile uses a custom font
         has_custom_font = card_class.is_custom_font(self.font)
+
+        # If not archiving all variations, return only indicated profile
+        if not global_preferences.pp.archive_all_variations:
+            seasons = 'generic'
+            if self.hide_season_title and card_class.USES_SEASON_TITLE:
+                seasons = 'hidden'
+            elif has_custom_season_titles:
+                seasons = 'custom'
+
+            return [{
+                'seasons': seasons,
+                'font': 'custom' if has_custom_font else 'generic'
+            }]
 
         # Get list of profile strings applicable to this object
         valid_profiles = [{'seasons': 'generic', 'font': 'generic'}]

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -53,7 +53,7 @@ class Profile:
             custom_episode_map=self.__episode_map.is_custom,
             episode_text_format=self.episode_text_format,
         )
-
+        
         # Determine whether this profile uses a custom font
         has_custom_font = card_class.is_custom_font(self.font)
 
@@ -129,7 +129,7 @@ class Profile:
 
         # Generic season titles are Specials and Season {n}
         if not self.__use_custom_seasons:
-            self.__episode_map.get_generic_season_title(episode_info)
+            return self.__episode_map.get_generic_season_title(episode_info)
 
         # Custom season title, query EpisodeMap for title
         return self.__episode_map.get_season_title(episode_info)

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -473,20 +473,35 @@ class Show(YamlReader):
             # Update source and blurring of this episode based on all settings
             applies_to = self.__episode_map.get_applies_to(episode.episode_info)
             unwatched_action = self.unwatched_action
-            match (applies_to, unwatched_action, self.style, episode.watched):
-                case ('all', _, 'unique' | 'backdrop', _):
-                    episode.update_source(manual_source)
-                case (('all', _, 'blur', _)
-                    | ('unwatched', 'ignore', 'blur', False)
-                    | ('unwatched', 'blur', _, False)):
-                    episode.blur = True
-                    episode.update_source(manual_source)
-                case ('unwatched', _, _, False):
-                    episode.update_source(manual_source)
-                case ('unwatched', _, 'backdrop', True):
-                    episode.update_source(self.backdrop)
-                case ('unwatched', _, 'blur', True):
-                    episode.blur = True
+            if applies_to == 'all' and self.style in ('unique', 'backdrop'):
+                episode.update_source(manual_source)
+            elif ((applies_to == 'all' and self.style == 'blur')
+                or (applies_to == 'unwatched' and unwatched_action == 'ignore'
+                    and self.style == 'blur' and not episode.watched)
+                or (applies_to == 'unwatched' and unwatched_action == 'blur'
+                    and not episode.watched)):
+                episode.blur = True
+                episode.update_source(manual_source)
+            elif (applies_to == 'unwatched' and not episode.watched):
+                episode.update_source(manual_source)
+            elif (applies_to == 'unwatched' and self.style == 'blur'
+                and episode.watched):
+                episode.blur = True
+            # Python 3.10 version..
+            # match (applies_to, unwatched_action, self.style, episode.watched):
+            #     case ('all', _, 'unique' | 'backdrop', _):
+            #         episode.update_source(manual_source)
+            #     case (('all', _, 'blur', _)
+            #         | ('unwatched', 'ignore', 'blur', False)
+            #         | ('unwatched', 'blur', _, False)):
+            #         episode.blur = True
+            #         episode.update_source(manual_source)
+            #     case ('unwatched', _, _, False):
+            #         episode.update_source(manual_source)
+            #     case ('unwatched', _, 'backdrop', True):
+            #         episode.update_source(self.backdrop)
+            #     case ('unwatched', _, 'blur', True):
+            #         episode.blur = True
             
 
 

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -2,6 +2,7 @@ from copy import copy
 
 from modules.Debug import log
 from modules.ShowSummary import ShowSummary
+import modules.preferences as global_preferences
 
 class ShowArchive:
     """
@@ -87,7 +88,12 @@ class ShowArchive:
 
             # Store this new Show and associated ShowSummary
             self.shows.append(new_show)
-            self.summaries.append(ShowSummary(new_show))
+            self.summaries.append(
+                ShowSummary(
+                    new_show,
+                    global_preferences.pp.summary_background_color
+                )
+            )
 
 
     def read_source(self) -> None:

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from random import sample
 
 from modules.Debug import log
-from modules.StandardTitleCard import StandardTitleCard
 from modules.ImageMaker import ImageMaker
+from modules.StandardTitleCard import StandardTitleCard
 
 class ShowSummary(ImageMaker):
     """
@@ -34,16 +34,20 @@ class ShowSummary(ImageMaker):
     """Path to the 'created by' image to add to all show summaries"""
     __CREATED_BY_PATH: Path = Path(__file__).parent / 'ref' / 'created_by.png'
 
-    __slots__ = ('show', 'logo', 'output', 'inputs', 'number_rows')
+    __slots__ = ('show', 'logo', 'output', 'background_color', 'inputs',
+                 'number_rows')
 
 
-    def __init__(self, show: 'Show') -> None:
+    def __init__(self, show: 'Show',
+                 background_color: str=BACKGROUND_COLOR) -> None:
         """
-        Constructs a new instance of this object. This initialized a
+        Constructs a new instance of this object. This initializes a
         ImageMagickInterface object, and searches the provided show object
         for existing title cards to use in `create()`.
         
-        :param      show:  The show object of which to create a summary for.
+        :param      show:               The Show object of which to create a
+                                        summary for.
+        :param      background_color:   Background color to use for the summary.
         """
 
         # Initialize parent object (for the ImageMagickInterface)
@@ -55,6 +59,9 @@ class ShowSummary(ImageMaker):
 
         # Output file is stored in the top-level media directory (usually an archive folder)
         self.output = show.media_directory / 'Summary.jpg'
+
+        # Get global background color
+        self.background_color = background_color
 
         # Initialize variables that will be set upon image selection
         self.inputs = []
@@ -110,7 +117,7 @@ class ShowSummary(ImageMaker):
 
         command = ' '.join([
             f'montage',
-            f'-background "{self.BACKGROUND_COLOR}"',
+            f'-background "{self.background_color}"',
             f'-density 300',
             f'-tile 3x3',
             f'-geometry +80+80',
@@ -137,7 +144,7 @@ class ShowSummary(ImageMaker):
         command = ' '.join([
             f'convert "{montage.resolve()}"',
             f'-resize 50%',
-            f'-background "{self.BACKGROUND_COLOR}"',
+            f'-background "{self.background_color}"',
             f'-gravity north',
             f'-splice 0x840',
             f'-font "{StandardTitleCard.EPISODE_COUNT_FONT}"',

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -15,7 +15,7 @@ class SonarrInterface(WebInterface):
     """
 
     """Episode titles that indicate a placeholder and are to be ignored"""
-    __PLACEHOLDER_NAMES = {'tba', 'TBA'}
+    __PLACEHOLDER_NAMES = {'tba', 'TBA', 'tbd', 'TBD'}
 
     """Datetime format string for airDateUtc field in Sonarr API requests"""
     __AIRDATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -415,8 +415,10 @@ class StandardTitleCard(CardType):
         :returns:   True if custom season titles are indicated, False otherwise.
         """
 
+        standard_etf = StandardTitleCard.EPISODE_TEXT_FORMAT.upper()
+
         return (custom_episode_map or
-                episode_text_format.upper() != self.EPISODE_TEXT_FORMAT.upper())
+                episode_text_format.upper() != standard_etf)
 
 
     def create(self) -> None:

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -257,7 +257,7 @@ class StandardTitleCard(CardType):
         command = ' '.join([
             f'convert "{titled_image.resolve()}"',
             *self.__series_count_text_global_effects(),
-            f'-font "{self.EPISODE_COUNT_FONT}"',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
             f'-gravity center',
             *self.__series_count_text_black_stroke(),
             f'-annotate +0+697.2 "{self.episode_text}"',
@@ -281,15 +281,15 @@ class StandardTitleCard(CardType):
         command = ' '.join([
             f'convert -debug annotate xc: ',
             *self.__series_count_text_global_effects(),
-            f'-font "{self.SEASON_COUNT_FONT}"',    # Season text
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
             f'-gravity east',
             *self.__series_count_text_effects(),
             f'-annotate +1600+697.2 "{self.season_text} "',
-            f'-font "{self.EPISODE_COUNT_FONT}"',   # Separator dot
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
             f'-gravity center',
             *self.__series_count_text_effects(),
             f'-annotate +0+689.5 "• "',
-            f'-gravity west',                       # Episode text
+            f'-gravity west',
             *self.__series_count_text_effects(),
             f'-annotate +1640+697.2 "{self.episode_text}"',
             f'null: 2>&1'
@@ -330,12 +330,12 @@ class StandardTitleCard(CardType):
             f'-background transparent',
             f'xc:transparent',
             *self.__series_count_text_global_effects(),
-            f'-font "{self.SEASON_COUNT_FONT}"',
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
             *self.__series_count_text_black_stroke(),
             f'-annotate +0+{height-25} "{self.season_text} "',
             *self.__series_count_text_effects(),
             f'-annotate +0+{height-25} "{self.season_text} "',
-            f'-font "{self.EPISODE_COUNT_FONT}"',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
             *self.__series_count_text_black_stroke(),
             f'-annotate +{width1}+{height-25-6.5} "•"',
             *self.__series_count_text_effects(),

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -402,37 +402,21 @@ class StandardTitleCard(CardType):
 
 
     @staticmethod
-    def is_custom_season_titles(season_map: dict, episode_range: dict, 
+    def is_custom_season_titles(custom_episode_map: bool, 
                                 episode_text_format: str) -> bool:
         """
         Determines whether the given attributes constitute custom or generic
         season titles.
         
-        :param      season_map:           The season map in use.
-        :param      episode_range:        The episode range in use.
-        :param      episode_text_format:  The episode text format in use.
+        :param      custom_episode_map:     Whether the EpisodeMap was
+                                            customized.
+        :param      episode_text_format:    The episode text format in use.
         
         :returns:   True if custom season titles are indicated, False otherwise.
         """
 
-        # Nonstandard episode text format
-        if episode_text_format != 'EPISODE {episode_number}':
-            return True
-
-        # Nonstandard episode range
-        if episode_range != {}:
-            return True
-
-        # If any season title isn't standard
-        for number, title in season_map.items():
-            if number == 0:
-                if title.lower() != 'specials':
-                    return True
-            else:
-                if title.lower() != f'season {number}':
-                    return True
-
-        return False
+        return (custom_episode_map or
+                episode_text_format.upper() != self.EPISODE_TEXT_FORMAT.upper())
 
 
     def create(self) -> None:


### PR DESCRIPTION
# Major Changes
- Separate manual image creation and "fixes" from `fixer.py` into `mini_maker.py` and `fixer.py`
  - `--title-card`, `--genre-card`, and `--show-summary` commands are now inside `mini_maker.py`
  - "Fixer" as a name makes more sense to "fix" things, as opposed to create them
  - Closes #132 
- Add ability to import archive directly into Plex
  - Created `--import-archive`/`--load-archive` and `--import-series`/`--load-series` arguments in `fixer.py` 
  - Closes #108
- Allow font size adjustment in `AnimeTitleCard`
  - Closes #133 
- Allow per-season/episode range manual source specification
  - Closes #126 
- Created global "style" options (`watched_style` and `unwatched_style`)
  - Looks for these options under `plex` section, or on a per-series option
  - Removed `art_all` and `blur_all` from `unwatched` options
  - Closes #134 
# Major Fixes 
- Actually use customized background color in `ShowSummary` creation
  - Closes #136
# Minor Changes
- Add `-t` argument alongside `--time`
- Log (under `DEBUG` log level) cards being loaded into Plex
- Add `--background-color` argument option to `mini_maker.py`
- Changed `MultiEpisode` class to dynamically get/set attributes from first episode (was hard-coded)
- Added backdrops to missing report
# Minor Fixes
- Don't immediately skip series after single failed card loading
- Ignore `TDB` as temporary titles
  - Closes #135 