### PR TITLE
Temporary TMDb API fix, better PMM overlay integration, 

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -28,7 +28,8 @@ ENV_PREFERENCE_FILE = 'TCM_PREFERENCES'
 DEFAULT_PREFERENCE_FILE = Path(__file__).parent / 'preferences.yml'
 
 # Old commands that have moved to mini_maker to warn user about
-OLD_COMMANDS = ('--title-card', '--genre-card', '--show-summary')
+OLD_COMMANDS = ('--title-card', '--genre-card', '--show-summary',
+                '--season-poster')
 
 # Create ArgumentParser object 
 parser = ArgumentParser(description='Manual fixes for the TitleCardMaker')
@@ -106,7 +107,7 @@ tmdb_group.add_argument(
     nargs=5,
     default=SUPPRESS,
     action='append',
-    metavar=('TITLE', 'YEAR', 'SEASON', 'EPISODES', 'DIRECTORY'),
+    metavar=('TITLE', 'YEAR', 'SEASON', 'EPISODE_RANGE', 'DIRECTORY'),
     help='Download the title card source images for the given season of the '
          'given series')
 tmdb_group.add_argument(
@@ -253,12 +254,20 @@ if hasattr(args, 'delete_blacklist'):
 
 if hasattr(args, 'tmdb_download_images') and pp.use_tmdb:
     for arg_set in args.tmdb_download_images:
+        try:
+            start, end = map(int, arg_set[3].split('-'))
+            episode_range = range(start, end+1)
+        except ValueError:
+            log.error(f'Invalid episode range, specify like "START-END", i.e. '
+                      f'2-10 for episodes 2 through 10')
+            continue
+
         TMDbInterface.manually_download_season(
             api_key=pp.tmdb_api_key,
             title=arg_set[0],
             year=int(arg_set[1]),
-            season=int(arg_set[2]),
-            episode_count=int(arg_set[3]),
+            season_number=int(arg_set[2]),
+            episode_range=episode_range,
             directory=Path(arg_set[4]),
         )
 

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -439,7 +439,8 @@ class PlexInterface:
 
 
     @retry(stop=stop_after_attempt(5),
-           wait=wait_fixed(3)+wait_exponential(min=1, max=32))
+           wait=wait_fixed(3)+wait_exponential(min=1, max=32),
+           before_sleep=lambda _:log.warning('Cannot upload image, retrying..'))
     def __retry_upload(self, plex_episode: 'Episode', filepath: Path) -> None:
         """
         Upload the given poster to the given Episode, retrying if it fails.

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -449,12 +449,7 @@ class PlexInterface:
         :param      filepath:       Filepath to the poster to upload.
         """
 
-        # Upload poster
         plex_episode.uploadPoster(filepath=filepath)
-
-        # If overlay integration is enabled, remove "Overlay" label
-        if self.preferences.integrate_with_pmm_overlays:
-            plex_episode.removeLabel(['Overlay'])
 
 
     def set_title_cards_for_series(self, library_name: str, 
@@ -508,10 +503,14 @@ class PlexInterface:
             # Update progress bar
             pbar.set_description(f'Updating {pl_episode.seasonEpisode.upper()}')
             
-            # Upload card to Plex
+            # Upload card to Plex, optionally remove Overlay label
             try:
                 self.__retry_upload(pl_episode, episode.destination.resolve())
                 loaded_count += 1
+
+                # If overlay integration is enabled, remove "Overlay" label
+                if self.preferences.integrate_with_pmm_overlays:
+                    pl_episode.removeLabel(['Overlay'])
             except Exception as e:
                 error_count += 1
                 log.warning(f'Unable to upload {episode.destination.resolve()} '

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -35,7 +35,8 @@ class PlexInterface:
                                     if the host device is untrusted.
         """
 
-        # Get global MediaInfoSet object
+        # Get global PreferenceParser and MediaInfoSet objects
+        self.preferences = global_objects.pp
         self.info_set = global_objects.info_set
 
         # Create PlexServer object with these arguments
@@ -448,7 +449,12 @@ class PlexInterface:
         :param      filepath:       Filepath to the poster to upload.
         """
 
+        # Upload poster
         plex_episode.uploadPoster(filepath=filepath)
+
+        # If overlay integration is enabled, remove "Overlay" label
+        if self.preferences.integrate_with_pmm_overlays:
+            plex_episode.removeLabel(['Overlay'])
 
 
     def set_title_cards_for_series(self, library_name: str, 

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -76,6 +76,7 @@ class PreferenceParser(YamlReader):
         self.use_plex = False
         self.plex_url = None
         self.plex_token = 'NA'
+        self.integrate_with_pmm_overlays = False
         self.global_watched_style = 'unique'
         self.global_unwatched_style = 'unique'
         self.use_sonarr = False
@@ -241,6 +242,10 @@ class PreferenceParser(YamlReader):
                 self.valid = False
             else:
                 self.global_unwatched_style = value
+
+        if (value := self._get('plex', 'integrate_with_pmm_overlays',
+                               type_=bool)) is not None:
+            self.integrate_with_pmm_overlays = value
 
         if self._is_specified('sonarr'):
             if (not self._is_specified('sonarr', 'url')

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -691,7 +691,7 @@ class TMDbInterface(WebInterface):
 
     @staticmethod
     def manually_download_season(api_key: str, title: str, year: int,
-                                 season: int, episode_count: int,
+                                 season_number: int, episode_range: 'iterable',
                                  directory: Path) -> None:
         """
         Download episodes 1-episode_count of the requested season for the given
@@ -700,8 +700,8 @@ class TMDbInterface(WebInterface):
         :param      api_key:        The api key for sending requsts to TMDb.
         :param      title:          The title of the requested show.
         :param      year:           The year of the requested show.
-        :param      season:         The season to download.
-        :param      episode_count:  The number of episodes to download
+        :param      season_number:  Which season to download.
+        :param      episode_range:  Iterable of episode numbers to download.
         :param      directory:      The directory to place the downloaded images
                                     in.
         """
@@ -711,15 +711,17 @@ class TMDbInterface(WebInterface):
 
         # Create SeriesInfo and EpisodeInfo objects
         si = SeriesInfo(title, year)
+        dbi.set_series_ids(si)
 
-        for episode in range(1, episode_count+1):
-            ei = EpisodeInfo('', season, episode)
+        for episode_number in episode_range:
+            ei = EpisodeInfo('', season_number, episode_number)
             image_url = dbi.get_source_image(si, ei, title_match=False)
 
             # If a valid URL was returned, download it
-            if image_url:
-                filename = f's{season}e{episode}.jpg'
+            if image_url is not None:
+                filename = f's{season_number}e{episode_number}.jpg'
                 dbi.download_image(image_url, directory / filename)
+                log.debug(f'Downloaded {(directory / filename).resolve()}')
 
 
     @staticmethod


### PR DESCRIPTION
# Major Changes
*N/A*
# Major Fixes 
- Temporary fix for TMDb episodes not reloading (causing images/translations to not be found)
  - TMDb doesn't return any way to "identify" a series that's been matched by external database ID (like TVDb or IMDb)
  - Addresses #222 until TMDb changes the API (if they do)
# Minor Changes
- Better integration with PMM episode overlays
  - Look for optional `integrate_with_pmm_overlays` setting within global `plex` preferences
  - If `true`, the `Overlay` label is deleted from an episode after a card has been uploaded
  - Closes #221 
- Download range of episodes from TMDb with fixer
  - Specify episode range like `2-10` within `--tmdb-download-images` fixer argument
  - Closes #211 
- Log card upload failures/retries
# Minor Fixes
*N/A*