### PR TITLE
Immediately remake watched episodes, specify filename format per-series, get episode data from Plex or TMDb, minor changes and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An automated title card maker for Plex.
 The Maker can be automated such that everything can be pulled without manual intervention (except for a few exceptions). Episode titles can be pulled from an instance of [Sonarr](https://sonarr.tv/), images and logos from [TheMovieDatabase](https://www.themoviedb.org/) and Plex, and the maker can even utilize an episode's watch status within Plex to create "spoiler free" versions of title cards automatically, as shown below:
 
 <img src="https://user-images.githubusercontent.com/17693271/174520069-d981b33e-df93-4166-a4dc-b898af82eb3f.jpg"/>
-
+  
 The actual image creation is done using the open-source and free image library called [ImageMagick](https://imagemagick.org/).
 
 ## Getting Started
@@ -49,13 +49,17 @@ Below are some examples of each style of title card that can be created automati
 
 > The above cards are, in order, the [AnimeTitleCard](https://github.com/CollinHeist/TitleCardMaker/wiki/AnimeTitleCard), [LogoTitleCard](https://github.com/CollinHeist/TitleCardMaker/wiki/LogoTitleCard), [RomanTitleCard](https://github.com/CollinHeist/TitleCardMaker/wiki/RomanTitleCard), [StandardTitleCard](https://github.com/CollinHeist/TitleCardMaker/wiki/StandardTitleCard), [StarWarsTitleCard](https://github.com/CollinHeist/TitleCardMaker/wiki/StarWarsTitleCard), and the [TextlessTitleCard](https://github.com/CollinHeist/TitleCardMaker/wiki/TextlessTitleCard)
 
-### User-Created Card Types
+<details><summary><h3>User-Created Card Types</h3></summary>
+  
 The TitleCardMaker can also use user-created and maintained card types hosted on the [companion GitHub](https://github.com/CollinHeist/TitleCardMaker-CardTypes), an example of each type is shown below:
 
 <img src="https://github.com/Wdvh/TitleCardMaker-CardTypes/blob/c14f1b3759983a63e66982ba6517e2bc3f651dca/Wdvh/S01E01.jpg" height="175"/> <img src="https://user-images.githubusercontent.com/17693271/169709359-ffc9e109-b327-44e9-b78a-7276f77fe917.jpg" height="175"/> <img src="https://user-images.githubusercontent.com/17693271/169709482-6bb023ab-4986-464e-88d6-0e05ad75d0d3.jpg" height="175"/> 
 <img src="https://github.com/CollinHeist/TitleCardMaker-CardTypes/blob/110c2ec729dbb20d8ed461e7cc5a07c54540f842/Wdvh/S01E07.jpg" height="175"/> <img src="https://cdn.discordapp.com/attachments/975108033531219979/977614937457303602/S01E04.jpg" height="175"/>  <img src="https://user-images.githubusercontent.com/1803189/171089736-f60a6ff2-0914-432a-a45d-145323d39c42.jpg" height="175"/> 
+<img src="https://github.com/Beedman/TitleCardMaker-CardTypes/blob/master/Beedman/The%20Afterparty%20(2022)%20-%20S01E02%20-%20Brett.jpg?raw=true" height="175"/>
 
-> The above cards are, in order, `Wdvh/StarWarsTitleOnly`, `Wdvh/WhiteTextStandard`, `Wdvh/WhiteTextAbsolute`, `Wdvh/WhiteTextTitleOnly`, `Yozora/SlimTitleCard`, and `lyonza/WhiteTextBroadcast`
+> The above cards are, in order, `Wdvh/StarWarsTitleOnly`, `Wdvh/WhiteTextStandard`, `Wdvh/WhiteTextAbsolute`, `Wdvh/WhiteTextTitleOnly`, `Yozora/SlimTitleCard`, `lyonza/WhiteTextBroadcast`, and `Beedman/GradientLogoTitleCard`
+  
+</details>
 
 ## Contributing
 If you'd like to contribute - whether that's a suggested feature, a bug fix, or anything else - please do so on GitHub by creating an issue, or [join the Discord](https://discord.gg/bJ3bHtw8wH). The best way for me to manage technical aspects of the project is on GitHub.

--- a/main.py
+++ b/main.py
@@ -14,8 +14,9 @@ try:
     from modules.RemoteFile import RemoteFile
     from modules.global_objects import set_preference_parser, set_font_validator
     from modules.Manager import Manager
-except ImportError:
+except ImportError as e:
     print(f'Required Python packages are missing - execute "pipenv install"')
+    print(f'  Specific Error: {e}')
     exit(1)
 
 # Environment variables
@@ -24,11 +25,14 @@ ENV_RUNTIME = 'TCM_RUNTIME'
 ENV_FREQUENCY = 'TCM_FREQUENCY'
 ENV_MISSING_FILE = 'TCM_MISSING'
 ENV_LOG_LEVEL = 'TCM_LOG'
+ENV_UPDATE_LIST= 'TCM_TAUTULLI_UPDATE_LIST'
+ENV_UPDATE_FREQUENCY = 'TCM_TAUTULLI_UPDATE_FREQUENCY'
 
 # Default values
 DEFAULT_PREFERENCE_FILE = Path(__file__).parent / 'preferences.yml'
 DEFAULT_MISSING_FILE = Path(__file__).parent / 'missing.yml'
 DEFAULT_FREQUENCY = '12h'
+DEFAULT_UPDATE_FREQUENCY = '2m'
 
 # Pseudo-type functions for argument runtime and frequency
 def runtime(arg: str) -> dict:
@@ -99,6 +103,21 @@ parser.add_argument(
     '-nc', '--no-color',
     action='store_true',
     help='Omit color from all print messages')
+parser.add_argument(
+    '--tautulli-update-list',
+    type=Path,
+    default=environ.get(ENV_UPDATE_LIST, SUPPRESS),
+    metavar='FILE',
+    help=f'File to monitor for Tautulli-driven episode watch-status updates. '
+         f'Environment variable {ENV_UPDATE_LIST}.')
+parser.add_argument(
+    '--tautulli-update-frequency',
+    type=frequency,
+    default=environ.get(ENV_UPDATE_FREQUENCY, DEFAULT_UPDATE_FREQUENCY),
+    metavar='FREQUENCY',
+    help=f'How often to check the Tautulli update list. Units can be s/m/h/d/w '
+         f'for seconds/minutes/hours/days/weeks. Environment variable '
+         f'{ENV_UPDATE_FREQUENCY}. Defaults to "{DEFAULT_UPDATE_FREQUENCY}"')
 
 # Parse given arguments
 args = parser.parse_args()
@@ -113,16 +132,26 @@ if not args.preferences.exists():
     log.critical(f'Preference file "{args.preferences.resolve()}" does not exist')
     exit(1)
 
-# Read the preference file, verify it is valid and exit if not
-if not (pp := PreferenceParser(args.preferences)).valid:
-    exit(1)
-
 # Store the PreferenceParser and FontValidator in the global namespace
+if not (pp := PreferenceParser(args.preferences)).valid:
+    log.critical(f'Preference file is invalid')
+    exit(1)
 set_preference_parser(pp)
 set_font_validator(FontValidator())
 
+# Function to re-read preference file
+def read_preferences():
+    # Read the preference file, verify it is valid and exit if not
+    if (pp := PreferenceParser(args.preferences)).valid:
+        set_preference_parser(pp)
+    else:
+        log.critical(f'Preference file is invalid, not updating preferences')
+    
 # Function to create and run Manager object
 def run():
+    # Re-read preferences
+    read_preferences()
+
     # Reset previously loaded assets
     RemoteFile.LOADED.truncate()
 
@@ -135,9 +164,48 @@ def run():
         log.critical(f'Invalid permissions - {error}')
         exit(1)
 
+# Function to read the Tautulli update list
+def read_update_list():
+    # If the file doesn't exist (nothing to parse), exit
+    if not args.tautulli_update_list.exists():
+        return None
+
+    # Re-read preferences
+    read_preferences()
+
+    # Read update list contents
+    try:
+        with args.tautulli_update_list.open('r') as file_handle:
+            update_list = list(map(int, file_handle.readlines()))
+        log.debug(f'Read update list ({update_list})')
+    except ValueError:
+        log.error(f'Error reading update list, skipping')
+        return None
+        
+    # Delete (clear) update list
+    args.tautulli_update_list.unlink(missing_ok=True)
+
+    # Remake all indicated cards
+    Manager.remake_cards(update_list)
+
 # Run immediately if specified
 if args.run:
-    run()
+    from cProfile import Profile
+    from pstats import Stats
+
+    with Profile() as pr:
+        run()
+
+    stats = Stats(pr)
+    stats.dump_stats(filename='all.prof')
+
+# Schedule reading the update list if specified
+if hasattr(args, 'tautulli_update_list'):
+    # Set schedule to execute based on given frequency
+    interval = args.tautulli_update_frequency['interval']
+    unit = args.tautulli_update_frequency['unit']
+    getattr(schedule.every(interval), unit).do(read_update_list)
+    log.debug(f'Scheduled read_update_list() every {unit} {interval}')
 
 # Schedule subsequent runs if specified
 if hasattr(args, 'runtime'):
@@ -155,8 +223,10 @@ if hasattr(args, 'runtime'):
     # Set schedule to execute based on given frequency
     interval, unit = args.frequency['interval'], args.frequency['unit']
     getattr(schedule.every(interval), unit).do(run)
+    log.debug(f'Scheduled run() every {interval} {unit}')
 
-    # Infinite loop of TCM Execution
+# Infinte loop if either infinite argument was indicated
+if hasattr(args, 'runtime') or hasattr(args, 'tautulli_update_list'):
     while True:
         # Run schedule, sleep until next run
         schedule.run_pending()

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -55,26 +55,25 @@ class AnimeTitleCard(CardType):
     def __init__(self, source: Path, output_file: Path, title: str, 
                  season_text: str, episode_text: str, hide_season: bool,
                  kanji: str=None, require_kanji: bool=False, separator: str='·',
-                 blur: bool=False, font_size: float=1.0, *args, **kwargs)->None:
+                 blur: bool=False, font_size: float=1.0, **kwargs)->None:
         """
         Constructs a new instance.
         
-        :param      source:             Source image for this card.
-        :param      output_file:        Output filepath for this card.
-        :param      title:              The title for this card.
-        :param      season_text:        The season text for this card.
-        :param      episode_text:       The episode text for this card.
-        :param      hide_season:        Whether to hide the season text on this
-                                        card.
-        :param      kanji:              Kanji text to place above the
-                                        episode title on this card.
-        :param      require_kanji:      Whether to require kanji for this card.
-        :param      separator:          Character to use to separate season and
-                                        episode text.
-        :param      blur:               Whether to blur the source image.
-        :param      font_size:          Scalar to apply to the title font size.
-        :param      args and kwargs:    Unused arguments to permit generalized
-                                        function calls for any CardType.
+        :param      source:         Source image for this card.
+        :param      output_file:    Output filepath for this card.
+        :param      title:          The title for this card.
+        :param      season_text:    The season text for this card.
+        :param      episode_text:   The episode text for this card.
+        :param      hide_season:    Whether to hide the season text on this card
+        :param      kanji:          Kanji text to place above the episode title
+                                    on this card.
+        :param      require_kanji:  Whether to require kanji for this card.
+        :param      separator:      Character to use to separate season and
+                                    episode text.
+        :param      blur:           Whether to blur the source image.
+        :param      font_size:      Scalar to apply to the title font size.
+        :param      kwargs:         Unused arguments to permit generalized
+                                    function calls for any CardType.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -28,7 +28,7 @@ class AnimeTitleCard(CardType):
     TITLE_FONT = str((REF_DIRECTORY / 'Flanker Griffo.otf').resolve())
     DEFAULT_FONT_CASE = 'source'
     TITLE_COLOR = 'white'
-    FONT_REPLACEMENTS = {}
+    FONT_REPLACEMENTS = {"♡": "", "☆": ""}
 
     """Whether this class uses season titles for the purpose of archives"""
     USES_SEASON_TITLE = True

--- a/modules/CardType.py
+++ b/modules/CardType.py
@@ -24,11 +24,11 @@ class CardType(ImageMaker):
 
     """Mapping of 'case' strings to format functions"""
     CASE_FUNCTIONS = {
-        'source': str,
-        'upper': str.upper,
-        'lower': str.lower,
-        'title': titlecase,
         'blank': lambda _: '',
+        'lower': str.lower,
+        'source': str,
+        'title': titlecase,
+        'upper': str.upper,
     }
 
     """Default episode text format string, can be overwritten by each class"""

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -144,7 +144,7 @@ class DataFileInterface:
                     episode_number,
                     episode_data.pop('abs_number', None),
                     episode_data.pop('tvdb_id', None),
-                    episode_data.pop('tmdb_id', None),
+                    episode_data.pop('imdb_id', None),
                 )
 
                 # Add any additional, unexpected keys from the YAML

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -103,7 +103,7 @@ class DataFileInterface:
         self.__write_data(yaml)
 
 
-    def read(self) -> dict:
+    def read(self) -> tuple[dict, set]:
         """
         Read the data file for this object, yielding each valid row.
         
@@ -122,17 +122,20 @@ class DataFileInterface:
 
             # Iterate through each episode of this season
             for episode_number, episode_data in season_data.items():
-                # If the 'title' key is missing (or no subkeys at all..) error
+                # If title is missing (or no subkeys at all..) error
                 if (not isinstance(episode_data, dict)
-                    or ('title' not in episode_data
-                    and 'preferred_title' not in episode_data)):
+                    or ('title' not in episode_data and
+                        'preferred_title' not in episode_data)):
                     log.error(f'Season {season_number}, Episode {episode_number}'
                               f' of "{self.file.resolve()}" is missing title')
                     continue
 
+                # Get existing keys for this episode
+                given_keys = set(episode_data)
+
                 # If translated title is available, prefer that
                 original_title = episode_data.pop('title', None)
-                title = episode_data.pop('preferred_title', original_title)
+                title = episode_data.get('preferred_title', original_title)
                 
                 # Construct EpisodeInfo object for this entry
                 episode_info = EpisodeInfo(
@@ -140,13 +143,15 @@ class DataFileInterface:
                     season_number,
                     episode_number,
                     episode_data.pop('abs_number', None),
+                    episode_data.pop('tvdb_id', None),
+                    episode_data.pop('tmdb_id', None),
                 )
 
                 # Add any additional, unexpected keys from the YAML
                 data = {'episode_info': episode_info}
                 data.update(episode_data)
                 
-                yield data
+                yield data, given_keys
 
 
     def read_entries_without_absolute(self) -> dict:

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -65,7 +65,7 @@ class Episode:
         """Returns an unambiguous string representation of the object"""
 
         return (f'<Episode {self.episode_info=}, {self.card_class=}, '
-                f'{self.source=}, {self.destination=}, {self.watched=},'
+                f'{self.source=}, {self.destination=}, {self.watched=}, '
                 f'{self.blur=}, {self.extra_characteristics=}>')
 
 

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -12,11 +12,12 @@ class Episode:
 
     __slots__ = ('episode_info', 'card_class', '__base_source', 'source',
                  'destination', 'downloadable_source', 'extra_characteristics',
-                 'watched', 'blur', 'spoil_type', )
+                 'given_keys', 'watched', 'blur', 'spoil_type', )
     
 
     def __init__(self, episode_info: 'EpisodeInfo', card_class: 'CardType',
-                 base_source: Path, destination: Path, **extras: dict) -> None:
+                 base_source: Path, destination: Path, given_keys: set,
+                 **extras: dict) -> None:
         """
         Constructs a new instance of an Episode.
 
@@ -25,6 +26,8 @@ class Episode:
                                     images within.
         :param      destination:    The destination for the title card
                                     associated with this Episode.
+        :param      given_keys:     Set of keys present in the initialization of
+                                    this Episode.
         :param      extras:         Additional characteristics to pass to the
                                     creation of the TitleCard from this Episode.
         """
@@ -42,7 +45,8 @@ class Episode:
         self.destination = destination
         self.downloadable_source = True
 
-        # Store extra characteristics
+        # Store given keys and extra characteristics
+        self.given_keys = given_keys
         self.extra_characteristics = extras
 
         # Episodes are watched, not blurred, and spoiled - until updated
@@ -63,6 +67,20 @@ class Episode:
         return (f'<Episode {self.episode_info=}, {self.card_class=}, '
                 f'{self.source=}, {self.destination=}, {self.watched=},'
                 f'{self.blur=}, {self.extra_characteristics=}>')
+
+
+    def key_is_specified(self, key: str) -> bool:
+        """
+        Return whether the given key was present in the initialization for this
+        Episode, i.e. whether the key can be added to the datafile.
+        
+        :param      key:    The key being checked.
+        
+        :returns:   Whether the given key was specified in the initialization
+                    of this Episode.
+        """
+
+        return key in self.given_keys
 
 
     def update_statuses(self, watched: bool, watched_style: str, 

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -10,7 +10,7 @@ class EpisodeInfo:
     with it.
     """
 
-    # Object attributes
+    # Dataclass initialization attributes
     title: str
     season_number: int
     episode_number: int
@@ -23,7 +23,7 @@ class EpisodeInfo:
     def __post_init__(self):
         """Called after __init__, sets types of indices, assigns key field"""
 
-        # Convert title to Title object
+        # Convert title to Title object if given as string
         if isinstance(self.title, str):
             self.title = Title(self.title)
 
@@ -151,9 +151,9 @@ class EpisodeInfo:
 
     def set_from_guids(self, guids: list['plexapi.media.GuidTag']) -> None:
         """
-        Sets the from guids.
+        Set this object's ID's from a list of Plex API list of GuidTags.
         
-        :param      guids:  The guids
+        :param      guids:  List of GUID's to parse for ID's.
         """
 
         for guid in guids:

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -84,6 +84,13 @@ class EpisodeInfo:
 
 
     @property
+    def has_all_ids(self) -> bool:
+        """Whether this object has all ID's defined"""
+
+        return (self.tvdb_id is not None) and (self.imdb_id is not None)
+
+
+    @property
     def ids(self) -> dict:
         """This object's ID's (as a dictionary)"""
 

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -109,7 +109,6 @@ class EpisodeInfo:
         """
 
         self.abs_number = int(abs_number)
-        self.abs = self.abs_number
 
 
     def set_tvdb_id(self, tvdb_id: int) -> None:

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -1,15 +1,17 @@
 from dataclasses import dataclass, field
 
+from modules.Title import Title
+
 @dataclass(eq=False, order=False)
 class EpisodeInfo:
     """
     This class describes static information about an Episode, such as the
     season, episode, and absolute number, as well as the various ID's associated
-    with it - such as Sonarr, TVDb, and TMDb.
+    with it.
     """
 
     # Object attributes
-    title: 'Title'
+    title: str
     season_number: int
     episode_number: int
     abs_number: int=None
@@ -20,6 +22,10 @@ class EpisodeInfo:
 
     def __post_init__(self):
         """Called after __init__, sets types of indices, assigns key field"""
+
+        # Convert title to Title object
+        if isinstance(self.title, str):
+            self.title = Title(self.title)
 
         # Convert indices to integers
         self.season_number = int(self.season_number)

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -13,11 +13,11 @@ class EpisodeInfo:
     season_number: int
     episode_number: int
     abs_number: int=None
-    sonarr_id: int=None
     tvdb_id: int=None
-    tmdb_id: int=None
+    imdb_id: str=None
     key: str = field(init=False, repr=False)
     
+
     def __post_init__(self):
         """Called after __init__, sets types of indices, assigns key field"""
 
@@ -78,6 +78,13 @@ class EpisodeInfo:
 
 
     @property
+    def ids(self) -> dict:
+        """This object's ID's (as a dictionary)"""
+
+        return {'tvdb_id': self.tvdb_id, 'imdb_id': self.imdb_id}
+
+
+    @property
     def episode_characteristics(self) -> dict:
         """This object's season/episode indices (as a dictionary)"""
 
@@ -99,16 +106,6 @@ class EpisodeInfo:
         self.abs = self.abs_number
 
 
-    def set_sonarr_id(self, sonarr_id: int) -> None:
-        """
-        Sets the Sonarr ID for this object.
-        
-        :param      tmdb_id:    The Sonarr ID to set.
-        """
-
-        self.sonarr_id = int(sonarr_id)
-
-
     def set_tvdb_id(self, tvdb_id: int) -> None:
         """
         Sets the TVDb ID for this object.
@@ -116,23 +113,25 @@ class EpisodeInfo:
         :param      tmdb_id:    The TVDb ID to set.
         """
 
-        self.tvdb_id = int(tvdb_id)
+        if self.tvdb_id is None and tvdb_id is not None:
+            self.tvdb_id = int(tvdb_id)
 
 
-    def set_tmdb_id(self, tmdb_id: int) -> None:
+    def set_imdb_id(self, imdb_id: str) -> None:
         """
-        Sets the TMDb ID for this object.
+        Sets the IMDb ID for this object.
         
-        :param      tmdb_id:    The TMDb ID to set.
+        :param      imdb_id:    The IMDb ID to set.
         """
 
-        self.tmdb_id = int(tmdb_id)
+        if self.imdb_id is None and imdb_id is not None:
+            self.imdb_id = imdb_id
 
 
     def copy_ids(self, other: 'EpisodeInfo') -> None:
         """
-        Copy all ID's from the given EpisodeInfo object. This copies the Sonarr,
-        TVDb, and TMDb ID's.
+        Copy all ID's from the given EpisodeInfo object. This copies the TVDb,
+        and TMDb ID's.
         
         :param      other:  The EpisodeInfo object to copy ID's from.
         """
@@ -140,7 +139,21 @@ class EpisodeInfo:
         if not isinstance(other, EpisodeInfo):
             raise TypeError(f"Can only copy ID's into an EpisodeInfo object")
 
-        self.sonarr_id = other.sonarr_id
-        self.tvdb_id = other.tvdb_id
-        self.tmdb_id = other.tmdb_id
+        self.set_tvdb_id(other.tvdb_id)
+        self.set_imdb_id(other.imdb_id)
+
+
+    def set_from_guids(self, guids: list['plexapi.media.GuidTag']) -> None:
+        """
+        Sets the from guids.
+        
+        :param      guids:  The guids
+        """
+
+        for guid in guids:
+            if 'tvdb://' in guid.id:
+                self.set_tvdb_id(guid.id[len('tvdb://'):])
+            elif 'imdb://' in guid.id:
+                self.set_imdb_id(guid.id[len('imdb://'):])
+
         

--- a/modules/LogoTitleCard.py
+++ b/modules/LogoTitleCard.py
@@ -58,7 +58,7 @@ class LogoTitleCard(CardType):
                  blur: bool=False, vertical_shift: int=0,
                  interline_spacing: int=0, kerning: float=1.0,
                  stroke_width: float=1.0, logo: str=None,
-                 background: str='#000000', *args, **kwargs) -> None:
+                 background: str='#000000', **kwargs) -> None:
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
@@ -84,7 +84,7 @@ class LogoTitleCard(CardType):
                                     text.
         :param  logo:               Filepath to the logo file.
         :param  background:         Backround color to use for this card.
