### PR TITLE
Create reality TV CardType, fix for first run of Maker

### DIFF
--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -94,7 +94,7 @@ class AnimeTitleCard(CardType):
 
         # Store kanji, set bool for whether to use it or not
         self.kanji = self.image_magick.escape_chars(kanji)
-        self.use_kanji = (kanji != None)
+        self.use_kanji = (kanji is not None)
 
         # Store season and episode text
         self.season_text = self.image_magick.escape_chars(season_text.upper())

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -62,8 +62,8 @@ class AnimeTitleCard(CardType):
     
     def __init__(self, source: Path, output_file: Path, title: str, 
                  season_text: str, episode_text: str, hide_season: bool,
-                 kanji: str=None, blur: bool=False, font_size: float=1.0,
-                 *args, **kwargs) -> None:
+                 kanji: str=None, require_kanji: bool=False, blur: bool=False,
+                 font_size: float=1.0, *args, **kwargs) -> None:
         """
         Constructs a new instance.
         
@@ -74,8 +74,9 @@ class AnimeTitleCard(CardType):
         :param      episode_text:       The episode text for this card.
         :param      hide_season:        Whether to hide the season text on this
                                         card.
-        :param      kanji:              Optional kanji text to place above the
+        :param      kanji:              Kanji text to place above the
                                         episode title on this card.
+        :param      require_kanji:      Whether to require kanji for this card.
         :param      blur:               Whether to blur the source image.
         :param      font_size:          Scalar to apply to the title font size.
         :param      args and kwargs:    Unused arguments to permit generalized
@@ -95,6 +96,7 @@ class AnimeTitleCard(CardType):
         # Store kanji, set bool for whether to use it or not
         self.kanji = self.image_magick.escape_chars(kanji)
         self.use_kanji = (kanji is not None)
+        self.require_kanji = require_kanji
 
         # Store season and episode text
         self.season_text = self.image_magick.escape_chars(season_text.upper())
@@ -428,6 +430,11 @@ class AnimeTitleCard(CardType):
         Make the necessary ImageMagick and system calls to create this object's
         defined title card.
         """
+
+        # If kanji is required (and not given), error!
+        if self.require_kanji and not self.use_kanji:
+            log.error(f'Kanji is required and not provided - skipping card')
+            return None
         
         # Create the output directory and any necessary parents 
         self.output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -245,7 +245,7 @@ class DataFileInterface:
             }
 
             # Add absolute number if given
-            if episode_info.abs_number != None:
+            if episode_info.abs_number is not None:
                 yaml[season_key][episode_info.episode_number]['abs_number'] =\
                     episode_info.abs_number
 

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -106,7 +106,7 @@ class Episode:
         """
 
         # If no actual new source was provided, return
-        if new_source == None:
+        if new_source is None:
             return False
 
         # Update source path based on input (Path/str of filename in source,etc)

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -30,7 +30,7 @@ class EpisodeInfo:
         self.episode_number = int(episode_number)
         self.episode = self.episode_number
 
-        self.abs_number = None if abs_number == None else int(abs_number)
+        self.abs_number = None if abs_number is None else int(abs_number)
         self.abs = self.abs_number
 
         # Create key for unique indexing associated with this Episode
@@ -55,10 +55,10 @@ class EpisodeInfo:
         ret = (f'<EpisodeInfo {self.title=}, {self.season_number=}, '
                f'{self.episode_number=}')
 
-        ret += '' if self.sonarr_id == None else f', {self.sonarr_id=}'
-        ret += '' if self.tvdb_id == None else f', {self.tvdb_id=}'
-        ret += '' if self.tmdb_id == None else f', {self.tmdb_id=}'
-        ret += '' if self.abs_number != None else f', {self.abs_number=}'
+        ret += '' if self.sonarr_id is None else f', {self.sonarr_id=}'
+        ret += '' if self.tvdb_id is None else f', {self.tvdb_id=}'
+        ret += '' if self.tmdb_id is None else f', {self.tmdb_id=}'
+        ret += '' if self.abs_number is None else f', {self.abs_number=}'
 
         return f'{ret}>'
 

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -197,7 +197,7 @@ class EpisodeMap:
             return default(episode_info)
         
         # Index by absolute episode number
-        if (episode_info.abs_number == None
+        if (episode_info.abs_number is None
             or episode_info.abs_number not in target):
             return default(episode_info)
         
@@ -217,7 +217,7 @@ class EpisodeMap:
                                         self.get_generic_season_title)
 
         if self.__index_by == 'episode':
-            if (episode_info.abs_number == None
+            if (episode_info.abs_number is None
                 and episode_info.season_number != 0):
                 log.warning(f'Episode range specified, but {episode_info} '
                             f'has no absolute episode number')

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -94,7 +94,7 @@ class Font:
         """Parse this object's YAML and update the validity and attributes."""
 
         # Whether to validate for this font
-        if (value := self.__yaml.get('validate')) != None:
+        if (value := self.__yaml.get('validate')) is not None:
             self.__validate = bool(value)
 
         # Font case
@@ -106,7 +106,7 @@ class Font:
                 self.case = self.__card_class.CASE_FUNCTIONS[value]
 
         # Font color
-        if (value := self.__yaml.get('color')) != None:
+        if (value := self.__yaml.get('color')) is not None:
             if (not isinstance(value, str)
                 or not bool(match('^#[a-fA-F0-9]{6}$', value))):
                 self.__error('color', value, 'specify as "#xxxxxx"')
@@ -114,7 +114,7 @@ class Font:
                 self.color = value
 
         # Font file
-        if (value := self.__yaml.get('file')) != None:
+        if (value := self.__yaml.get('file')) is not None:
             if not isinstance(value, str):
                 self.__error('file', value, 'not a valid path')
             elif (value := Path(value)).exists():
@@ -129,7 +129,7 @@ class Font:
                 self.__error('file', value, 'no font file found')
 
         # Font replacements
