### PR TITLE
Error and exit if old unwatched setting is used

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
 from pathlib import Path
+from os import environ
 from re import match
 from time import sleep
 
@@ -15,6 +16,10 @@ try:
 except ImportError:
     print(f'Required Python packages are missing - execute "pipenv install"')
     exit(1)
+
+# Environment variables
+RUNTIME_ENV = 'TCM_RUNTIME'
+FREQUENCY_ENV = 'TCM_FREQUENCY'
 
 # Default path for the preference file to parse
 DEFAULT_PREFERENCE_FILE = Path(__file__).parent / 'preferences.yml'
@@ -60,13 +65,13 @@ parser.add_argument(
     '-t', '--time', '--runtime',
     dest='runtime',
     type=runtime,
-    default=SUPPRESS,
+    default=environ.get(RUNTIME_ENV, SUPPRESS),
     metavar='HH:MM',
     help='When to first run the TitleCardMaker (in 24-hour time)')
 parser.add_argument(
     '-f', '--frequency',
     type=frequency,
-    default='12h',
+    default=environ.get(FREQUENCY_ENV, '12h'),
     metavar='FREQUENCY[unit]',
     help='How often to run the TitleCardMaker (default "12h"). Units can be '
          'm/h/d for minutes/hours/days')

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -217,8 +217,8 @@ class PreferenceParser(YamlReader):
                 self.global_unwatched_style = str(value).lower()
 
         if self['plex', 'unwatched']:
-            log.warning(f'Plex "unwatched" setting has been renamed to '
-                        f'"unwatched_style"')
+            log.critical(f'Plex "unwatched" setting has been renamed to '
+                         f'"unwatched_style"')
             self.valid = False
 
         if self['sonarr']:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -219,6 +219,7 @@ class PreferenceParser(YamlReader):
         if self['plex', 'unwatched']:
             log.warning(f'Plex "unwatched" setting has been renamed to '
                         f'"unwatched_style"')
+            self.valid = False
 
         if self['sonarr']:
             if not all((self['sonarr', 'url'], self['sonarr', 'api_key'])):

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -238,6 +238,9 @@ class Show(YamlReader):
                 self.valid = False
             else:
                 self.unwatched_style = match_value
+        if self['unwatched']:
+            log.error(f'"unwatched" setting has been renamed "unwatched_style"')
+            self.valid = False
 
         if self._is_specified('seasons', 'hide'):
             self.hide_seasons = bool(self['seasons', 'hide'])


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
N/A
# Minor Changes
- Look for environment variables when scheduling Maker
  - `--time` looks for `TCM_RUNTIME` environment variable
  - `--frequency` looks for `TCM_FREQUENCY` environment variable
- Critically error if old `unwatched` setting is used in place of new `unwatched_style` 
# Minor Fixes
N/A