-        :param  args and kwargs:    Unused arguments to permit generalized calls
+        :param  kwargs:             Unused arguments to permit generalized calls
                                     for any CardType.
         """
         

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -99,6 +99,25 @@ class Manager:
             archive.find_multipart_episodes()
 
 
+    def add_new_episodes(self) -> None:
+        """
+        Adds new episodes.
+        """
+
+        # If Sonarr, Plex, and TMDb are disabled, exit
+        if (not self.sonarr_interface and not self.plex_interface
+            and not self.tmdb_interface):
+            return None
+
+        # For each show in the Manager, look for new episodes using any of the
+        # possible interfaces
+        for show in tqdm(self.shows + self.archives, desc='Adding new episodes',
+                         **TQDM_KWARGS):
+            show.add_new_episodes(
+                self.sonarr_interface, self.plex_interface, self.tmdb_interface
+            )
+
+
     def check_tmdb_for_translations(self) -> None:
         """Query TMDb for all translated episode titles (if indicated)."""
 
@@ -124,22 +143,6 @@ class Manager:
         for show in (pbar := tqdm(self.shows + self.archives,
                                   desc='Downloading logos', **TQDM_KWARGS)):
             show.download_logo(self.tmdb_interface)
-
-
-    def check_sonarr_for_new_episodes(self) -> None:
-        """
-        Query Sonarr to see if any new episodes exist for every show known to
-        this manager.
-        """
-
-        # If Sonarr is globally disabled, skip
-        if not self.preferences.use_sonarr:
-            return None
-
-        # Go through each show in the Manager and query Sonarr
-        for show in tqdm(self.shows + self.archives, desc='Querying Sonarr',
-                         **TQDM_KWARGS):
-            show.query_sonarr(self.sonarr_interface)
 
 
     def select_source_images(self) -> None:
@@ -245,7 +248,7 @@ class Manager:
         
         self.create_shows()
         self.read_show_source()
-        self.check_sonarr_for_new_episodes()
+        self.add_new_episodes()
         self.check_tmdb_for_translations()
         self.download_logos()
         self.select_source_images()

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -155,14 +155,7 @@ class Manager:
                                  f'"{show.series_info.short_name}"')
 
             # Select source images from Plex and/or TMDb
-            interfaces = {'plex_interface': None, 'tmdb_interface': None}
-            if self.preferences.use_plex:
-                interfaces['plex_interface'] = self.plex_interface
-            if self.preferences.use_tmdb:
-                interfaces['tmdb_interface'] = self.tmdb_interface
-
-            # Pass enabled interfaces
-            show.select_source_images(**interfaces)
+            show.select_source_images(self.plex_interface, self.tmdb_interface)
 
 
     def create_missing_title_cards(self) -> None:

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -211,6 +211,41 @@ class PlexInterface:
             return None
 
 
+    def get_all_episodes(self, library_name,
+                         series_info: SeriesInfo) -> list[EpisodeInfo]:
+        """
+        Gets all episode info for the given series. Only episodes that have 
+        already aired are returned.
+        
+        :param      series_info:    SeriesInfo for the entry.
+        
+        :returns:   List of EpisodeInfo objects for this series.
+        """
+
+        # If the given library cannot be found, exit
+        if not (library := self.__get_library(library_name)):
+            return []
+
+        # If the given series cannot be found in this library, exit
+        if not (series := self.__get_series(library, series_info)):
+            return []
+
+        # Create list of all episodes in Plex
+        all_episodes = []
+        for plex_episode in series.episodes():
+            episode_info = EpisodeInfo(
+                plex_episode.title,
+                plex_episode.parentIndex,
+                plex_episode.index,
+            )
+
+            # Assign ID's, add to list
+            episode_info.set_from_guids(plex_episode.guids)
+            all_episodes.append(episode_info)
+
+        return all_episodes
+
+
     def has_series(self, library_name: str, series_info: 'SeriesInfo') -> bool:
         """
         Determine whether the given series is present within Plex.

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -21,8 +21,8 @@ class PreferenceParser(YamlReader):
     file and parses it into individual attributes.
     """
 
-    """Valid source identifiers"""
-    VALID_SOURCES = ('tmdb', 'plex')
+    """Valid image source identifiers"""
+    VALID_IMAGE_SOURCES = ('tmdb', 'plex')
 
     """Directory for all temporary objects created/maintained by the Maker"""
     TEMP_DIR = Path(__file__).parent / '.objects'
@@ -59,7 +59,7 @@ class PreferenceParser(YamlReader):
         self.card_type = 'standard'
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.card_extension = TitleCard.DEFAULT_CARD_EXTENSION
-        self.source_priority = ('tmdb', 'plex')
+        self.image_source_priority = ('tmdb', 'plex')
         self.validate_fonts = True
         self.zero_pad_seasons = False
         self.hide_season_folders = False
@@ -164,14 +164,15 @@ class PreferenceParser(YamlReader):
             else:
                 self.card_extension = extension
 
-        if (value := self._get('options', 'source_priority', type_=str)) !=None:
+        if (value := self._get('options',
+                               'image_source_priority', type_=str)) is not None:
             lower_strip = lambda s: str(s).lower().strip()
             sources = tuple(map(lower_strip, value.split(', ')))
-            if not all(_ in self.VALID_SOURCES for _ in sources):
-                log.critical(f'Source priorities "{value}" is invalid')
+            if not all(_ in self.VALID_IMAGE_SOURCES for _ in sources):
+                log.critical(f'Image source priority "{value}" is invalid')
                 self.valid = False
             else:
-                self.source_priority = sources
+                self.image_source_priority = sources
 
         if (value := self._get('options', 'validate_fonts', type_=bool)) !=None:
             self.validate_fonts = value
@@ -229,11 +230,6 @@ class PreferenceParser(YamlReader):
             else:
                 self.global_unwatched_style = value
 
-        if self._is_specified('plex', 'unwatched'):
-            log.critical(f'Plex "unwatched" setting has been renamed to '
-                         f'"unwatched_style"')
-            self.valid = False
-
         if self._is_specified('sonarr'):
             if (not self._is_specified('sonarr', 'url')
                 or not self._is_specified('sonarr', 'api_key')):
@@ -266,6 +262,17 @@ class PreferenceParser(YamlReader):
 
         if (value := self._get('imagemagick', 'container', type_=str)) != None:
             self.imagemagick_container = value
+
+        # Warn for renamed settings
+        if self._is_specified('options', 'source_priority'):
+            log.critical(f'Options "source_priority" setting has been renamed '
+                         f'to "image_source_priority"')
+            self.valid = False
+
+        if self._is_specified('plex', 'unwatched'):
+            log.critical(f'Plex "unwatched" setting has been renamed to '
+                         f'"unwatched_style"')
+            self.valid = False
 
 
     def __apply_template(self, templates: dict, series_yaml: dict,
@@ -410,17 +417,17 @@ class PreferenceParser(YamlReader):
 
     @property
     def check_tmdb(self):
-        return 'tmdb' in self.source_priority
+        return 'tmdb' in self.image_source_priority
 
     @property
     def check_plex(self):
-        return 'plex' in self.source_priority
+        return 'plex' in self.image_source_priority
 
     @property
     def check_plex_before_tmdb(self) -> bool:
         """Whether to check Plex source before TMDb"""
 
-        priorities = self.source_priority
+        priorities = self.image_source_priority
         if 'plex' in priorities:
             if 'tmdb' in priorities:
                 return priorities.index('plex') < priorities.index('tmdb')

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -395,15 +395,17 @@ class PreferenceParser(YamlReader):
             # Get font map for this file
             font_map = file_yaml.get('fonts', {})
 
-            # Get templates for this file
+            # Get templates for this file, validate they're all dictionaries
             templates = {}
-            for name, template in file_yaml.get('templates', {}).items():
-                # If not specified as dictionary, error and skip
-                if not isinstance(template, dict):
-                    log.error(f'Invalid template specification for "{name}" in '
-                              f'series file "{file.resolve()}"')
-                    continue
-                templates[name] = Template(name, template)
+            value = file_yaml.get('templates', {})
+            if isinstance(value, dict):
+                for name, template in value.items():
+                    # If not specified as dictionary, error and skip
+                    if not isinstance(template, dict):
+                        log.error(f'Invalid template specification for "{name}"'
+                                  f' in series file "{file.resolve()}"')
+                        continue
+                    templates[name] = Template(name, template)
 
             # Go through each series in this file
             for show_name in tqdm(file_yaml['series'], desc='Creating Shows',

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -24,6 +24,9 @@ class PreferenceParser(YamlReader):
     """Valid image source identifiers"""
     VALID_IMAGE_SOURCES = ('tmdb', 'plex')
 
+    """Valid episode data source identifiers"""
+    VALID_EPISODE_DATA_SOURCES = ('sonarr', 'plex', 'tmdb')
+
     """Directory for all temporary objects created/maintained by the Maker"""
     TEMP_DIR = Path(__file__).parent / '.objects'
 
@@ -60,6 +63,7 @@ class PreferenceParser(YamlReader):
         self.card_filename_format = TitleCard.DEFAULT_FILENAME_FORMAT
         self.card_extension = TitleCard.DEFAULT_CARD_EXTENSION
         self.image_source_priority = ('tmdb', 'plex')
+        self.episode_data_source = 'sonarr'
         self.validate_fonts = True
         self.zero_pad_seasons = False
         self.hide_season_folders = False
@@ -173,6 +177,14 @@ class PreferenceParser(YamlReader):
                 self.valid = False
             else:
                 self.image_source_priority = sources
+
+        if (value := self._get('options',
+                               'episode_data_source', type_=str)) is not None:
+            if (value := value.lower()) in self.VALID_EPISODE_DATA_SOURCES:
+                self.episode_data_source = value
+            else:
+                log.critical(f'Episode data source "{value}" is invalid')
+                self.valid = False
 
         if (value := self._get('options', 'validate_fonts', type_=bool)) !=None:
             self.validate_fonts = value

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -35,6 +35,13 @@ class Profile:
         self.__use_custom_font = True
 
 
+    def __repr__(self) -> str:
+        """Returns an unambiguous string representation of the object."""
+
+        return (f'<Profile {self.__use_custom_seasons=}, '
+                f'{self.__use_custom_font=}>')
+
+
     def get_valid_profiles(self, card_class: CardType) -> [dict]:
         """
         Gets the valid applicable profiles for this profile. For example,