-        if (value := self.__yaml.get('replacements')) != None:
+        if (value := self.__yaml.get('replacements')) is not None:
             if not isinstance(value, dict):
                 self.__error('replacements', value, 'must be character set')
             if any(len(key) != 1 for key in value.keys()):
@@ -141,7 +141,7 @@ class Font:
                 self.replacements = value
 
         # Font Size
-        if (value := self.__yaml.get('size')) != None:
+        if (value := self.__yaml.get('size')) is not None:
             if (not isinstance(value, str)
                 or not bool(self._PERCENT_REGEX_POSITIVE.match(value))):
                 self.__error('size', value, 'specify as "x%')
@@ -149,21 +149,21 @@ class Font:
                 self.size = float(value[:-1]) / 100.0
 
         # Vertical shift
-        if (value := self.__yaml.get('vertical_shift')) != None:
+        if (value := self.__yaml.get('vertical_shift')) is not None:
             if not isinstance(value, int):
                 self.__error('vertical_shift', value, 'must be integer')
             else:
                 self.vertical_shift = value
 
         # Interline spacing
-        if (value := self.__yaml.get('interline_spacing')) != None:
+        if (value := self.__yaml.get('interline_spacing')) is not None:
             if not isinstance(value, int):
                 self.__error('interline_spacing', value, 'must be integer')
             else:
                 self.interline_spacing = value
                 
         # Kerning
-        if (value := self.__yaml.get('kerning')) != None:
+        if (value := self.__yaml.get('kerning')) is not None:
             if (not isinstance(value, str)
                 or not bool(self._PERCENT_REGEX.match(value))):
                 self.__error('kerning', value, 'specify as "x%"')
@@ -171,7 +171,7 @@ class Font:
                 self.kerning = float(value[:-1]) / 100.0
 
         # Stroke width
-        if (value := self.__yaml.get('stroke_width')) != None:
+        if (value := self.__yaml.get('stroke_width')) is not None:
             if (not isinstance(value, str)
                 or not bool(self._PERCENT_REGEX_POSITIVE.match(value))):
                 self.__error('stroke_width', value, 'specify as "x%"')

--- a/modules/LogoTitleCard.py
+++ b/modules/LogoTitleCard.py
@@ -16,7 +16,7 @@ class LogoTitleCard(CardType):
     """Characteristics for title splitting by this class"""
     TITLE_CHARACTERISTICS = {
         'max_line_width': 32,   # Character count to begin splitting titles
-        'max_line_count': 3,    # Maximum number of lines a title can take up
+        'max_line_count': 2,    # Maximum number of lines a title can take up
         'top_heavy': False,     # This class uses bottom heavy titling
     }
 

