### PR TITLE
Pull sources from Plex, new textless card type, other changes/fixes

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -20,14 +20,20 @@ except ImportError:
     print(f'Required Python packages are missing - execute "pipenv install"')
     exit(1)
 
+# Default path for the preference file to parse
+DEFAULT_PREFERENCE_FILE = Path(__file__).parent / 'preferences.yml'
+
+# Old commands that have moved to mini_maker to warn user about
 OLD_COMMANDS = ('--title-card', '--genre-card', '--show-summary')
 
 # Create ArgumentParser object 
 parser = ArgumentParser(description='Manual fixes for the TitleCardMaker')
-parser.add_argument('-p', '--preference-file', type=Path, 
-                    default='preferences.yml', metavar='PREFERENCE_FILE',
-                    help='Preference YAML file for parsing '
-                         'ImageMagick/Sonarr/TMDb options')
+parser.add_argument(
+    '-p', '--preference-file',
+    type=Path, 
+    default=DEFAULT_PREFERENCE_FILE,
+    metavar='PREFERENCE_FILE',
+    help='Preference YAML file for global options')
 
 # Argument group for Miscellaneous functions
 misc_group = parser.add_argument_group('Miscellaneous')

--- a/main.py
+++ b/main.py
@@ -38,12 +38,12 @@ def runtime(arg: str) -> dict:
 
 def frequency(arg: str) -> dict:
     try:
-        interval, unit = match(r'(\d+)(m|h|d)', arg).groups()
+        interval, unit = match(r'(\d+)(m|h|d|w)', arg).groups()
         interval, unit = int(interval), unit.lower()