--- a/modules/RomanNumeralTitleCard.py
+++ b/modules/RomanNumeralTitleCard.py
@@ -53,7 +53,7 @@ class RomanNumeralTitleCard(CardType):
                  title_color: str, episode_number: int=1, blur: bool=False, 
                  background: str='black', 
                  roman_numeral_color: str=ROMAN_NUMERAL_TEXT_COLOR,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         """
         Constructs a new instance.
         
@@ -67,7 +67,7 @@ class RomanNumeralTitleCard(CardType):
         :param      background:             Color for the background.
         :param      roman_numeral_color:    Color for the roman numerals.
         :param      blur:                   Whether to blur the source image.
-        :param      args and kwargs:        Unused arguments.
+        :param      kwargs:                 Unused arguments.
         """
 
         # Initialize the parent class - this sets up an ImageMagickInterface

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -1,3 +1,5 @@
+from modules.Debug import log
+
 class SeriesInfo:
     """
     This class encapsulates static information that is tied to a single Series.
@@ -99,7 +101,8 @@ class SeriesInfo:
         :param      sonarr_id:  The Sonarr ID used for this series.
         """
         
-        self.sonarr_id = int(sonarr_id)
+        if self.sonarr_id is None:
+            self.sonarr_id = int(sonarr_id)
 
 
     def set_tvdb_id(self, tvdb_id: int) -> None:
@@ -109,7 +112,8 @@ class SeriesInfo:
         :param      tvdb_id:  The TVDb ID for this series.
         """
 
-        self.tvdb_id = int(tvdb_id)
+        if self.tvdb_id is None:
+            self.tvdb_id = int(tvdb_id)
 
 
     def set_tmdb_id(self, tmdb_id: int) -> None:
@@ -118,8 +122,9 @@ class SeriesInfo:
         
         :param      tmdb_id:    The TMDb ID for this series.
         """
-
-        self.tmdb_id = int(tmdb_id)
+        
+        if self.tmdb_id is None:
+            self.tmdb_id = int(tmdb_id)
 
 
     @staticmethod

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -405,7 +405,15 @@ class Show(YamlReader):
 
         # No episodes found by data source
         if not all_episodes:
+            log.info(f'No episodes found for {self} from '
+                     f'{self.episode_data_source}')
             return None
+
+        # Apply episode ID's to all episodes
+        def set_ids(episode_info):
+            if (ep := self.episodes.get(episode_info.key)) is not None:
+                ep.episode_info.copy_ids(episode_info)
+        tuple(map(set_ids, all_episodes))
 
         # Filter out episodes that already exist
         new_episodes = list(filter(

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -467,7 +467,7 @@ class Show(YamlReader):
         # Filter episodes not needing ID's - i.e. has card, and has translation
         def does_need_id(item) -> bool:
             _, episode = item
-            if episode.destination is None:
+            if episode.episode_info.has_all_ids or episode.destination is None:
                 return False
             if not episode.destination.exists():
                 return True

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -198,7 +198,7 @@ class Show(YamlReader):
         if (name := self._get('name', type_=str)) is not None:
             self.series_info.update_name(name)
 
-        if (format_ := self.get('filename_format', type_=str)) is not None:
+        if (format_ := self._get('filename_format', type_=str)) is not None:
             if not TitleCard.validate_card_format_string(format_):
                 self.valid = False
             else:
@@ -219,6 +219,15 @@ class Show(YamlReader):
                 # If card type was specified for this library, set that
                 if (card_type := this_library.get('card_type')):
                     self.__parse_card_type(card_type)
+
+        if (id_ := self._get('sonarr_id', type_=int)) is not None:
+            self.series_info.set_sonarr_id(id_)
+
+        if (id_ := self._get('tvdb_id', type_=int)) is not None:
+            self.series_info.set_tvdb_id(id_)
+
+        if (id_ := self._get('tmdb_id', type_=int)) is not None:
+            self.series_info.set_tmdb_id(id_)
 
         if (card_type := self._get('card_type', type_=str)) is not None:
             self.__parse_card_type(card_type)

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -696,7 +696,7 @@ class Show(YamlReader):
                 check_plex = False
 
             # Go through each source interface indicated, try and get source
-            for source_interface in self.preferences.source_priority:
+            for source_interface in self.preferences.image_source_priority:
                 # Query either TMDb or Plex for the source image
                 image_url = None
                 if source_interface == 'tmdb' and check_tmdb:

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -90,6 +90,7 @@ class Show(YamlReader):
         self.library_name = None
         self.library = None
         self.archive = self.preferences.create_archive
+        self.episode_data_source = self.preferences.episode_data_source
         self.sonarr_sync = self.preferences.use_sonarr
         self.sync_specials = self.preferences.sonarr_sync_specials
         self.tmdb_sync = self.preferences.use_tmdb
@@ -240,6 +241,15 @@ class Show(YamlReader):
 
         if (value := self._get('archive', type_=bool)) is not None:
             self.archive = value
+
+        if (value := self._get('episode_data_source', type_=str)) is not None:
+            value = value.lower().strip()
+            if value in self.preferences.VALID_EPISODE_DATA_SOURCES:
+                self.episode_data_source = value
+            else:
+                log.error(f'Invalid episode data source "{value}" in series '
+                          f'{self}')
+                self.valid = False
 
         if (value := self._get('sonarr_sync', type_=bool)) is not None:
             self.sonarr_sync = value

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -83,6 +83,7 @@ class Show(YamlReader):
             
         # Setup default values that can be overwritten by YAML
         self.series_info = SeriesInfo(name, year)
+        self.card_filename_format = self.preferences.card_filename_format
         self.media_directory = None
         self.card_class = TitleCard.CARD_TYPES[self.preferences.card_type]
         self.episode_text_format = self.card_class.EPISODE_TEXT_FORMAT
@@ -197,6 +198,12 @@ class Show(YamlReader):
         if (name := self._get('name', type_=str)) is not None:
             self.series_info.update_name(name)
 
+        if (format_ := self.get('filename_format', type_=str)) is not None:
+            if not TitleCard.validate_card_format_string(format_):
+                self.valid = False
+            else:
+                self.card_filename_format = format_
+
         if (library := self._get('library')) is not None:
             # If the given library isn't in libary map, invalid
             if not (this_library := self.__library_map.get(library)):
@@ -298,7 +305,7 @@ class Show(YamlReader):
             return None
         
         return TitleCard.get_output_filename(
-            self.preferences.card_filename_format,
+            self.card_filename_format,
             self.series_info,
             episode_info,
             self.media_directory

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -315,12 +315,13 @@ class Show(YamlReader):
         self.episodes = {}
 
         # Go through each entry in the file interface
-        for entry in self.file_interface.read():
+        for entry, given_keys in self.file_interface.read():
             # Create Episode object for this entry, store under key
             self.episodes[entry['episode_info'].key] = Episode(
                 base_source=self.source_directory,
                 destination=self.__get_destination(entry['episode_info']),
                 card_class=self.card_class,
+                given_keys=given_keys,
                 **entry,
             )
 
@@ -457,7 +458,7 @@ class Show(YamlReader):
             # Get each translation for this series
             for translation in self.title_languages:
                 # If the key already exists, skip this episode
-                if translation['key'] in episode.extra_characteristics:
+                if episode.key_is_specified(translation['key']):
                     continue
 
                 # Update progress bar
@@ -484,7 +485,7 @@ class Show(YamlReader):
 
                 # Adding translated title, log it
                 log.debug(f'Added "{language_title}" to '
-                          f'"{translation["key"]}" for {self}')
+                          f'"{translation["key"]}" for {self} {episode}')
 
         # If any translations were added, re-read source
         if modified:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -5,7 +5,6 @@ from re import IGNORECASE, compile as re_compile
 from modules.Debug import log
 from modules.EpisodeInfo import EpisodeInfo
 from modules.SeriesInfo import SeriesInfo
-from modules.Title import Title
 from modules.WebInterface import WebInterface
 
 class SonarrInterface(WebInterface):
@@ -223,19 +222,15 @@ class SonarrInterface(WebInterface):
         return all_episode_info
 
 
-    def get_all_episodes_for_series(self,
-                                    series_info: SeriesInfo) -> [EpisodeInfo]:
+    def get_all_episodes(self, series_info: SeriesInfo) -> list[EpisodeInfo]:
         """
-        Gets all episode info for the given series title from Sonarr. Only
-        episodes that have already aired are returned.
+        Gets all episode info for the given series. Only episodes that have 
+        already aired are returned.
         
         :param      series_info:    SeriesInfo for the entry.
         
         :returns:   List of EpisodeInfo objects for this series.
         """
-
-        # Set the Sonarr ID for this series
-        self.__set_ids(series_info)
 
         # If no ID was returned, error and return an empty list
         if series_info.sonarr_id is None:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -75,6 +75,39 @@ class SonarrInterface(WebInterface):
                 f', mapping of {len(self.__series_ids)} series>')
 
 
+    def __map_all_ids(self) -> None:
+        """
+        Map all Sonarr series to their Sonarr and TVDb ID's. This updates this
+        object's __series_ids attribute with keys of the full name for each
+        series (as well as the full name version of each alternate title) to a
+        dictionary with data 'sonarr_id' and 'tvdb_id'.
+        """
+
+        # Construct GET arguments
+        url = f'{self.url}series'
+        params = self.__standard_params
+        all_series = self._get(url, params)
+
+        # Reset series dictionary
+        self.__series_ids = {}
+
+        # Go through each series in Sonarr
+        for series in all_series:
+            # Get this series' internal (sonarr) and TVDb ID's
+            data = {'sonarr_id': series['id'], 'tvdb_id': series['tvdbId']}
+
+            # Map the primary title to these ID's
+            si = SeriesInfo(series['title'], series['year'])
+            self.__series_ids[si.full_match_name] = data
+            self.__series_ids[f'sonarr:{series["id"]}'] = data
+            self.__series_ids[f'tvdb:{series["tvdbId"]}'] = data
+
+            # Map each alternate title to these ID's
+            for alt_title in series['alternateTitles']:
+                alt_si = SeriesInfo(alt_title['title'], series['year'])
+                self.__series_ids[alt_si.full_match_name] = data
+
+
     def __warn_missing_series(self, series_info: SeriesInfo) -> None:
         """
         Warn a given series is missing from Sonarr, but only if it hasn't
@@ -100,70 +133,39 @@ class SonarrInterface(WebInterface):
         :param      series_info:    SeriesInfo to modify.
         """
 
-        # Series does not exist in Sonarr
-        if series_info.full_match_name not in self.__series_ids:
+        # Match priority is Sonarr ID > TVDb ID > Series name
+        if (series_info.sonarr_id is not None and
+            (ids := self.__series_ids.get(f'sonarr:{series_info.sonarr_id}'))):
+            pass
+        elif (series_info.tvdb_id is not None and 
+            (ids := self.__series_ids.get(f'tvdb:{series_info.tvdb_id}'))):
+            pass
+        elif (ids := self.__series_ids.get(series_info.full_match_name)):
+            pass
+        else:
             return None
 
-        # Get the Sonarr ID from the ID map
-        sonarr_id = self.__series_ids[series_info.full_match_name]['sonarr_id']
-        series_info.set_sonarr_id(sonarr_id)
-
-        # Get the TVDb ID from the ID map
-        tvdb_id = self.__series_ids[series_info.full_match_name]['tvdb_id']
-        series_info.set_tvdb_id(tvdb_id)
+        # Set ID's for this series
+        series_info.set_sonarr_id(ids['sonarr_id'])
+        series_info.set_tvdb_id(ids['tvdb_id'])
 
 
-    def __map_all_ids(self) -> None:
+    def set_series_ids(self, series_info: SeriesInfo) -> None:
         """
-        Map all Sonarr series to their Sonarr and TVDb ID's. This updates this
-        object's __series_ids attribute with keys of the full name for each
-        series (as well as the full name version of each alternate title) to a
-        dictionary with data 'sonarr_id' and 'tvdb_id'.
+        Set the TVDb ID for the given SeriesInfo object.
+
+        :param      series_info:    SeriesInfo to update.
         """
 
-        # Construct GET arguments
-        url = f'{self.url}series'
-        params = self.__standard_params
-        all_series = self._get(url, params)
+        # Set the Sonarr ID for this series
+        self.__set_ids(series_info)
 
-        # Go through each series in Sonarr
-        for series in all_series:
-            # Get this series' internal (sonarr) and TVDb ID's
-            data = {
-                'sonarr_id': series['id'],
-                'tvdb_id': series['tvdbId'],
-            }
-
-            # Map the primary title to these ID's
-            si = SeriesInfo(series['title'], series['year'])
-            self.__series_ids[si.full_match_name] = data
-
-            # Map each alternate title to these ID's
-            for alt_title in series['alternateTitles']:
-                alt_si = SeriesInfo(alt_title['title'], series['year'])
-                self.__series_ids[alt_si.full_match_name] = data
+        # If no ID was returned, error and return
+        if series_info.sonarr_id is None:
+            self.__warn_missing_series(series_info)
 
 
-    def list_all_series_id(self) -> None:
-        """List all the series ID's of all shows used by Sonarr. """
-
-        # Construct GET arguments
-        url = f'{self.url}series'
-        params = self.__standard_params
-        all_series = self._get(url, params)
-
-        # Go through each series in Sonarr
-        for show in all_series:
-            # Print the main and alternate titles
-            main_title = show['title']
-            alt_titles = [_['title'] for _ in show['alternateTitles']]
-
-            padding = len(f'{show["id"]} : ')
-            titles = f'\n{" " * padding}'.join([main_title] + alt_titles)
-            print(f'{show["id"]} : {titles}')
-
-
-    def __get_all_episode_info(self, series_id: int) -> [EpisodeInfo]:
+    def __get_all_episode_info(self, series_id: int) -> list[EpisodeInfo]:
         """
         Gets all episode info for the given series ID. Only returns episodes
         that have aired already.
@@ -204,18 +206,12 @@ class SonarrInterface(WebInterface):
             # Create EpisodeInfo object for this entry
             # Non-canon episodes don't have absolute numbers
             episode_info = EpisodeInfo(
-                Title(episode['title']),
+                episode['title'],
                 episode['seasonNumber'],
                 episode['episodeNumber'],
-                episode.get('absoluteEpisodeNumber', None)
+                episode.get('absoluteEpisodeNumber'),
+                episode.get('tvdbId'),
             )
-
-            # Add info for the Sonarr ID
-            episode_info.set_sonarr_id(episode['id'])
-
-            # If this episode has a non-zero TVDb ID (that exists), add that
-            if episode.get('tvdbId'):
-                episode_info.set_tvdb_id(episode['tvdbId'])
 
             all_episode_info.append(episode_info)
 
@@ -229,7 +225,7 @@ class SonarrInterface(WebInterface):
         
         :param      series_info:    SeriesInfo for the entry.
         
-        :returns:   List of EpisodeInfo objects for this series.
+        :returns:   List of EpisodeInfo objects for the given series.
         """
 
         # If no ID was returned, error and return an empty list
@@ -240,48 +236,54 @@ class SonarrInterface(WebInterface):
         return self.__get_all_episode_info(series_info.sonarr_id)
 
 
-    def set_series_ids(self, series_info: SeriesInfo) -> None:
-        """
-        Set the TVDb ID to the given SeriesInfo object.
-
-        :param      series_info:    SeriesInfo for the entry.
-        """
-
-        # Set the Sonarr ID for this series
-        self.__set_ids(series_info)
-
-        # If no ID was returned, error and return
-        if series_info.sonarr_id is None:
-            self.__warn_missing_series(series_info)
-
-
-    def set_all_episode_ids(self, series_info: SeriesInfo,
-                            all_episodes: ['Episode']) -> None:
+    def set_episode_ids(self, series_info: SeriesInfo,
+                        infos: list[EpisodeInfo]) -> None:
         """
         Set all the episode ID's for the given list of EpisodeInfo objects. This
-        sets the Sonarr and TVDb ID's for each episode. As a byproduct, this
-        also updates the series ID's for the SeriesInfo object
+        sets the TVDb ID for each episode.
         
         :param      series_info:    SeriesInfo for the entry.
-        :param      all_episodes:   List of Episodes to update the EpisodeInfo
-                                    object of.
+        :param      infos:          List of EpisodeInfo objects to update.
         """
 
-        # Set the Sonarr ID for this series
-        self.__set_ids(series_info)
-
         # Get all sonarr-created EpisodeInfo objects
-        all_sonarr_episodes = self.get_all_episodes_for_series(series_info)
+        all_sonarr_episodes = self.get_all_episodes(series_info)
 
         # Go through each episode 
-        for episode in all_episodes:
+        for info in infos:
+            # Skip if EpisodeInfo already has TVDb ID
+            if info.tvdb_id is not None:
+                continue
+
             # Find the matching EpisodeInfo object returned by Sonarr
-            for sonarr_info in all_sonarr_episodes:
+            for index, sonarr_info in enumerate(all_sonarr_episodes):
                 # If these objects correspond to the same data, transfer ID's
                 # from the Sonarr EpisodeInfo objects to the primary ones
-                if episode.episode_info == sonarr_info:
-                    episode.episode_info.copy_ids(sonarr_info)
+                if info == sonarr_info:
+                    info.copy_ids(sonarr_info)
+
+                    # Delete this index for faster searching, exit Sonarr loop
+                    del all_sonarr_episodes[index]
                     break
+
+
+    def list_all_series_id(self) -> None:
+        """List all the series ID's of all shows used by Sonarr. """
+
+        # Construct GET arguments
+        url = f'{self.url}series'
+        params = self.__standard_params
+        all_series = self._get(url, params)
+
+        # Go through each series in Sonarr
+        for show in all_series:
+            # Print the main and alternate titles
+            main_title = show['title']
+            alt_titles = [_['title'] for _ in show['alternateTitles']]
+
+            padding = len(f'{show["id"]} : ')
+            titles = f'\n{" " * padding}'.join([main_title] + alt_titles)
+            print(f'{show["id"]} : {titles}')
 
 
     def get_series(self, filter_tags: list=[]) -> [(SeriesInfo, Path)]:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -248,7 +248,7 @@ class SonarrInterface(WebInterface):
 
         # Get all sonarr-created EpisodeInfo objects
         all_sonarr_episodes = self.get_all_episodes(series_info)
-
+        
         # Go through each episode 
         for info in infos:
             # Skip if EpisodeInfo already has TVDb ID

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -34,13 +34,13 @@ class StandardTitleCard(CardType):
     """Standard class has standard archive name"""
     ARCHIVE_NAME = 'standard'
 
-    """Source path for the gradient image overlayed over all title cards"""
-    __GRADIENT_IMAGE = REF_DIRECTORY / 'GRADIENT.png'
-
     """Default fonts and color for series count text"""
     SEASON_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Semibold.otf'
     EPISODE_COUNT_FONT = REF_DIRECTORY / 'Proxima Nova Regular.otf'
     SERIES_COUNT_TEXT_COLOR = '#CFCFCF'
+
+    """Source path for the gradient image overlayed over all title cards"""
+    __GRADIENT_IMAGE = REF_DIRECTORY / 'GRADIENT.png'
 
     """Paths to intermediate files that are deleted after the card is created"""
     __SOURCE_WITH_GRADIENT = CardType.TEMP_DIR / 'source_gradient.png'
@@ -58,7 +58,7 @@ class StandardTitleCard(CardType):
                  font_size: float, title_color: str, hide_season: bool,
                  separator: str='•', blur: bool=False, vertical_shift: int=0,
                  interline_spacing: int=0, kerning: float=1.0,
-                 stroke_width: float=1.0, *args, **kwargs) -> None:
+                 stroke_width: float=1.0, **kwargs) -> None:
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
@@ -83,7 +83,7 @@ class StandardTitleCard(CardType):
         :param  kerning:            Scalar to apply to kerning of the title text.
         :param  stroke_width:       Scalar to apply to black stroke of the title
                                     text.
