### PR TITLE
Don't check source images for logo cards, minor changes and fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,17 @@ ENV TCM_PREFERENCES=/config/preferences.yml
 RUN groupadd -g 314 titlecardmaker; \
     useradd -u 314 -g 314 titlecardmaker
 
-# Intall OS dependencies
-RUN apt-get update; \
-    apt-get upgrade -y; \
-    apt update
-
 # Install gosu
 RUN set -eux; \
     apt-get update; \
     apt-get install -y gosu; \
     rm -rf /var/lib/apt/lists/*; \
     gosu nobody true
+
+# Intall OS dependencies
+RUN apt-get update; \
+    apt-get upgrade -y; \
+    apt update
 
 # Install ImageMagick
 RUN apt install -y imagemagick

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,17 @@ ENV TCM_PREFERENCES=/config/preferences.yml
 RUN groupadd -g 314 titlecardmaker; \
     useradd -u 314 -g 314 titlecardmaker
 
+# Intall OS dependencies
+RUN apt-get update; \
+    apt-get upgrade -y; \
+    apt update
+
 # Install gosu
 RUN set -eux; \
     apt-get update; \
     apt-get install -y gosu; \
     rm -rf /var/lib/apt/lists/*; \
     gosu nobody true
-
-# Intall OS dependencies
-RUN apt-get update; \
-    apt-get upgrade -y; \
-    apt update
 
 # Install ImageMagick
 RUN apt install -y imagemagick
@@ -35,7 +35,6 @@ RUN export MAGICK_HOME="$HOME/ImageMagick-7.1.0"; \
     export DYLD_LIBRARY_PATH="$MAGICK_HOME/lib/"
 
 # Install TCM package dependencies
-#RUN pip3 install -r requirements.txt    
 RUN pip3 install --no-cache-dir --upgrade pipenv; \
     pipenv lock --keep-outdated --requirements > requirements.txt; \
     pip3 install -r requirements.txt

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -433,7 +433,8 @@ class AnimeTitleCard(CardType):
 
         # If kanji is required (and not given), error!
         if self.require_kanji and not self.use_kanji:
-            log.error(f'Kanji is required and not provided - skipping card')
+            log.error(f'Kanji is required and not provided - skipping card'
+                      f'"{self.output_file.resolve()}"')
             return None
         
         # Create the output directory and any necessary parents 

--- a/modules/LogoTitleCard.py
+++ b/modules/LogoTitleCard.py
@@ -237,6 +237,7 @@ class LogoTitleCard(CardType):
             f'-size "{self.TITLE_CARD_SIZE}"',  # Create backdrop
             f'xc:"{self.background}"',          # Fill canvas with color
             f'"{resized_logo.resolve()}"',
+            f'-set colorspace sRGB',
             f'-gravity north',
             f'-geometry "+0+{offset}"',         # Put logo on backdrop
             f'-composite "{self.__BACKDROP_WITH_LOGO.resolve()}"',
@@ -493,5 +494,5 @@ class LogoTitleCard(CardType):
         images = [resized_logo, backdrop_logo, titled_image]
         if not self.hide_season:
             images.append(series_count_image)
-
+        
         self.image_magick.delete_intermediate_images(*images)

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -262,7 +262,8 @@ class Manager:
                     continue
 
                 # If source file doesn't exist, add to report
-                if not episode.source.exists():
+                if (show.card_class.USES_UNIQUE_SOURCES
+                    and not episode.source.exists()):
                     if str(episode) not in show_dict:
                         show_dict[str(episode)] = {}
                     show_dict[str(episode)]['source'] = episode.source.name

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -643,17 +643,17 @@ class Show(YamlReader):
 
         # Go through each episode for this show
         for _, episode in (pbar := tqdm(self.episodes.items(), **TQDM_KWARGS)):
-            # Update progress bar
-            pbar.set_description(f'Creating {episode}')
-            
             # Skip episodes without a destination or that already exist
             if not episode.destination or episode.destination.exists():
                 continue
-                
+
             # Skip episodes without souce that need them
             if (self.card_class.USES_UNIQUE_SOURCES
                 and not episode.source.exists()):
                 continue
+
+            # Update progress bar
+            pbar.set_description(f'Creating {episode}')
 
             # Create a TitleCard object for this episode with Show's profile
             title_card = TitleCard(

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -646,9 +646,13 @@ class Show(YamlReader):
             # Update progress bar
             pbar.set_description(f'Creating {episode}')
             
-            # Skip episodes without a destination, source, or that exist
-            if (not episode.destination or episode.destination.exists()
-                or not episode.source.exists()):
+            # Skip episodes without a destination or that already exist
+            if not episode.destination or episode.destination.exists():
+                continue
+                
+            # Skip episodes without souce that need them
+            if (self.card_class.USES_UNIQUE_SOURCES
+                and not episode.source.exists()):
                 continue
 
             # Create a TitleCard object for this episode with Show's profile

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -193,9 +193,9 @@ class SonarrInterface(WebInterface):
                     and air_datetime > datetime.now() + timedelta(hours=2)):
                         continue
 
-                # Skip temporary placeholder names if aired in the last 24 hours
+                # Skip temporary placeholder names if aired in the last 48 hours
                 if (self.__TEMP_IGNORE_REGEX.match(episode['title'])
-                    and air_datetime > datetime.now() + timedelta(days=1)):
+                    and air_datetime > datetime.now() + timedelta(days=2)):
                         continue
 
             # Skip permanent placeholder names

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -256,14 +256,11 @@ class TitleCard:
         # If the card already exists, exit
         if self.file.exists():
             return False
-
-        # If the input source doesn't exist, exit
-        if not self.episode.source.exists():
-            return False
             
-        # Create card, return whether it was successful
+        # Create card
         self.maker.create()
         
+        # Return whether card creation was successful or not
         if self.file.exists():
             log.debug(f'Created card "{self.file.resolve()}"')
             return True


### PR DESCRIPTION
# Major Changes
N/A
# Major Fixes 
- Skip source file existence check if not using unique sources (i.e. `LogoTitleCard`)
  - Closes #166
# Minor Changes
- Ignore temp names from Sonarr for up to 2 days after episode airdate
  - Reflects latest Sonarr development changes which implement 2-day buffer due to TVDb API caching
# Minor Fixes
- Fix `LogoTitlecard`s being converted to greyscale if non sRGB color code was provided as background color
  - Closes #165
- Don't report missing source images for `LogoTitleCard`