-        assert interval > 0 and unit in ('m', 'h', 'd')
+        assert interval > 0 and unit in ('m', 'h', 'd', 'w')
         return {
             'interval': interval,
-            'unit': {'m': 'minutes', 'h': 'hours', 'd': 'days'}[unit]
+            'unit': {'m':'minutes', 'h':'hours', 'd':'days', 'w':'weeks'}[unit]
         }
     except Exception:
         raise ArgumentTypeError(f'Invalid frequency, specify as FREQUENCY[unit]'
@@ -74,7 +74,7 @@ parser.add_argument(
     default=environ.get(FREQUENCY_ENV, '12h'),
     metavar='FREQUENCY[unit]',
     help='How often to run the TitleCardMaker (default "12h"). Units can be '
-         'm/h/d for minutes/hours/days')
+         'm/h/d/w for minutes/hours/days/weeks')
 parser.add_argument(
     '-m', '--missing', 
     type=Path,

--- a/main.py
+++ b/main.py
@@ -122,14 +122,7 @@ def run():
 
 # Run immediately if specified
 if args.run:
-    from cProfile import Profile
-    from pstats import Stats
-
-    with Profile() as pr:
-        run()
-
-    stats = Stats(pr)
-    stats.dump_stats(filename='all.prof')   
+    run()  
 
 # Schedule subsequent runs if specified
 if hasattr(args, 'runtime'):

--- a/main.py
+++ b/main.py
@@ -122,7 +122,14 @@ def run():
 
 # Run immediately if specified
 if args.run:
-    run()
+    from cProfile import Profile
+    from pstats import Stats
+
+    with Profile() as pr:
+        run()
+
+    stats = Stats(pr)
+    stats.dump_stats(filename='all.prof')   
 
 # Schedule subsequent runs if specified
 if hasattr(args, 'runtime'):

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -14,11 +14,16 @@ except ImportError:
     print(f'Required Python packages are missing - execute "pipenv install"')
     exit(1)
 
+# Default path for the preference file to parse
+DEFAULT_PREFERENCE_FILE = Path(__file__).parent / 'preferences.yml'
+
 parser = ArgumentParser(description='Manually make cards')
-parser.add_argument('-p', '--preference-file', type=Path, 
-                    default='preferences.yml', metavar='PREFERENCE_FILE',
-                    help='Preference YAML file for parsing '
-                         'ImageMagick/Sonarr/TMDb options')
+parser.add_argument(
+    '-p', '--preference-file',
+    type=Path, 
+    default=DEFAULT_PREFERENCE_FILE,
+    metavar='PREFERENCE_FILE',
+    help='Preference YAML file for global options')
 
 # Argument group for 'manual' title card creation
 title_card_group = parser.add_argument_group('Title Cards',

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -20,7 +20,7 @@ class CardType(ImageMaker):
     """
 
     """Default case string for all title text"""
-    DEFAULT_FONT_CASE = 'upper'
+    DEFAULT_FONT_CASE = 'source'
 
     """Mapping of 'case' strings to format functions"""
     CASE_FUNCTIONS = {
@@ -34,10 +34,13 @@ class CardType(ImageMaker):
     """Default episode text format string, can be overwritten by each class"""
     EPISODE_TEXT_FORMAT = 'EPISODE {episode_number}'
 
+    """Whether this class uses unique source images for card creation"""
+    USES_UNIQUE_SOURCES = True
+
     """Standard size for all title cards"""
     TITLE_CARD_SIZE = '3200x1800'
 
-    """Blur effects to apply to spoiler-free images"""
+    """Standard blur effect to apply to spoiler-free images"""
     BLUR_PROFILE = '0x60'
 
     @property

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -28,6 +28,7 @@ class CardType(ImageMaker):
         'upper': str.upper,
         'lower': str.lower,
         'title': titlecase,
+        'blank': lambda _: '',
     }
 
     """Default episode text format string, can be overwritten by each class"""

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -133,16 +133,16 @@ class Manager:
             show.query_sonarr(self.sonarr_interface)
 
 
-    def create_missing_title_cards(self) -> None:
+    def select_source_images(self) -> None:
         """
-        Creates all missing title cards for every show known to this Manager.
-        For each show, this calls Show.create_missing_title_cards().
+        Select and download the source images for every show known to this
+        manager.
         """
 
-        # Go through every show in the Manager, create cards
+        # Go through each show and download source images
         for show in (pbar := tqdm(self.shows, **TQDM_KWARGS)):
             # Update progress bar
-            pbar.set_description(f'Creating Title Cards for '
+            pbar.set_description(f'Selecting sources for '
                                  f'"{show.series_info.short_name}"')
 
             # Modify unwatched episodes based on Plex watch status
@@ -154,6 +154,19 @@ class Manager:
                     show.select_source_images(self.plex_interface)
             else:
                 show.select_source_images()
+
+
+    def create_missing_title_cards(self) -> None:
+        """
+        Creates all missing title cards for every show known to this Manager.
+        For each show, this calls Show.create_missing_title_cards().
+        """
+
+        # Go through every show in the Manager, create cards
+        for show in (pbar := tqdm(self.shows, **TQDM_KWARGS)):
+            # Update progress bar
+            pbar.set_description(f'Creating Title Cards for '
+                                 f'"{show.series_info.short_name}"')
 
             # Pass the TMDbInterface to the show if globally enabled
             if self.preferences.use_tmdb:
@@ -196,7 +209,6 @@ class Manager:
             # Update progress bar
             pbar.set_description(f'Updating archive for '
                                  f'"{show_archive.series_info.short_name}"')
-
             # Pass the TMDbInterface to the show if globally enabled
             if self.preferences.use_tmdb:
                 show_archive.update_archive(self.tmdb_interface)

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -136,7 +136,7 @@ class Manager:
     def select_source_images(self) -> None:
         """
         Select and download the source images for every show known to this
-        manager.
+        manager. For each show, this called Show.select_source_images().
         """
 
         # Go through each show and download source images
@@ -206,11 +206,8 @@ class Manager:
             # Update progress bar
             pbar.set_description(f'Updating archive for '
                                  f'"{show_archive.series_info.short_name}"')
-            # Pass the TMDbInterface to the show if globally enabled
-            if self.preferences.use_tmdb:
-                show_archive.update_archive(self.tmdb_interface)
-            else:
-                show_archive.update_archive()
+            
+            show_archive.update_archive()
 
 
     def create_summaries(self) -> None:

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -168,11 +168,8 @@ class Manager:
             pbar.set_description(f'Creating Title Cards for '
                                  f'"{show.series_info.short_name}"')
 
-            # Pass the TMDbInterface to the show if globally enabled
-            if self.preferences.use_tmdb:
-                show.create_missing_title_cards(self.tmdb_interface)
-            else:
-                show.create_missing_title_cards()
+            # Create cards
+            show.create_missing_title_cards()
 
     
     def update_plex(self) -> None:
@@ -242,11 +239,12 @@ class Manager:
 
     def run(self) -> None:
         """Run the manager and exit."""
-
+        
         self.create_shows()
         self.read_show_source()
         self.check_sonarr_for_new_episodes()
         self.check_tmdb_for_translations()
+        self.select_source_images()
         self.create_missing_title_cards()
         self.update_plex()
         self.update_archive()

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -308,6 +308,41 @@ class PlexInterface:
                 )
 
 
+    def get_source_image(self, library_name: str, series_info: 'SeriesInfo',
+                         episode_info: 'EpisodeInfo') -> str:
+        """
+        Get the source image (i.e. the URL to the existing thumbnail) for the
+        given episode within Plex.
+        
+        :param      library_name:   Name of the library the series is under.
+        :param      series_info:    The series to get the thumbnail of.
+        :param      episode_info:   The episode to get the thumbnail of.
+        
+        :returns:   URL to the thumbnail of the given Episode. None if the
+                    episode DNE.
+        """
+
+        # If the given library cannot be found, exit
+        if not (library := self.__get_library(library_name)):
+            return None
+
+        # If the given series cannot be found in this library, exit
+        if not (series := self.__get_series(library, series_info)):
+            return None
+
+        # Get Episode from within Plex
+        try:
+            plex_episode = series.episode(
+                season=episode_info.season_number,
+                episode=episode_info.episode_number
+            )
+
+            return f'{self.__server._baseurl}{plex_episode.thumb}'
+        except NotFound:
+            # Episode DNE in Plex, return
+            return None
+
+
     @retry(stop=stop_after_attempt(5),
            wait=wait_fixed(3)+wait_exponential(min=1, max=32))
     def __retry_upload(self, plex_episode: 'Episode', filepath: Path) -> None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -191,8 +191,8 @@ class PreferenceParser(YamlReader):
                                type_=str)) != None:
             self.logo_filename = value
 
-        if (value := self._get('archive', 'summary', 'minimum_episodes',
-                               type_=int) != None):
+        if ((value := self._get('archive', 'summary', 'minimum_episodes',
+                               type_=int)) != None):
             self.summary_minimum_episode_count = value
 
         if (value := self._get('plex', 'url', type_=str)) != None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -21,6 +21,10 @@ class PreferenceParser(YamlReader):
     file and parses it into individual attributes.
     """
 
+    """Valid source identifiers"""
+    VALID_SOURCES = ('tmdb', 'plex')
+
+
     def __init__(self, file: Path) -> None:
         """
         Constructs a new instance of this object. This reads the given file,
@@ -49,6 +53,7 @@ class PreferenceParser(YamlReader):
         self.card_type = 'standard'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.card_extension = TitleCard.DEFAULT_CARD_EXTENSION
+        self.source_priority = ['tmdb', 'plex']
         self.validate_fonts = True
         self.zero_pad_seasons = False
         self.archive_directory = None
@@ -152,6 +157,14 @@ class PreferenceParser(YamlReader):
                 self.valid = False
             else:
                 self.card_extension = extension
+
+        if (value := self._get('options', 'source_priority', type_=str)) !=None:
+            sources = tuple(map(str.lower, value.split(', ')))
+            if not all(_ in self.VALID_SOURCES for _ in sources):
+                log.critical(f'Source priorities "{value}" is invalid')
+                self.valid = False
+            else:
+                self.source_priority = sources
 
         if (value := self._get('options', 'validate_fonts', type_=bool)) !=None:
             self.validate_fonts = value

--- a/modules/RemoteCardType.py
+++ b/modules/RemoteCardType.py
@@ -27,35 +27,42 @@ class RemoteCardType:
         """
         Construct a new RemoteCardType. This downloads the source file at the
         specified location and loads it as a class in the global modules, under
-        the interpreted class name.
+        the interpreted class name. If the given remote specification is a file
+        that exists, that file is loaded.
         
         :param      remote: URL to remote card to inject. Should omit repo base.
                             Should be specified like {username}/{class_name}.
+                            Can also be a local filepath.
         """
 
-        # Make GET request for the contents of the specified value
-        url = f'{self.URL_BASE}/{remote}.py'
-        if (response := get(url)).status_code >= 400:
-            log.error(f'Cannot identify remote Card Type "{remote}"')
-            self.valid = False
-            return None
+        if (file := Path(remote)).exists():
+            # Get class name from file
+            class_name = file.stem
+            file_name = str(file.resolve())
+        else:
+            # Make GET request for the contents of the specified value
+            url = f'{self.URL_BASE}/{remote}.py'
+            if (response := get(url)).status_code >= 400:
+                log.error(f'Cannot identify remote Card Type "{remote}"')
+                self.valid = False
+                return None
 
-        # Succesful request (i.e. file remotely exists)
-        # Get username and class name from the git specification
-        username = remote.split('/')[0]
-        class_name = remote.split('/')[-1]  
+            # Succesful request (i.e. file remotely exists)
+            # Get username and class name from the git specification
+            username = remote.split('/')[0]
+            class_name = remote.split('/')[-1]  
 
-        # Download and write the CardType class into a temporary file
-        file_name = self.TEMP_DIR / f'{username}-{class_name}.py'
-        file_name.parent.mkdir(parents=True, exist_ok=True)
+            # Download and write the CardType class into a temporary file
+            file_name = self.TEMP_DIR / f'{username}-{class_name}.py'
+            file_name.parent.mkdir(parents=True, exist_ok=True)
 
-        # Download file, import as module
-        try:
             # Write remote file contents to temporary class
             with (file_name).open('wb') as fh:
                 fh.write(response.content)
             log.debug(f'Wrote {class_name}.py to {file_name.resolve()}')
 
+        # Import new file as module
+        try:
             # Create module for newly loaded file
             spec = spec_from_file_location(class_name, file_name)
             module = module_from_spec(spec)
@@ -64,11 +71,11 @@ class RemoteCardType:
 
             # Get class from module namespace
             self.card_class = module.__dict__[class_name]
-            log.info(f'Loaded Remote Card Type "{remote}"')
+            log.info(f'Loaded CardType "{remote}"')
             self.valid = True
         except Exception as e:
             # Some error in loading, set object as invalid
-            log.error(f'Cannot load Remote Card Type "{remote}", returned "{e}"')
+            log.error(f'Cannot load CardType "{remote}", returned "{e}"')
             self.card_class = None
             self.valid = False
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -95,6 +95,7 @@ class Show(YamlReader):
         self.hide_seasons = False
         self.__episode_map = EpisodeMap()
         self.title_language = {}
+        self.extras = {}
 
         # Set object attributes based off YAML and update validity
         self.__parse_yaml()
@@ -248,12 +249,16 @@ class Show(YamlReader):
                 
         # Construct EpisodeMap on seasons/episode ranges specification
         self.__episode_map = EpisodeMap(
-            self._get('seasons'),
-            self._get('episode_ranges')
+            self._get('seasons', type_=dict),
+            self._get('episode_ranges', type_=dict)
         )
 
         # Update object validity from EpisodeMap validity
         self.valid &= self.__episode_map.valid
+
+        # Read all extras
+        if (self._is_specified('extras', type_=dict)):
+            self.extras = self._get('extras')
 
 
     def __get_destination(self, episode_info: 'EpisodeInfo') -> Path:
@@ -586,6 +591,7 @@ class Show(YamlReader):
                 episode,
                 self.profile,
                 self.card_class.TITLE_CHARACTERISTICS,
+                **self.extras,
                 **episode.extra_characteristics,
             )
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -33,7 +33,6 @@ class Show(YamlReader):
     """Filename to the backdrop for a series"""
     BACKDROP_FILENAME = 'backdrop.jpg'
 
-
     __slots__ = ('preferences', 'valid', '__library_map', 'series_info',
                  'media_directory', 'card_class', 'episode_text_format',
                  'library_name', 'library', 'archive', 'sonarr_sync',
@@ -562,10 +561,10 @@ class Show(YamlReader):
                                     backdrop if one is needed and DNE.
         """
         
-        # Modify Episodes based on plex status
+        # Modify Episodes watched/blur/source files based on plex status
         download_backdrop = self.__apply_styles(plex_interface)
             
-        # Query TMDb for the backdrop if one does not exist
+        # Query TMDb for the backdrop if one does not exist and is needed
         if (download_backdrop and tmdb_interface and self.tmdb_sync
             and not self.backdrop.exists()):
             # Download background art 
@@ -615,14 +614,8 @@ class Show(YamlReader):
                     break
 
 
-    def create_missing_title_cards(self,
-                                   tmdb_interface: 'TMDbInterface'=None) ->None:
-        """
-        Creates any missing title cards for each episode of this show.
-
-        :param      tmdb_interface:     Optional TMDbInterface to download any
-                                        missing source images from.
-        """
+    def create_missing_title_cards(self) ->None:
+        """Create any missing title cards for each episode of this show."""
 
         # If the media directory is unspecified, exit
         if self.media_directory is None:

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -584,12 +584,17 @@ class Show(YamlReader):
 
             # If TMDb is a source interface, verify episode has been permanently
             # blacklisted before trying Plex
-            if ('tmdb' in self.preferences.source_priority and self.tmdb_sync
-                and tmdb_interface):
-                check_plex = tmdb_interface.is_permanently_blacklisted(
-                    self.series_info,
-                    episode.episode_info,
-                )
+            source_priority = self.preferences.source_priority
+            if ('tmdb' in source_priority and 'plex' in source_priority
+                and tmdb_interface and self.tmdb_sync):
+                # If plex is higher priority than TMDb, check always
+                if source_priority.index('plex') <source_priority.index('tmdb'):
+                    check_plex = True
+                else:
+                    check_plex = tmdb_interface.is_permanently_blacklisted(
+                        self.series_info,
+                        episode.episode_info,
+                    )
             else:
                 # TMDb not being checked, always check plex (if specified)
                 check_plex = True

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -609,7 +609,6 @@ class Show(YamlReader):
 
                 # If URL was returned by either interface, download
                 if image_url != None:
-                    log.error(f'{self} {episode} -> {image_url}')
                     WebInterface.download_image(image_url, episode.source)
                     break
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -488,6 +488,7 @@ class Show(YamlReader):
                 self.unwatched_style,
             )
         else:
+            # If no PlexInterface, assume all episodes are unwatched
             [episode.update_statuses(False, self.watched_style,
                                      self.unwatched_style)
              for _, episode in self.episodes.items()]
@@ -522,7 +523,7 @@ class Show(YamlReader):
             elif watched_style == 'unique':
                 continue
             elif watched_style == 'art':
-                found = episode.update_source(self.backdrop, downloadable=False)
+                found = episode.update_source(self.backdrop, downloadable=True)
                 download_backdrop = True
             else:
                 episode.blur = True

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -96,6 +96,13 @@ class ShowArchive:
             )
 
 