-        :param  args and kwargs:    Unused arguments to permit generalized calls
+        :param  kwargs:             Unused arguments to permit generalized calls
                                     for any CardType.
         """
         

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -9,8 +9,7 @@ from modules.Debug import log
 class StarWarsTitleCard(CardType):
     """
     This class describes a type of ImageMaker that produces title cards in the
-    theme of Star Wars cards as designed by reddit user /u/Olivier_286. These
-    cards are not as customizable as the standard template.
+    theme of Star Wars cards as designed by reddit user /u/Olivier_286.
     """
 
     """Directory where all reference files used by this card are stored"""
@@ -23,54 +22,46 @@ class StarWarsTitleCard(CardType):
         'top_heavy': True,      # This class uses top heavy titling
     }
 
-    """How to name archive directories for this type of card"""
-    ARCHIVE_NAME = 'Star Wars Style'
-
-    """Path to the font to use for the episode title"""
+    """Characteristics of the default title font"""
     TITLE_FONT = str((REF_DIRECTORY/'Monstice-Base.ttf').resolve())
-
-    """Color to use for the episode title"""
     TITLE_COLOR = '#DAC960'
-
-    """Default episode text format string"""
-    EPISODE_TEXT_FORMAT = 'EPISODE {episode_number}'
-
-    """Color of the episode/episode number text"""
-    EPISODE_TEXT_COLOR = '#AB8630'
-
-    """Standard font replacements for the title font"""
     FONT_REPLACEMENTS = {'Ō': 'O', 'ō': 'o'}
+
+    """Characteristics of the episode text"""
+    EPISODE_TEXT_FORMAT = 'EPISODE {episode_number}'
+    EPISODE_TEXT_COLOR = '#AB8630'
+    EPISODE_TEXT_FONT = REF_DIRECTORY / 'HelveticaNeue.ttc'
+    EPISODE_NUMBER_FONT = REF_DIRECTORY / 'HelveticaNeue-Bold.ttf'
 
     """Whether this class uses season titles for the purpose of archives"""
     USES_SEASON_TITLE = False
 
+    """How to name archive directories for this type of card"""
+    ARCHIVE_NAME = 'Star Wars Style'
+
     """Path to the reference star image to overlay on all source images"""
     __STAR_GRADIENT_IMAGE = REF_DIRECTORY / 'star_gradient.png'
-
-    """Path to the font to use for the episode/episode number text """
-    EPISODE_TEXT_FONT = REF_DIRECTORY / 'HelveticaNeue.ttc'
-    EPISODE_NUMBER_FONT = REF_DIRECTORY / 'HelveticaNeue-Bold.ttf'
 
     """Paths to intermediate files that are deleted after the card is created"""
     __SOURCE_WITH_STARS = CardType.TEMP_DIR / 'source_gradient.png'
 
 
-    __slots__ = ('source_file', 'output_file', 'title', 'episode_prefix',
-                 'episode_text', 'hide_episode_text', 'blur')
+    __slots__ = ('source_file', 'output_file', 'title', 'hide_episode_text', 
+                 'episode_prefix', 'episode_text', 'blur')
 
     
     def __init__(self, source: Path, output_file: Path, title: str,
-                 episode_text: str, blur: bool=False, *args, **kwargs) -> None:
+                 episode_text: str, blur: bool=False, **kwargs) -> None:
         """
         Constructs a new instance.
         