--- a/modules/LogoTitleCard.py
+++ b/modules/LogoTitleCard.py
@@ -1,0 +1,497 @@
+from pathlib import Path
+from re import findall
+
+from modules.CardType import CardType
+from modules.Debug import log
+
+class LogoTitleCard(CardType):
+    """
+    This class describes a type of CardType that produces logo-centric title
+    cards, primarily for the purpose of reality TV shows.
+    """
+    
+    """Directory where all reference files used by this card are stored"""
+    REF_DIRECTORY = Path(__file__).parent / 'ref'
+
+    """Characteristics for title splitting by this class"""
+    TITLE_CHARACTERISTICS = {
+        'max_line_width': 32,   # Character count to begin splitting titles
+        'max_line_count': 3,    # Maximum number of lines a title can take up
+        'top_heavy': False,     # This class uses bottom heavy titling
+    }
+
+    """Default font and text color for episode title text"""
+    TITLE_FONT = str((REF_DIRECTORY / 'Sequel-Neue.otf').resolve())
+    TITLE_COLOR = '#EBEBEB'
+
+    """Default characters to replace in the generic font"""
+    FONT_REPLACEMENTS = {'[': '(', ']': ')', '(': '[', ')': ']', '―': '-',
+                         '…': '...'}
+
+    """Whether this CardType uses season titles for archival purposes"""
+    USES_SEASON_TITLE = True
+
+    """Whether this CardType uses unique source images"""
+    USES_UNIQUE_SOURCES = False
+
+    """Standard class has standard archive name"""
+    ARCHIVE_NAME = 'Logo Style'
+
+    """Default fonts and color for series count text"""
+    SEASON_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Semibold.otf'
+    EPISODE_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Regular.otf'
+    SERIES_COUNT_TEXT_COLOR = '#CFCFCF'
+
+    """Paths to intermediate files that are deleted after the card is created"""
+    __RESIZED_LOGO = CardType.TEMP_DIR / 'resized_logo.png'
+    __BACKDROP_WITH_LOGO = CardType.TEMP_DIR / 'backdrop_logo.png'
+    __LOGO_WITH_TITLE = CardType.TEMP_DIR / 'logo_title.png'
+    __SERIES_COUNT_TEXT = CardType.TEMP_DIR / 'series_count_text.png'
+
+    __slots__ = ('source_file', 'output_file', 'title', 'season_text',
+                 'episode_text', 'font', 'font_size', 'title_color',
+                 'hide_season', 'blur', 'vertical_shift', 'interline_spacing',
+                 'kerning', 'stroke_width')
+
+
+    def __init__(self, output_file: Path, title: str, season_text: str,
+                 episode_text: str, font: str, font_size: float,
+                 title_color: str, hide_season: bool, blur: bool=False,
+                 vertical_shift: int=0, interline_spacing: int=0,
+                 kerning: float=1.0, stroke_width: float=1.0,
+                 logo: str=None, background: str='#000000',
+                 *args, **kwargs) -> None:
+        """
+        Initialize the TitleCardMaker object. This primarily just stores
+        instance variables for later use in `create()`. If the provided font
+        does not have a character in the title text, a space is used instead.
+
+        :param  output_file:        Output file.
+        :param  title:              Episode title.
+        :param  season_text:        Text to use as season count text. Ignored if
+                                    hide_season is True.
+        :param  episode_text:       Text to use as episode count text.
+        :param  font:               Font to use for the episode title.
+        :param  font_size:          Scalar to apply to the title font size.
+        :param  title_color:        Color to use for the episode title.
+        :param  hide_season:        Whether to omit the season text (and joining
+                                    character) from the title card completely.
+        :param  blur:               Whether to blur the source image.
+        :param  vertical_shift:     Pixels to adjust title vertical shift by.
+        :param  interline_spacing:  Pixels to adjust title interline spacing by.
+        :param  kerning:            Scalar to apply to kerning of the title text.
+        :param  stroke_width:       Scalar to apply to black stroke of the title
+                                    text.
+        :param  logo:               Filepath to the logo file.
+        :param  background:         Backround color to use for this card.
+        :param  args and kwargs:    Unused arguments to permit generalized calls
+                                    for any CardType.
+        """
+        
+        # Initialize the parent class - this sets up an ImageMagickInterface
+        super().__init__()
+
+        self.logo = Path(logo) if logo != None else None
+        self.output_file = output_file
+
+        # Ensure characters that need to be escaped are
+        self.title = self.image_magick.escape_chars(title)
+        self.season_text = self.image_magick.escape_chars(season_text.upper())
+        self.episode_text = self.image_magick.escape_chars(episode_text.upper())
+
+        self.font = font
+        self.font_size = font_size
+        self.title_color = title_color
+        self.hide_season = hide_season
+        self.blur = blur
+        self.vertical_shift = vertical_shift
+        self.interline_spacing = interline_spacing
+        self.kerning = kerning
+        self.stroke_width = stroke_width
+        self.background = background
+
+
+    def __title_text_global_effects(self) -> list:
+        """
+        ImageMagick commands to implement the title text's global effects.
+        Specifically the the font, kerning, fontsize, and center gravity.
+        
+        :returns:   List of ImageMagick commands.
+        """
+
+        font_size = 157.41 * self.font_size
+        interline_spacing = -22 + self.interline_spacing
+        kerning = -1.25 * self.kerning
+
+        return [
+            f'-font "{self.font}"',
+            f'-kerning {kerning}',
+            f'-interword-spacing 50',
+            f'-interline-spacing {interline_spacing}',
+            f'-pointsize {font_size}',
+            f'-gravity south',
+        ]   
+
+
+    def __title_text_black_stroke(self) -> list:
+        """
+        ImageMagick commands to implement the title text's black stroke.
+        
+        :returns:   List of ImageMagick commands.
+        """
+
+        stroke_width = 3.0 * self.stroke_width
+
+        return [
+            f'-fill black',
+            f'-stroke black',
+            f'-strokewidth {stroke_width}',
+        ]
+
+
+    def __series_count_text_global_effects(self) -> list:
+        """
+        ImageMagick commands for global text effects applied to all series count
+        text (season/episode count and dot).
+        
+        :returns:   List of ImageMagick commands.
+        """
+
+        return [
+            f'-kerning 5.42',
+            f'-pointsize 67.75',
+        ]
+
+
+    def __series_count_text_black_stroke(self) -> list:
+        """
+        ImageMagick commands for adding the necessary black stroke effects to
+        series count text.
+        
+        :returns:   List of ImageMagick commands.
+        """
+
+        return [
+            f'-fill black',
+            f'-stroke black',
+            f'-strokewidth 6',
+        ]
+
+
+    def __series_count_text_effects(self) -> list:
+        """
+        ImageMagick commands for adding the necessary text effects to the series
+        count text.
+        
+        :returns:   List of ImageMagick commands.
+        """
+
+        return [
+            f'-fill "{self.SERIES_COUNT_TEXT_COLOR}"',
+            f'-stroke "{self.SERIES_COUNT_TEXT_COLOR}"',
+            f'-strokewidth 0.75',
+        ]
+
+
+    def _resize_logo(self) -> Path:
+        """
+        Resize the logo into at most a 1875x1030 bounding box.
+        
+        :returns:   Path to the created image.
+        """
+
+        command = ' '.join([
+            f'convert',
+            f'"{self.logo.resolve()}"',
+            f'-resize x1030',
+            f'-resize 1875x1030\>',
+            f'"{self.__RESIZED_LOGO.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.__RESIZED_LOGO
+
+
+    def _add_logo_to_backdrop(self, resized_logo: Path) -> Path:
+        """
+        Add the resized logo to a fixed color backdrop.
+        
+        :returns:   Path to the created image.
+        """
+
+        # Get height of the resized logo to determine offset
+        height_command = ' '.join([
+            f'identify',
+            f'-format "%h"',
+            f'"{resized_logo.resolve()}"',
+        ])
+
+        height = int(self.image_magick.run_get_output(height_command))
+
+        # Get offset of where to place logo onto card
+        offset = 60 + ((1030 - height) // 2)
+
+        command = ' '.join([
+            f'convert',
+            f'-size "{self.TITLE_CARD_SIZE}"',  # Create backdrop
+            f'xc:"{self.background}"',          # Fill canvas with color
+            f'"{resized_logo.resolve()}"',
+            f'-gravity north',
+            f'-geometry "+0+{offset}"',         # Put logo on backdrop
+            f'-composite "{self.__BACKDROP_WITH_LOGO.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.__BACKDROP_WITH_LOGO
+
+
+    def _add_title_text(self, backdrop_logo: Path) -> Path:
+        """
+        Adds episode title text to the provide image.
+
+        :param      backdrop_logo:  The backdrop and logo image.
+        
+        :returns:   Path to the created image that has the title text added.
+        """
+
+        vertical_shift = 245 + self.vertical_shift
+
+        command = ' '.join([
+            f'convert "{backdrop_logo.resolve()}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            *self.__title_text_global_effects(),
+            *self.__title_text_black_stroke(),
+            f'-annotate +0+{vertical_shift} "{self.title}"',
+            f'-fill "{self.title_color}"',
+            f'-annotate +0+{vertical_shift} "{self.title}"',
+            f'"{self.__LOGO_WITH_TITLE.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.__LOGO_WITH_TITLE
+
+
+    def _add_series_count_text_no_season(self, titled_image: Path) -> Path:
+        """
+        Adds the series count text without season title/number.
+        
+        :param      titled_image:  The titled image to add text to.
+
+        :returns:   Path to the created image (the output file).
+        """
+
+        command = ' '.join([
+            f'convert "{titled_image.resolve()}"',
+            *self.__series_count_text_global_effects(),
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
+            f'-gravity center',
+            *self.__series_count_text_black_stroke(),
+            f'-annotate +0+697.2 "{self.episode_text}"',
+            *self.__series_count_text_effects(),
+            f'-annotate +0+697.2 "{self.episode_text}"',
+            f'"{self.output_file.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.output_file
+
+
+    def _get_series_count_text_dimensions(self) -> dict:
+        """
+        Gets the series count text dimensions.
+        
+        :returns:   The series count text dimensions.
+        """
+
+        command = ' '.join([
+            f'convert -debug annotate xc: ',
+            *self.__series_count_text_global_effects(),
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
+            f'-gravity east',
+            *self.__series_count_text_effects(),
+            f'-annotate +1600+697.2 "{self.season_text} "',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
+            f'-gravity center',
+            *self.__series_count_text_effects(),
+            f'-annotate +0+689.5 "• "',
+            f'-gravity west',
+            *self.__series_count_text_effects(),
+            f'-annotate +1640+697.2 "{self.episode_text}"',
+            f'null: 2>&1'
+        ])
+
+        # Get text dimensions from the output
+        metrics = self.image_magick.run_get_output(command)
+        widths = list(map(int, findall(r'Metrics:.*width:\s+(\d+)', metrics)))
+        heights = list(map(int, findall(r'Metrics:.*height:\s+(\d+)', metrics)))
+
+        # Don't raise IndexError if no dimensions were found
+        if len(widths) < 2 or len(heights) < 2:
+            log.warning(f'Unable to identify font dimensions, file bug report')
+            widths = [370, 47, 357]
+            heights = [68, 83, 83]
+
+        return {
+            'width':    sum(widths),
+            'width1':   widths[0],
+            'width2':   widths[1],
+            'height':   max(heights)+25,
+        }
+
+
+    def _create_series_count_text_image(self, width: float, width1: float,
+                                        width2: float, height: float) -> Path:
+        """
+        Creates an image with only series count text. This image is transparent,
+        and not any wider than is necessary (as indicated by `dimensions`).
+        
+        :returns:   Path to the created image containing only series count text.
+        """
+
+        # Create text only transparent image of season count text
+        command = ' '.join([
+            f'convert -size "{width}x{height}"',
+            f'-alpha on',
+            f'-background transparent',
+            f'xc:transparent',
+            *self.__series_count_text_global_effects(),
+            f'-font "{self.SEASON_COUNT_FONT.resolve()}"',
+            *self.__series_count_text_black_stroke(),
+            f'-annotate +0+{height-25} "{self.season_text} "',
+            *self.__series_count_text_effects(),
+            f'-annotate +0+{height-25} "{self.season_text} "',
+            f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
+            *self.__series_count_text_black_stroke(),
+            f'-annotate +{width1}+{height-25-6.5} "•"',
+            *self.__series_count_text_effects(),
+            f'-annotate +{width1}+{height-25-6.5} "•"',
+            *self.__series_count_text_black_stroke(),
+            f'-annotate +{width1+width2}+{height-25} "{self.episode_text}"',
+            *self.__series_count_text_effects(),
+            f'-annotate +{width1+width2}+{height-25} "{self.episode_text}"',
+            f'"PNG32:{self.__SERIES_COUNT_TEXT.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.__SERIES_COUNT_TEXT
+
+
+    def _combine_titled_image_series_count_text(self, titled_image: Path,
+                                                series_count_image: Path)->Path:
+        """
+        Combine the titled image (image+backdrop+episode title) and the series
+        count image (optional season number+optional dot+episode number) into a
+        single image. This is written into the output image for this object.
+
+        :param      titled_image:       Path to the titled image to add.
+        :param      series_count_image: Path to the series count transparent
+                                        image to add.
+
+        :returns:   Path to the created image (the output file).
+        """
+
+        command = ' '.join([
+            f'composite',
+            f'-gravity center',
+            f'-geometry +0+690.2',
+            f'"{series_count_image.resolve()}"',
+            f'"{titled_image.resolve()}"',
+            f'"{self.output_file.resolve()}"',
+        ])
+
+        self.image_magick.run(command)
+
+        return self.output_file
+
+
+    @staticmethod
+    def is_custom_font(font: 'Font') -> bool:
+        """
+        Determines whether the given font characteristics constitute a default
+        or custom font.
+        
+        :param      font:   The Font being evaluated.
+        
+        :returns:   True if a custom font is indicated, False otherwise.
+        """
+
+        return ((font.file != LogoTitleCard.TITLE_FONT)
+            or (font.size != 1.0)
+            or (font.color != LogoTitleCard.TITLE_COLOR)
+            or (font.replacements != LogoTitleCard.FONT_REPLACEMENTS)
+            or (font.vertical_shift != 0)
+            or (font.interline_spacing != 0)
+            or (font.kerning != 1.0)
+            or (font.stroke_width != 1.0))
+
+
+    @staticmethod
+    def is_custom_season_titles(custom_episode_map: bool, 
+                                episode_text_format: str) -> bool:
+        """
+        Determines whether the given attributes constitute custom or generic
+        season titles.
+        
+        :param      custom_episode_map:     Whether the EpisodeMap was
+                                            customized.
+        :param      episode_text_format:    The episode text format in use.
+        
+        :returns:   True if custom season titles are indicated, False otherwise.
+        """
+
+        standard_etf = LogoTitleCard.EPISODE_TEXT_FORMAT.upper()
+
+        return (custom_episode_map or
+                episode_text_format.upper() != standard_etf)
+
+
+    def create(self) -> None:
+        """
+        Make the necessary ImageMagick and system calls to create this object's
+        defined title card.
+        """
+        
+        # Skip card if logo doesn't exist
+        if self.logo == None:
+            log.error(f'Logo file not specified')
+            return None
+        elif not self.logo.exists():
+            log.error(f'Logo file "{self.logo.resolve()}" does not exist')
+            return None
+
+        # Resize logo
+        resized_logo = self._resize_logo()
+        
+        # Create backdrop+logo image
+        backdrop_logo = self._add_logo_to_backdrop(resized_logo)
+
+        # Add either one or two lines of episode text 
+        titled_image = self._add_title_text(backdrop_logo)
+
+        # Create the output directory and any necessary parents 
+        self.output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # If season text is hidden, just add episode text 
+        if self.hide_season:
+            self._add_series_count_text_no_season(titled_image)
+        else:
+            # If adding season text, create intermediate images and combine them
+            series_count_image = self._create_series_count_text_image(
+                **self._get_series_count_text_dimensions()
+            )
+            self._combine_titled_image_series_count_text(
+                titled_image,
+                series_count_image
+            )
+
+        # Delete all intermediate images
+        images = [resized_logo, backdrop_logo, titled_image]
+        if not self.hide_season:
+            images.append(series_count_image)
+
+        self.image_magick.delete_intermediate_images(*images)

--- a/modules/LogoTitleCard.py
+++ b/modules/LogoTitleCard.py
@@ -91,7 +91,7 @@ class LogoTitleCard(CardType):
         # Initialize the parent class - this sets up an ImageMagickInterface
         super().__init__()
 
-        self.logo = Path(logo) if logo != None else None
+        self.logo = Path(logo) if logo is not None else None
         self.output_file = output_file
 
         # Ensure characters that need to be escaped are
@@ -457,7 +457,7 @@ class LogoTitleCard(CardType):
         """
         
         # Skip card if logo doesn't exist
-        if self.logo == None:
+        if self.logo is None:
             log.error(f'Logo file not specified')
             return None
         elif not self.logo.exists():

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -268,7 +268,7 @@ class Manager:
                     show_dict[str(episode)]['source'] = episode.source.name
 
                 # If destination card doesn't exist, add to report
-                if (episode.destination != None
+                if (episode.destination is not None
                     and not episode.destination.exists()):
                     if str(episode) not in show_dict:
                         show_dict[str(episode)] = {}

--- a/modules/MultiEpisode.py
+++ b/modules/MultiEpisode.py
@@ -50,7 +50,7 @@ class MultiEpisode:
         
         # If all episode have absolute numbers, get their range
         self.abs_start, self.abs_end = None, None
-        if all(e.abs_number != None for e in episode_infos):
+        if all(e.abs_number is not None for e in episode_infos):
             abs_numbers = tuple(map(lambda e: e.abs_number, episode_infos))
             self.abs_start = min(abs_numbers)
             self.abs_end = max(abs_numbers)
@@ -82,8 +82,8 @@ class MultiEpisode:
         ret = (f'<MultiEpisode episode_start={self.episode_start}, episode_end='
                f'{self.episode_end}, title={self.episode_info.title}, '
                f'destination={self.destination}')
-        ret += f', abs_start={self.abs_start}' if self.abs_start != None else ''
-        ret += f', abs_end={self.abs_end}' if self.abs_end != None else ''
+        ret += '' if self.abs_start is None else f', abs_start={self.abs_start}'
+        ret += '' if self.abs_end is None else f', abs_end={self.abs_end}'
 
         return f'{ret}>'
 

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -59,7 +59,7 @@ class PlexInterface:
         """
 
         # If no episode was given, get condition for entire series
-        if episode == None:
+        if episode is None:
             return (
                 (where('library') == library_name) &
                 (where('series') == series_info.full_name)
@@ -175,14 +175,14 @@ class PlexInterface:
 
         # Try by TVDb ID
         try:
-            if series_info.tvdb_id != None:
+            if series_info.tvdb_id is not None:
                 return library.getGuid(f'tvdb://{series_info.tvdb_id}')
         except NotFound:
             pass
 
         # Try by TMDb ID
         try:
-            if series_info.tmdb_id != None:
+            if series_info.tmdb_id is not None:
                 return library.getGuid(f'tmdb://{series_info.tmdb_id}')
         except NotFound:
             pass
@@ -222,7 +222,7 @@ class PlexInterface:
             return False
 
         # If the given series cannot be found in this library, exit
-        return self.__get_series(library, series_info) != None
+        return self.__get_series(library, series_info) is not None
 
 
     def update_watched_statuses(self, library_name: str,
@@ -273,7 +273,7 @@ class PlexInterface:
 
             # Get loaded card characteristics for this episode
             details = self.__get_loaded_episode(loaded_series, episode)
-            loaded = details != None
+            loaded = (details is not None)
             spoiler_status = details['spoiler'] if loaded else None
 
             # Delete and reset card if current spoiler type doesnt match

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -56,6 +56,7 @@ class PreferenceParser(YamlReader):
         self.source_priority = ('tmdb', 'plex')
         self.validate_fonts = True
         self.zero_pad_seasons = False
+        self.hide_season_folders = False
         self.archive_directory = None
         self.create_archive = False
         self.archive_all_variations = True
@@ -172,6 +173,10 @@ class PreferenceParser(YamlReader):
 
         if (value := self._get('options', 'zero_pad_seasons',type_=bool))!=None:
             self.zero_pad_seasons = value
+
+        if (value := self._get('options', 'hide_season_folders',
+                               type_=bool)) != None:
+            self.hide_season_folders = value
 
         if (value := self._get('archive', 'path', type_=Path)) != None:
             self.archive_directory = value
@@ -444,15 +449,21 @@ class PreferenceParser(YamlReader):
     def get_season_folder(self, season_number: int) -> str:
         """
         Get the season folder name for the given season number, padding the
-        season number if indicated by the preference file.
+        season number if indicated by the preference file, and returning an
+        empty string if season folders are hidden.
         
-        :param      season_number:  The season number.
+        :param      season_number:  The season number to get the folder name of.
         
-        :returns:   The season folder. This is 'Specials' for 0, and either a
-                    zero-padded or not zero-padded version of "Season {x}".
+        :returns:   The season folder name. Empty string if folders are hidden,
+                    'Specials' for season 0, and either a zero-padded or not
+                    zero-padded version of "Season {x}" otherwise.
         """
 
-        # Season 0 is always Specials
+        # If season folders are hidden, return empty string
+        if self.hide_season_folders:
+            return ''
+
+        # Season 0 is always Specials (never padded)
         if season_number == 0:
             return 'Specials'
 

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -42,7 +42,7 @@ class PreferenceParser(YamlReader):
         self.read_file()
 
         # Check for required source directory
-        if (value := self._get('options', 'source', type_=Path)) == None:
+        if (value := self._get('options', 'source', type_=Path)) is None:
             log.critical(f'Preference file missing required options/source '
                          f'attribute')
             exit(1)
@@ -128,7 +128,7 @@ class PreferenceParser(YamlReader):
 
         lower_str = lambda v: str(v).lower()
 
-        if (value := self._get('options', 'series')) != None:
+        if (value := self._get('options', 'series')) is not None:
             if isinstance(value, list):
                 self.series_files = value
             else:

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -147,7 +147,7 @@ class Profile:
 
         # Warn if absolute number is requested but not present
         if (self.__use_custom_seasons and '{abs_' in self.episode_text_format
-            and episode.episode_info.abs_number == None):
+            and episode.episode_info.abs_number is None):
                 log.warning(f'Episode text formatting uses absolute episode '
                             f'number, but {episode} has no absolute number')
 

--- a/modules/RemoteCardType.py
+++ b/modules/RemoteCardType.py
@@ -22,7 +22,7 @@ class RemoteCardType:
     TEMP_DIR = Path(__file__).parent / '.objects'
 
     """List of assets that have been loaded already"""
-    LOADED = TinyDB(TEMP_DIR / 'remote_assets.json')
+    LOADED = TinyDB(TEMP_DIR / 'remote_assets.json', create_dirs=True)
 
     __slots__ = ('card_class', 'valid')
 

--- a/modules/RemoteFile.py
+++ b/modules/RemoteFile.py
@@ -46,7 +46,7 @@ class RemoteFile:
         self.local_file.parent.mkdir(parents=True, exist_ok=True)
 
         # If file has already been loaded this run, skip
-        if self.LOADED.get(where('remote') == self.remote_source) != None:
+        if self.LOADED.get(where('remote') == self.remote_source) is not None:
             return None
 
         # Download the remote file for local use

--- a/modules/RemoteFile.py
+++ b/modules/RemoteFile.py
@@ -23,7 +23,7 @@ class RemoteFile:
     TEMP_DIR = Path(__file__).parent / '.objects'
 
     """List of assets that have been loaded already"""
-    LOADED = TinyDB(TEMP_DIR / 'remote_assets.json')
+    LOADED = TinyDB(TEMP_DIR / 'remote_assets.json', create_dirs=True)
 
 
     def __init__(self, username: str, filename: str) -> None:

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -54,9 +54,9 @@ class SeriesInfo:
         """Returns a unambiguous string representation of the object."""
 
         ret = f'<SeriesInfo name={self.name}, year={self.year}'
-        ret += '' if self.sonarr_id == None else f', sonarr_id={self.sonarr_id}'
-        ret += '' if self.tvdb_id == None else f', tvdb_id={self.tvdb_id}'
-        ret += '' if self.tmdb_id == None else f', tmdb_id={self.tmdb_id}'
+        ret += '' if self.sonarr_id is None else f', sonarr_id={self.sonarr_id}'
+        ret += '' if self.tvdb_id is None else f', tvdb_id={self.tvdb_id}'
+        ret += '' if self.tmdb_id is None else f', tmdb_id={self.tmdb_id}'
 
         return f'{ret}>'
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -262,7 +262,7 @@ class Show(YamlReader):
         self.valid &= self.__episode_map.valid
 
         # Read all extras
-        if (self._is_specified('extras')):
+        if self._is_specified('extras'):
             self.extras = self._get('extras', type_=dict)
 
 

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -74,7 +74,7 @@ class Show(YamlReader):
         self.series_info = SeriesInfo(name, 0)
 
         # If year isn't given, skip completely
-        if (year := self._get('year', type_=int)) == None:
+        if (year := self._get('year', type_=int)) is None:
             log.error(f'Series "{name}" is missing the required "year"')
             self.valid = False
             return None
@@ -183,10 +183,10 @@ class Show(YamlReader):
         invalid attributes and update this object's validity.
         """
 
-        if (name := self._get('name', type_=str)) != None:
+        if (name := self._get('name', type_=str)) is not None:
             self.series_info.update_name(name)
 
-        if (library := self._get('library')) != None:
+        if (library := self._get('library')) is not None:
             # If the given library isn't in libary map, invalid
             if not (this_library := self.__library_map.get(library)):
                 log.error(f'Library "{library}" of series {self} is not found '
@@ -202,35 +202,35 @@ class Show(YamlReader):
                 if (card_type := this_library.get('card_type')):
                     self.__parse_card_type(card_type)
 
-        if (card_type := self._get('card_type', type_=str)) != None:
+        if (card_type := self._get('card_type', type_=str)) is not None:
             self.__parse_card_type(card_type)
             
-        if (value := self._get('media_directory', type_=Path)) != None:
+        if (value := self._get('media_directory', type_=Path)) is not None:
             self.media_directory = value
 
-        if (value := self._get('episode_text_format', type_=str)) != None:
+        if (value := self._get('episode_text_format', type_=str)) is not None:
             self.episode_text_format = value
 
-        if (value := self._get('archive', type_=bool)) != None:
+        if (value := self._get('archive', type_=bool)) is not None:
             self.archive = value
 
-        if (value := self._get('sonarr_sync', type_=bool)) != None:
+        if (value := self._get('sonarr_sync', type_=bool)) is not None:
             self.sonarr_sync = value
 
-        if (value := self._get('sync_specials', type_=bool)) != None:
+        if (value := self._get('sync_specials', type_=bool)) is not None:
             self.sync_specials = value
 
-        if (value := self._get('tmdb_sync', type_=bool)) != None:
+        if (value := self._get('tmdb_sync', type_=bool)) is not None:
             self.tmdb_sync = value
 
-        if (value := self._get('watched_style', type_=str)) != None:
+        if (value := self._get('watched_style', type_=str)) is not None:
             if value not in self.VALID_STYLES:
                 log.error(f'Invalid watched style "{value}" in series {self}')
                 self.valid = False
             else:
                 self.watched_style = value
 
-        if (value := self._get('unwatched_style', type_=str)) != None:
+        if (value := self._get('unwatched_style', type_=str)) is not None:
             if value not in self.VALID_STYLES:
                 log.error(f'Invalid unwatched style "{value}" in series {self}')
                 self.valid = False
@@ -241,11 +241,11 @@ class Show(YamlReader):
             log.error(f'"unwatched" setting has been renamed "unwatched_style"')
             self.valid = False
 
-        if (value := self._get('seasons', 'hide', type_=bool)) != None:
+        if (value := self._get('seasons', 'hide', type_=bool)) is not None:
             self.hide_seasons = value
 
         if (self._is_specified('translation', 'language')
-            and (key := self._get('translation', 'key', type_=str)) != None):
+            and (key := self._get('translation', 'key',type_=str)) is not None):
             if key in ('title', 'abs_number'):
                 log.error(f'Cannot add translations under the key "{key}" in '
                           f'series {self}')
@@ -452,7 +452,7 @@ class Show(YamlReader):
             )
 
             # If episode wasn't found, or the original title was returned, skip!
-            if (language_title == None
+            if (language_title is None
                 or language_title ==  episode.episode_info.title.full_title):
                 continue
 
@@ -487,11 +487,11 @@ class Show(YamlReader):
         """
 
         # If no library, ignore styles
-        if self.library == None:
+        if self.library is None:
             return False
 
         # Update watched statuses via Plex
-        if plex_interface == None:
+        if plex_interface is None:
             # If no PlexInterface, assume all episodes are unwatched
             [episode.update_statuses(False, self.watched_style,
                                      self.unwatched_style)
@@ -577,7 +577,7 @@ class Show(YamlReader):
         always_check_tmdb = (self.preferences.use_tmdb and tmdb_interface
                              and self.tmdb_sync and self.preferences.check_tmdb)
         always_check_plex = (self.preferences.use_plex and plex_interface
-            and self.library != None and self.preferences.check_plex
+            and self.library is not None and self.preferences.check_plex
             and plex_interface.has_series(self.library_name, self.series_info))
 
         # For each episode, query interfaces (in priority order) for source
@@ -622,7 +622,7 @@ class Show(YamlReader):
                     )
 
                 # If URL was returned by either interface, download
-                if image_url != None:
+                if image_url is not None:
                     WebInterface.download_image(image_url, episode.source)
                     break
             
@@ -678,7 +678,7 @@ class Show(YamlReader):
         """
 
         # Skip if no library specified
-        if self.library_name == None:
+        if self.library_name is None:
             return None
 
         # Update Plex

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -186,7 +186,7 @@ class SonarrInterface(WebInterface):
         # Go through each episode and get its season/episode number, and title
         for episode in all_episodes:
             # Get airdate of this episode
-            if (ep_airdate := episode.get('airDateUtc')) != None:
+            if (ep_airdate := episode.get('airDateUtc')) is not None:
                 # If episode hasn't aired, skip
                 air_datetime=datetime.strptime(ep_airdate,self.__AIRDATE_FORMAT)
                 if (not episode['hasFile']
@@ -238,7 +238,7 @@ class SonarrInterface(WebInterface):
         self.__set_ids(series_info)
 
         # If no ID was returned, error and return an empty list
-        if series_info.sonarr_id == None:
+        if series_info.sonarr_id is None:
             self.__warn_missing_series(series_info)
             return []
 
@@ -256,7 +256,7 @@ class SonarrInterface(WebInterface):
         self.__set_ids(series_info)
 
         # If no ID was returned, error and return
-        if series_info.sonarr_id == None:
+        if series_info.sonarr_id is None:
             self.__warn_missing_series(series_info)
 
 

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -140,7 +140,7 @@ class TMDbInterface(WebInterface):
         later = (datetime.now() + timedelta(days=1)).timestamp()
 
         # If this entry exists, check that next has passed
-        if entry != None:
+        if entry is not None:
             if datetime.now().timestamp() >= entry['next']:
                 self.__blacklist.update(
                     {'failures': entry['failures']+1, 'next': later},
@@ -184,7 +184,7 @@ class TMDbInterface(WebInterface):
         )
 
         # If request DNE, not blacklisted
-        if entry == None:
+        if entry is None:
             return False
 
         # If too many failures, blacklisted
@@ -213,7 +213,7 @@ class TMDbInterface(WebInterface):
         )
 
         # If request hasn't been blacklisted, not blacklisted
-        if entry == None:
+        if entry is None:
             return False
 
         # If too many failures, blacklisted
@@ -241,7 +241,7 @@ class TMDbInterface(WebInterface):
             return None
 
         # Match by TVDB ID if available
-        if series_info.tvdb_id != None:
+        if series_info.tvdb_id is not None:
             # Construct GET arguments
             url = f'{self.API_BASE_URL}find/{series_info.tvdb_id}'
             params = {'api_key': self.__api_key, 'external_source': 'tvdb_id'}
@@ -304,7 +304,7 @@ class TMDbInterface(WebInterface):
         """
         
         # If the episode has a TVDb ID, query with that first
-        if episode_info.tvdb_id != None:
+        if episode_info.tvdb_id is not None:
             # GET parameters and request
             url = f'{self.API_BASE_URL}find/{episode_info.tvdb_id}'
             params = {'api_key': self.__api_key, 'external_source': 'tvdb_id'}
@@ -321,7 +321,7 @@ class TMDbInterface(WebInterface):
                 }
 
         # If the series has no TMDb ID, cannot continue
-        if series_info.tmdb_id == None:
+        if series_info.tmdb_id is None:
             return None
 
         # Match by series TMDb ID and series index with title matching
@@ -333,7 +333,7 @@ class TMDbInterface(WebInterface):
 
         # If episode was not found, query by absolute number in all seasons
         if ('success' in tmdb_info and not tmdb_info['success']
-            and episode_info.abs_number != None):
+            and episode_info.abs_number is not None):
             # Query TMDb until the absolute number has been found
             for season in range(0, episode_info.season_number+1)[::-1]:
                 url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
@@ -352,7 +352,7 @@ class TMDbInterface(WebInterface):
         # Episode has been found on TMDb, check title
         if 'name' in tmdb_info and episode_info.title.matches(tmdb_info['name']):
             # Title matches, return the resulting season/episode number
-            if episode_info.tvdb_id != None:
+            if episode_info.tvdb_id is not None:
                 log.info(f'Add TVDb ID {episode_info.tvdb_id} to TMDb "'
                          f'{series_info}" {episode_info}')
 
@@ -447,7 +447,7 @@ class TMDbInterface(WebInterface):
             return False
 
         # Format with this episode, return whether this matches the translation
-        if episode_info.abs_number != None:
+        if episode_info.abs_number is not None:
             # Check against episode and absolute number
             return title in (
                 generic.format(number=episode_info.episode_number),
@@ -485,7 +485,7 @@ class TMDbInterface(WebInterface):
         index = self.__find_episode(series_info, episode_info, title_match)
 
         # If None was returned, episode not found - warn, blacklist, and exit
-        if index == None:
+        if index is None:
             log.debug(f'TMDb has no matching episode for "{series_info}" '
                      f'{episode_info}')
             self.__update_blacklist(series_info, episode_info, 'image')
@@ -546,7 +546,7 @@ class TMDbInterface(WebInterface):
         index = self.__find_episode(series_info, episode_info)
 
         # If episode was not found - blacklist, and exit
-        if index == None:
+        if index is None:
             self.__update_blacklist(series_info, episode_info, 'title')
             return None
 

--- a/modules/Title.py
+++ b/modules/Title.py
@@ -254,7 +254,7 @@ class Title:
 
         matching_titles = map(self.get_matching_title, titles)
 
-        if self.__original_title != None:
+        if self.__original_title is not None:
             return any(title in (self.__original_title, self.match_title)
                        for title in matching_titles)
         

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -5,6 +5,7 @@ import modules.global_objects as global_objects
 
 # Default CardType classes
 from modules.AnimeTitleCard import AnimeTitleCard
+from modules.LogoTitleCard import LogoTitleCard
 from modules.StandardTitleCard import StandardTitleCard
 from modules.StarWarsTitleCard import StarWarsTitleCard
 from modules.TextlessTitleCard import TextlessTitleCard
@@ -35,6 +36,7 @@ class TitleCard:
         'anime': AnimeTitleCard,
         'star wars': StarWarsTitleCard,
         'textless': TextlessTitleCard,
+        'logo': LogoTitleCard,
     }
 
     """Mapping of illegal filename characters and their replacements"""

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -37,6 +37,7 @@ class TitleCard:
         'star wars': StarWarsTitleCard,
         'textless': TextlessTitleCard,
         'logo': LogoTitleCard,
+        'reality tv': LogoTitleCard,
     }
 
     """Mapping of illegal filename characters and their replacements"""

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -143,7 +143,7 @@ class TitleCard:
                 season=episode_info.season_number,
                 episode=episode_info.episode_number,
                 title=episode_info.title.full_title,
-                abs_number=abs_number if abs_number != None else 0,
+                abs_number=abs_number if abs_number is not None else 0,
             )
         )
         
@@ -211,7 +211,7 @@ class TitleCard:
                 episode_start=multi_episode.episode_start,
                 episode_end=multi_episode.episode_end,
                 title=multi_episode.episode_info.title.full_title,
-                abs_number=abs_number if abs_number != None else 0,
+                abs_number=abs_number if abs_number is not None else 0,
             )
         )
 

--- a/modules/YamlReader.py
+++ b/modules/YamlReader.py
@@ -39,7 +39,7 @@ class YamlReader(ABC):
                 value = value[attrib]
 
             # If no type conversion is indicated, just return value
-            if type_ == None:
+            if type_ is None:
                 return value
 
             try:
@@ -77,7 +77,7 @@ class YamlReader(ABC):
                 return False
 
             # If this level has sub-attributes, but is blank (None) - False
-            if current[attribute] == None:
+            if current[attribute] is None:
                 return False
 
             # Move to the next level


### PR DESCRIPTION
# Major Changes
- Create reality TV/logo-based title card type
  - New `card_type` identifiers `logo` and `reality tv`
  - Requires "extras" to specify logo and background, like:
     ```yaml
    extras:
      logo: /path/to/some/logo.png
      background: green # any color
     ```
  - Example of the card:
    <img src="https://user-images.githubusercontent.com/17693271/172190927-80f6d258-c91d-49c9-ba8d-575a46b55396.jpg" width="600"/>
  - Closes #149
- Added global option to disable season subfolders
  - New `hide_season_holders` option under `options` in global preferences
  - Affects both normal media directories _and_ archives
  - Closes #76 
# Major Fixes 
- Create `modules/.objects/` directory during module loading (causing error for docker container)
# Minor Changes
- Add ability to require kanji for a series using the `anime` card type
  - If the `require_kanji` extra is provided, cards of that series will not be made if no kanji was found/given
  - Example specification would be:
    ```yaml
    extras:
      require_kanji: true
    ```
  - Closes #163 
# Minor Fixes
N/A