+    def __repr__(self) -> str:
+        """Returns a unambiguous string representation of the object."""
+
+        return (f'<ShowArchive for {self.series_info} with {len(self.shows)} '
+                f'profiles>')
+
+
     def read_source(self) -> None:
         """Call read_source() on each Show object in this archive."""
 

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -89,8 +89,8 @@ class ShowSummary(ImageMaker):
         # Skip if the number of available episodes is below the minimum
         minimum = self.preferences.summary_minimum_episode_count
         if episode_count < minimum:
-            log.info(f'Skipping ShowSummary, {self.show} has {episode_count} '
-                     f'episodes, minimum setting is {minimum}')
+            log.debug(f'Skipping ShowSummary, {self.show} has {episode_count} '
+                      f'episodes, minimum setting is {minimum}')
             return False
 
         # Get a random subset of images to create the summary with
@@ -303,7 +303,7 @@ class ShowSummary(ImageMaker):
             return None
 
         # Select images for montaging
-        if not self.__select_images():
+        if not self.__select_images() or len(self.inputs) == 0:
             return None
             
         # Create montage of title cards

--- a/modules/ShowSummary.py
+++ b/modules/ShowSummary.py
@@ -297,10 +297,6 @@ class ShowSummary(ImageMaker):
         done at the start of this function.
         """
 
-        # If there are no title cards to montage
-        if len(self.inputs) == 0:
-            return None
-
         # Exit if a logo does not exist
         if not self.logo.exists():
             log.warning('Cannot create ShowSummary - no logo found')

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -72,9 +72,7 @@ class StandardTitleCard(CardType):
         :param  season_text:        Text to use as season count text. Ignored if
                                     hide_season is True.
         :param  episode_text:       Text to use as episode count text.
-        :param  font:               Font to use for the episode title. MUST be a
-                                    a valid ImageMagick font, or filepath to a
-                                    font.
+        :param  font:               Font to use for the episode title.
         :param  font_size:          Scalar to apply to the title font size.
         :param  title_color:        Color to use for the episode title.
         :param  hide_season:        Whether to omit the season text (and joining

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -68,7 +68,7 @@ class StandardTitleCard(CardType):
 
         :param  source:             Source image.
         :param  output_file:        Output file.
-        :param  title_top_line:     Episode title.
+        :param  title:              Episode title.
         :param  season_text:        Text to use as season count text. Ignored if
                                     hide_season is True.
         :param  episode_text:       Text to use as episode count text.

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -213,7 +213,7 @@ class StarWarsTitleCard(CardType):
         :param      gradient_source:    Source image with starry gradient
                                         overlaid.
         
-        :returns:   Path to the created image.
+        :returns:   Path to the created image (the output file).
         """
 
         command = ' '.join([

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -32,6 +32,9 @@ class StarWarsTitleCard(CardType):
     """Color to use for the episode title"""
     TITLE_COLOR = '#DAC960'
 
+    """Default episode text format string"""
+    EPISODE_TEXT_FORMAT = 'EPISODE {episode_number}'
+
     """Color of the episode/episode number text"""
     EPISODE_TEXT_COLOR = '#AB8630'
 
@@ -294,12 +297,15 @@ class StarWarsTitleCard(CardType):
         """
 
         generic_formats = (
-            'EPISODE {episode_number}',
-            'CHAPTER {episode_number}',
-            'PART {episode_number}',
+            'episode {episode_number}',
+            'chapter {episode_number}',
+            'part {episode_number}',
+            'episode {abs_number}',
+            'chapter {abs_number}',
+            'part {abs_number}',
         )
-
-        return episode_text_format not in generic_formats
+        
+        return episode_text_format.lower() not in generic_formats
 
 
     def create(self) -> None:

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -51,6 +51,10 @@ class StarWarsTitleCard(CardType):
     """Paths to intermediate files that are deleted after the card is created"""
     __SOURCE_WITH_STARS = CardType.TEMP_DIR / 'source_gradient.png'
 
+
+    __slots__ = ('source_file', 'output_file', 'title', 'episode_prefix',
+                 'episode_text', 'hide_episode_text', 'blur')
+
     
     def __init__(self, source: Path, output_file: Path, title: str,
                  episode_text: str, blur: bool=False, *args, **kwargs) -> None:
@@ -78,10 +82,15 @@ class StarWarsTitleCard(CardType):
         
         # Modify episode text to remove "Episode"-like text, replace numbers
         # with text, strip spaces, and convert to uppercase
-        self.episode_prefix = 'EPISODE'
-        self.episode_text = self.image_magick.escape_chars(
-            self.__modify_episode_text(episode_text)
-        )
+        self.hide_episode_text = len(episode_text) == 0
+        if self.hide_episode_text:
+            self.episode_prefix = None
+            self.episode_text = self.image_magick.escape_chars(episode_text)
+        else:
+            self.episode_prefix = 'EPISODE'
+            self.episode_text = self.image_magick.escape_chars(
+                self.__modify_episode_text(episode_text)
+            )
 
         # Store blur flag
         self.blur = blur
@@ -117,6 +126,7 @@ class StarWarsTitleCard(CardType):
             self.episode_prefix = 'EPISODE'
             modified_text = modified_text.replace('EPISODE', '')
         elif match(rf'PART\s*(\d+)', modified_text):
+            self.episode_prefix = 'PART'
             modified_text = modified_text.replace('PART', '')
 
         try:
@@ -197,18 +207,43 @@ class StarWarsTitleCard(CardType):
         :returns:   List of ImageMagick commands.
         """
 
+        # Get variable horizontal offset based of episode prefix
+        text_offset = {'EPISODE': 720, 'CHAPTER': 720, 'PART': 570}
+        offset = text_offset[self.episode_prefix]
+
         return [
             f'-gravity west',
             f'-font "{self.EPISODE_NUMBER_FONT.resolve()}"',
             f'-pointsize 53',
             f'-kerning 19',
-            f'-annotate +720-140 "{self.episode_text}"',
+            f'-annotate +{offset}-140 "{self.episode_text}"',
         ]
 
 
-    def __add_text(self, gradient_source: Path) -> Path:
+    def __add_only_title(self, gradient_source: Path) -> Path:
         """
-        Add the title, "EPISODE" prefix, and episode text to the give image.
+        Add the title to the given image.
+        
+        :param      gradient_source:    Source image with starry gradient
+                                        overlaid.
+        
+        :returns:   Path to the created image (the output file).
+        """
+
+        command = ' '.join([
+            f'convert "{gradient_source.resolve()}"',
+            *self.__add_title_text(),
+            f'"{self.output_file.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.output_file
+
+
+    def __add_all_text(self, gradient_source: Path) -> Path:
+        """
+        Add the title, "EPISODE" prefix, and episode text to the given image.
         
         :param      gradient_source:    Source image with starry gradient
                                         overlaid.
@@ -258,7 +293,11 @@ class StarWarsTitleCard(CardType):
         :returns:   True if custom season titles are indicated, False otherwise.
         """
 
-        generic_formats = ('EPISODE {episode_number}', 'PART {episode_number}')
+        generic_formats = (
+            'EPISODE {episode_number}',
+            'CHAPTER {episode_number}',
+            'PART {episode_number}',
+        )
 
         return episode_text_format not in generic_formats
 
@@ -273,7 +312,10 @@ class StarWarsTitleCard(CardType):
         self.output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Add text to starry image, result is output
-        output_file = self.__add_text(star_image)
+        if self.hide_episode_text:
+            self.__add_only_title(star_image)
+        else:
+            self.__add_all_text(star_image)
 
         # Delete all intermediate images
         self.image_magick.delete_intermediate_images(star_image)

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -232,7 +232,7 @@ class TMDbInterface(WebInterface):
             self.__get_condition(query_type, series_info, episode_info)
         )
 
-        # If request hasn't been blacklisted, not blacklisted
+        # If request DNE, not blacklisted
         if entry == None:
             return False
 
@@ -242,6 +242,31 @@ class TMDbInterface(WebInterface):
 
         # If next hasn't passed, treat as temporary blacklist
         return datetime.now().timestamp() < entry['next']
+
+
+    def is_permanently_blacklisted(self, series_info: SeriesInfo,
+                                   episode_info: EpisodeInfo,
+                                   query_type: str='source') -> bool:
+        """
+        Determines if permanently blacklisted.
+        
+        :param      series_info:   The series information
+        :param      episode_info:  The episode information
+        
+        :returns:   True if permanently blacklisted, False otherwise.
+        """
+
+        # Get the blacklist entry for this request
+        entry = self.__blacklist.get(
+            self.__get_condition(query_type, series_info, episode_info)
+        )
+
+        # If request hasn't been blacklisted, not blacklisted
+        if entry == None:
+            return False
+
+        # If too many failures, blacklisted
+        return entry['failures'] > self.preferences.tmdb_retry_count
 
 
     def __set_tmdb_id(self, series_info: SeriesInfo) -> None:

--- a/modules/TextlessTitleCard.py
+++ b/modules/TextlessTitleCard.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from re import findall
+
+from modules.CardType import CardType
+from modules.Debug import log
+
+class TextlessTitleCard(CardType):
+    """
+    This class describes a type of CardType that does not modify the source
+    image in anyway, and only optionally blurs it. No text of any kind is added.
+    """
+
+    """Characteristics for title splitting by this class"""
+    TITLE_CHARACTERISTICS = {
+        'max_line_width': 999,  # Character count to begin splitting titles
+        'max_line_count': 1,    # Maximum number of lines a title can take up
+        'top_heavy': False,     # This class uses bottom heavy titling
+    }
+
+    """Font case for this card is entirely blank"""
+    DEFAULT_FONT_CASE = 'blank'
+
+    """Default episode text format string, can be overwritten by each class"""
+    EPISODE_TEXT_FORMAT = ''
+
+    """Default font and text color for episode title text"""
+    TITLE_FONT = None
+    TITLE_COLOR = None
+
+    """Default characters to replace in the generic font"""
+    FONT_REPLACEMENTS = {}
+
+    """Whether this CardType uses season titles for archival purposes"""
+    USES_SEASON_TITLE = False
+
+    """Standard class has standard archive name"""
+    ARCHIVE_NAME = 'Textless Version'
+
+    __slots__ = ('source_file', 'output_file', 'blur')
+
+
+    def __init__(self, source: Path, output_file: Path, blur: bool=False,
+                 *args, **kwargs) -> None:
+        """
+        Initialize the TitleCardMaker object. This primarily just stores
+        instance variables for later use in `create()`. If the provided font
+        does not have a character in the title text, a space is used instead.
+
+        :param  source:             Source image.
+        :param  output_file:        Output file.
+        :param  blur:               Whether to blur the source image.
+        :param  args and kwargs:    Unused arguments to permit generalized calls
+                                    for any CardType.
+        """
+        
+        # Initialize the parent class - this sets up an ImageMagickInterface
+        super().__init__()
+
+        # Store arguments as attributes
+        self.source_file = source
+        self.output_file = output_file
+        self.blur = blur
+
+
+    def _resize_and_blur(self) -> Path:
+        """
+        Resize the source image, optionally blurring. Write the resulting image
+        to the output filepath.
+        
+        :returns:   Path to the created image (the output file).
+        """
+
+        command = ' '.join([
+            f'convert "{self.source_file.resolve()}"',
+            f'+profile "*"',
+            f'-gravity center',
+            f'-resize "{self.TITLE_CARD_SIZE}^"',
+            f'-extent "{self.TITLE_CARD_SIZE}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            f'"{self.output_file.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.output_file
+
+
+    @staticmethod
+    def is_custom_font(font: 'Font') -> bool:
+        """
+        Determines whether the given font characteristics constitute a default
+        or custom font.
+        
+        :param      font:   The Font being evaluated.
+        
+        :returns:   False, as fonts are not customizable with this card.
+        """
+
+        return False
+
+
+    @staticmethod
+    def is_custom_season_titles(custom_episode_map: bool, 
+                                episode_text_format: str) -> bool:
+        """
+        Determines whether the given attributes constitute custom or generic
+        season titles.
+        
+        :param      custom_episode_map:     Whether the EpisodeMap was
+                                            customized.
+        :param      episode_text_format:    The episode text format in use.
+        
+        :returns:   False, as season titles are not customizable with this card.
+        """
+
+        return False
+
+
+    def create(self) -> None:
+        """
+        Make the necessary ImageMagick and system calls to create this object's
+        defined title card.
+        """
+
+        # Create the output directory and any necessary parents 
+        self.output_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Resize and optionally blur the source images
+        self._resize_and_blur()
+
+        

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -7,6 +7,7 @@ import modules.preferences as global_preferences
 from modules.AnimeTitleCard import AnimeTitleCard
 from modules.StandardTitleCard import StandardTitleCard
 from modules.StarWarsTitleCard import StarWarsTitleCard
+from modules.TextlessTitleCard import TextlessTitleCard
 
 class TitleCard:
     """
@@ -33,6 +34,7 @@ class TitleCard:
         'generic': StandardTitleCard,
         'anime': AnimeTitleCard,
         'star wars': StarWarsTitleCard,
+        'textless': TextlessTitleCard,
     }
 
     """Mapping of illegal filename characters and their replacements"""

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -71,7 +71,8 @@ class WebInterface:
         return self.__cached_results[-1]
 
 
-    def download_image(self, image_url: str, destination: 'Path') -> None:
+    @staticmethod
+    def download_image(image_url: str, destination: 'Path') -> None:
         """
         Download the provided image URL to the destination filepath.
         


### PR DESCRIPTION
# Major Changes
- Let source images be pulled from Plex
  - Added parsing for `source_priority` global option (defaults to `tmdb, plex`), like:
  ```yaml
  options:
    source_priority: tmdb | plex | tmdb, plex | plex, tmdb
  ```
  - This can specify the order of where source image should be pulled from
  - Created `PlexInterface.get_source_image()` method
  - Closes #141
- Created `TextlessTitleCard` title card class
  - Added `textless` card type identifier
  - Created `blank` font case that just deletes the title text
  - Closes #143
- Allow series-wide arbitrary extras to be provided to `TitleCard` classes
  - Closes #147 
- Allow for local `card_type` files 
  - Closes #150 
# Major Fixes 
- Correctly read summary minimum episode count
# Minor Changes
- Let frequency be scheduled in weeks
- Made `WebInterface.download_image()` static
- Added ability to completely hide `"EPISODE {x}"` (episode text) from Star Wars card if episode text format is `""` (empty string)
- Added variable episode text offset in `StarWarsTitleCard` if prefix text is chapter, episode, or part
- Precompile partless title regex 
- Change `CardType.DEFAULT_FONT_CASE` to `source`, from `upper`
# Minor Fixes
- Correctly set backdrop as downloadable for `art`/`art` un/watched styles