-        :param      source:             Source image for this card.
-        :param      output_file:        Output filepath for this card.
-        :param      title:              The title for this card.
-        :param      episode_text:       The episode text for this card.
-        :param      blur:               Whether to blur the source image.
-        :param      args and kwargs:    Unused arguments to permit generalized
-                                        function calls for any CardType.
+        :param      source:         Source image for this card.
+        :param      output_file:    Output filepath for this card.
+        :param      title:          The title for this card.
+        :param      episode_text:   The episode text for this card.
+        :param      blur:           Whether to blur the source image.
+        :param      kwargs:         Unused arguments to permit generalized
+                                    function calls for any CardType.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -465,15 +465,14 @@ class TMDbInterface(WebInterface):
     def set_episode_ids(self, series_info: SeriesInfo,
                         infos: list[EpisodeInfo]) -> None:
         """
-        Set all the episode ID's for the given list of EpisodeInfo objects. This
-        sets the Sonarr and TVDb ID's for each episode. As a byproduct, this
-        also updates the series ID's for the SeriesInfo object
+        Set all the episode ID's for the given list of EpisodeInfo objects. For
+        TMDb, this does nothing, as TMDb cannot provide any useful episode ID's.
         
         :param      series_info:    SeriesInfo for the entry.
         :param      infos:          List of EpisodeInfo objects to update.
         """
 
