### PR TITLE
Allow for preferred titles, fixed source image selection from TMDb

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,14 @@ def run():
 
 # Run immediately if specified
 if args.run:
-    run()  
+    from cProfile import Profile
+    from pstats import Stats
+
+    with Profile() as pr:
+        run()
+
+    stats = Stats(pr)
+    stats.dump_stats(filename='all.prof')   
 
 # Schedule subsequent runs if specified
 if hasattr(args, 'runtime'):

--- a/main.py
+++ b/main.py
@@ -122,14 +122,7 @@ def run():
 
 # Run immediately if specified
 if args.run:
-    from cProfile import Profile
-    from pstats import Stats
-
-    with Profile() as pr:
-        run()
-
-    stats = Stats(pr)
-    stats.dump_stats(filename='all.prof')   
+    run()
 
 # Schedule subsequent runs if specified
 if hasattr(args, 'runtime'):

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -124,14 +124,19 @@ class DataFileInterface:
             for episode_number, episode_data in season_data.items():
                 # If the 'title' key is missing (or no subkeys at all..) error
                 if (not isinstance(episode_data, dict)
-                    or 'title' not in episode_data):
+                    or ('title' not in episode_data
+                    and 'preferred_title' not in episode_data)):
                     log.error(f'Season {season_number}, Episode {episode_number}'
                               f' of "{self.file.resolve()}" is missing title')
                     continue
 
+                # If translated title is available, prefer that
+                title = episode_data.pop('title', '')
+                title = episode_data.pop('preferred_title', title)
+
                 # Construct EpisodeInfo object for this entry
                 episode_info = EpisodeInfo(
-                    Title(episode_data.pop('title')),
+                    Title(title),
                     season_number,
                     episode_number,
                     episode_data.pop('abs_number', None),

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -145,15 +145,15 @@ class Manager:
             pbar.set_description(f'Selecting sources for '
                                  f'"{show.series_info.short_name}"')
 
-            # Modify unwatched episodes based on Plex watch status
+            # Select source images from Plex and/or TMDb
+            interfaces = {'plex_interface': None, 'tmdb_interface': None}
             if self.preferences.use_plex:
-                if self.preferences.use_tmdb:
-                    show.select_source_images(self.plex_interface,
-                                              self.tmdb_interface)
-                else:
-                    show.select_source_images(self.plex_interface)
-            else:
-                show.select_source_images()
+                interfaces['plex_interface'] = self.plex_interface
+            if self.preferences.use_tmdb:
+                interfaces['tmdb_interface'] = self.tmdb_interface
+
+            # Pass enabled interfaces
+            show.select_source_images(**interfaces)
 
 
     def create_missing_title_cards(self) -> None:

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -242,6 +242,25 @@ class PlexInterface:
             return None
 
 
+    def has_series(self, library_name: str, series_info: 'SeriesInfo') -> bool:
+        """
+        Determine whether the given series is present within Plex.
+        
+        :param      library_name:   The name of the library containing the
+                                    series to update.
+        :param      series_info:    The series to update.
+        
+        :returns:   True if the series is present within Plex.
+        """
+
+        # If the given library cannot be found, exit
+        if not (library := self.__get_library(library_name)):
+            return False
+
+        # If the given series cannot be found in this library, exit
+        return self.__get_series(library, series_info) != None
+
+
     def update_watched_statuses(self, library_name: str,
                                 series_info: 'SeriesInfo', episode_map: dict,
                                 watched_style: str, unwatched_style: str)->None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -53,7 +53,7 @@ class PreferenceParser(YamlReader):
         self.card_type = 'standard'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.card_extension = TitleCard.DEFAULT_CARD_EXTENSION
-        self.source_priority = ['tmdb', 'plex']
+        self.source_priority = ('tmdb', 'plex')
         self.validate_fonts = True
         self.zero_pad_seasons = False
         self.archive_directory = None
@@ -159,7 +159,8 @@ class PreferenceParser(YamlReader):
                 self.card_extension = extension
 
         if (value := self._get('options', 'source_priority', type_=str)) !=None:
-            sources = tuple(map(str.lower, value.split(', ')))
+            lower_strip = lambda s: str(s).lower().strip()
+            sources = tuple(map(lower_strip, value.split(', ')))
             if not all(_ in self.VALID_SOURCES for _ in sources):
                 log.critical(f'Source priorities "{value}" is invalid')
                 self.valid = False
@@ -399,6 +400,25 @@ class PreferenceParser(YamlReader):
                     font_map,
                     self.source_directory,
                 )
+
+
+    @property
+    def check_tmdb(self):
+        return 'tmdb' in self.source_priority
+
+    @property
+    def check_plex(self):
+        return 'plex' in self.source_priority
+
+    @property
+    def check_plex_before_tmdb(self) -> bool:
+        """Whether to check Plex source before TMDb"""
+
+        priorities = self.source_priority
+        if 'plex' in priorities and 'tmdb' in priorities:
+            return priorities.index('plex') < priorities.index('tmdb')
+
+        return False
 
                 
     def meets_minimum_resolution(self, width: int, height: int) -> bool:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -415,8 +415,11 @@ class PreferenceParser(YamlReader):
         """Whether to check Plex source before TMDb"""
 
         priorities = self.source_priority
-        if 'plex' in priorities and 'tmdb' in priorities:
-            return priorities.index('plex') < priorities.index('tmdb')
+        if 'plex' in priorities:
+            if 'tmdb' in priorities:
+                return priorities.index('plex') < priorities.index('tmdb')
+
+            return True
 
         return False
 

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -61,7 +61,7 @@ class WebInterface:
         # Make new request, add to cache
         self.__cached_results.append(self.__retry_get(url=url, params=params))
         self.__cache.append({'url': url, 'params': str(params)})
-
+        
         # Delete element from cache if length has been exceeded
         if len(self.__cache) > self.CACHE_LENGTH:
             self.__cache.pop(0)


### PR DESCRIPTION
# Major Changes
- Add parsing for "preferred title" in data file reading 
  - If translated titles are preferred to standard ones, then the translation can be stored under `preferred_title` and it will be used by the Maker instead of standard `title`
  - Closes #154
# Major Fixes 
- Match episode text format key modifiers for `MultiEpisode` objects
  - Episode text format strings like `Episode {episode_number:02}` weren't being modified properly, as the modifier text (`:02`) wasn't being identified
  - Now using following regex to identify any prefix/postfix/modifier text:
  ```regex
  ^(.*?)(\s*){(episode|abs)_number(.*?)}(.*)
  ```
  - Closes #152
- Correctly identify whether a TMDb request has been permanently blacklisted
- Correctly select source images if using _only_ TMDb sourcing 
  - Closes #153 
# Minor Changes
- Delete functionality to import old TMDb blacklist
# Minor Fixes
N/A