-        pass
+        return None
 
 
     def __determine_best_image(self, images: list,

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -374,11 +374,10 @@ class TMDbInterface(WebInterface):
             url = f'{self.API_BASE_URL}find/{episode_info.tvdb_id}'
             params = {'api_key': self.__api_key, 'external_source': 'tvdb_id'}
             results = self._get(url, params)['tv_episode_results']
-
+            
             # If an episode was found, return its index
             if len(results) > 0:
-                # Set series TMDb ID
-                series_info.set_tmdb_id(results[0]['show_id'])
+                return {
                     'season': results[0]['season_number'],
                     'episode': results[0]['episode_number'],
                 }

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -319,10 +319,11 @@ class TMDbInterface(WebInterface):
 
         # Get all seasons on TMDb
         url = f'{self.API_BASE_URL}tv/{series_info.tmdb_id}'
-        num_seasons = len(self._get(url, self.__standard_params)['seasons'])
+        seasons = self._get(url, self.__standard_params)['seasons']
+        season_numbers = [s['season_number'] for s in seasons]
 
         all_episodes = []
-        for season_number in range(num_seasons):
+        for season_number in season_numbers:
             # Get episodes for this season
             url = (f'{self.API_BASE_URL}tv/{series_info.tmdb_id}/season/'
                    f'{season_number}')

--- a/modules/TextlessTitleCard.py
+++ b/modules/TextlessTitleCard.py
@@ -7,7 +7,7 @@ from modules.Debug import log
 class TextlessTitleCard(CardType):
     """
     This class describes a type of CardType that does not modify the source
-    image in anyway, and only optionally blurs it. No text of any kind is added.
+    image in anyway, only optionally blurring it. No text of any kind is added.
     """
 
     """Characteristics for title splitting by this class"""
@@ -23,11 +23,9 @@ class TextlessTitleCard(CardType):
     """Default episode text format string, can be overwritten by each class"""
     EPISODE_TEXT_FORMAT = ''
 
-    """Default font and text color for episode title text"""
+    """Characteristics of the default title font"""
     TITLE_FONT = None
     TITLE_COLOR = None
-
-    """Default characters to replace in the generic font"""
     FONT_REPLACEMENTS = {}
 
     """Whether this CardType uses season titles for archival purposes"""
@@ -40,17 +38,17 @@ class TextlessTitleCard(CardType):
 
 
     def __init__(self, source: Path, output_file: Path, blur: bool=False,
-                 *args, **kwargs) -> None:
+                 **kwargs) -> None:
         """
         Initialize the TitleCardMaker object. This primarily just stores
         instance variables for later use in `create()`. If the provided font
         does not have a character in the title text, a space is used instead.
 
-        :param  source:             Source image.
-        :param  output_file:        Output file.
-        :param  blur:               Whether to blur the source image.
-        :param  args and kwargs:    Unused arguments to permit generalized calls
-                                    for any CardType.
+        :param  source:         Source image.
+        :param  output_file:    Output file.
+        :param  blur:           Whether to blur the source image.
+        :param  kwargs:         Unused arguments to permit generalized calls for
+                                any CardType.
         """
         
         # Initialize the parent class - this sets up an ImageMagickInterface

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -65,9 +65,10 @@ class TitleCard:
         """
         Constructs a new instance of this class.
         
-        :param      episode:    The episode whose TitleCard this corresponds to.
-        :param      profile:    The profile to apply to the creation of this 
-                                title card.
+        :param      episode:                The episode whose TitleCard this
+                                            corresponds to.
+        :param      profile:                The profile to apply to the creation
+                                            of this title card.
         :param      title_characteristics:  Dictionary of characteristics from
                                             the CardType class for this Episode
                                             to pass to Title.apply_profile().
@@ -80,7 +81,7 @@ class TitleCard:
         self.episode = episode
         self.profile = profile
 
-        # Apply the given profile to the Episode's Title
+        # Apply the given profile to the Title
         self.converted_title = episode.episode_info.title.apply_profile(
             profile, **title_characteristics
         )   
@@ -94,6 +95,7 @@ class TitleCard:
             episode_text=profile.get_episode_text(self.episode),
             hide_season=profile.hide_season_title,
             blur=episode.blur,
+            watched=episode.watched,
             **profile.font.get_attributes(),
             **extra_characteristics,
             **self.episode.episode_info.episode_characteristics,

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -100,7 +100,7 @@ class TitleCard:
             **extra_characteristics,
             **self.episode.episode_info.episode_characteristics,
         )
-
+        
         # File associated with this card is the episode's destination
         self.file = episode.destination
 

--- a/modules/tautulli/update_card.sh
+++ b/modules/tautulli/update_card.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$@" >> update.txt


### PR DESCRIPTION
# Major Changes
- Add ability to immediately remake cards after they've been watched
  - Maker can now monitor (on a variable frequency) a file written to by Tautulli and immediately remake cards after they're watched
  - Added `--tautulli-update-list` and `--tautulli-update-frequency` arguments
    - Also set via `TCM_TAUTULLI_UPDATE_LIST` and `TCM_TAUTULLI_UPDATE_FREQUENCY` environment variables
    - Specify file to monitor for what cards to remake
    - Specify how often to read that file (defaults to 2 minutes)
  - For example, the following will check the specified file every 60 seconds for cards to remake:
  ```console
  $ pipenv run python main.py --tautulli-update-list /docker/tautulli/update.txt --tautulli-update-frequency 60s
  ```
  - Closes #194 
- Let card filename format be set per-series
  - Specify as `filename_format` within series YAML (overrides global default), like so:
     ```yaml
     series:
       One Piece:
         year: 1999
         filename_format: "One Piece - S01E{abs_number:04}"
     ```
  - Closes #203 
- Add ability to get episode data from TMDb or Plex, in addition to Sonarr/TVDb
  - Specify globally and/or per-series with `episode_data_source` option, like so:
     ```yaml
     options:
       episode_data_source: plex
     ```
  - Closes #201
  - Closes #97
- Get episode ID's as a part of the main run routine to improve episode matching on TMDb
  - Episode ID's are now sourced from Sonarr, TMDb, _and_ Plex (was just Sonarr)
- Rename global `source_priority` option to `image_source_priority`
# Major Fixes 
N/A
# Minor Changes
- Add `Beedman/GradientLogoTitleCard` user-submitted card to README (example of card below)
  <img src="https://github.com/Beedman/TitleCardMaker-CardTypes/blob/master/Beedman/The%20Afterparty%20(2022)%20-%20S01E02%20-%20Brett.jpg?raw=true" height="200"/>
- Add character replacements for "♡" and "☆" to `AnimeTitleCard`
- Let Sonarr, TMDb, TVDb, and IMDb ID's be manually set within YAML
  - Specify with `sonarr_id`, `tmdb_id`, or `tvdb_id` for a given series
  - Specify with `tvdb_id`, or `imdb_id` in the datafile for a given episode
  - Closes #200 
- Pass episode watch status to `CardType` initialization
  - Closes #204 
- No longer require Sonarr URL to end in `/api/v3/`, this is detected/added automatically
  - Closes #207 
# Minor Fixes
- Don't check for preferred title translations if already present
  - Closes #202 
- Handle empty template specification in series YAML files