### PR TITLE
Make year semi-optional, add exclusions and specify templates in YAML sync, other changes and fixes

### DIFF
--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -40,6 +40,7 @@ class Manager:
             self.sonarr_interface = SonarrInterface(
                 url=self.preferences.sonarr_url,
                 api_key=self.preferences.sonarr_api_key,
+                verify_ssl=self.preferences.sonarr_verify_ssl,
             )
 
         # Optionally assign TMDbInterface

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -32,6 +32,7 @@ class Manager:
             self.plex_interface = PlexInterface(
                 url=self.preferences.plex_url,
                 x_plex_token=self.preferences.plex_token,
+                verify_ssl=self.preferences.plex_verify_ssl,
             )
 
         # Optionally assign SonarrInterface

--- a/modules/MediaInfoSet.py
+++ b/modules/MediaInfoSet.py
@@ -264,6 +264,9 @@ class MediaInfoSet:
         self.series_names[f'{name} ({series_info.year})'] = series_info
 
         # Delete old key
-        del self.series_names[old_key]
+        try:
+            del self.series_names[old_key]
+        except KeyError:
+            pass
 
         

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -9,6 +9,7 @@ from modules.Debug import log, TQDM_KWARGS
 import modules.global_objects as global_objects
 from modules.EpisodeInfo import EpisodeInfo
 from modules.SeriesInfo import SeriesInfo
+from modules.WebInterface import WebInterface
 
 class PlexInterface:
     """
@@ -29,23 +30,28 @@ class PlexInterface:
     SKIP_SERIES_THRESHOLD = 3
 
 
-    def __init__(self, url: str, x_plex_token: str=None) -> None:
+    def __init__(self, url: str, x_plex_token: str=None,
+                 verify_ssl: bool=True) -> None:
         """
         Constructs a new instance of a Plex Interface.
         
-        :param      url:            The url at which Plex is hosted.
-        :param      x_plex_token:   The x plex token for sending API requests to
-                                    if the host device is untrusted.
+        Args:
+            url: URL of plex server.
+            x_plex_token: X-Plex Token for sending API requests to Plex.
+            verify_ssl: Whether to verify SSL requests when querying Plex.
         """
 
         # Get global PreferenceParser and MediaInfoSet objects
         self.preferences = global_objects.pp
         self.info_set = global_objects.info_set
 
+        # Create Session for caching HTTP responses
+        self.__session = WebInterface('Plex', verify_ssl).session
+
         # Create PlexServer object with these arguments
         try:
             self.__token = x_plex_token
-            self.__server = PlexServer(url, x_plex_token)
+            self.__server = PlexServer(url, x_plex_token, self.__session)
         except Unauthorized:
             log.critical(f'Invalid Plex Token "{x_plex_token}"')
             exit(1)

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -77,6 +77,7 @@ class PreferenceParser(YamlReader):
         self.use_plex = False
         self.plex_url = None
         self.plex_token = 'NA'
+        self.plex_verify_ssl = True
         self.integrate_with_pmm_overlays = False
         self.global_watched_style = 'unique'
         self.global_unwatched_style = 'unique'
@@ -227,6 +228,9 @@ class PreferenceParser(YamlReader):
 
         if (value := self._get('plex', 'token', type_=str)) != None:
             self.plex_token = value
+
+        if (value := self._get('plex', 'verify_ssl', type_=bool)) is not None:
+            self.plex_verify_ssl = value
 
         if (value := self._get('plex', 'watched_style', type_=lower_str))!=None:
             if value not in Show.VALID_STYLES:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -265,7 +265,7 @@ class PreferenceParser(YamlReader):
         if (value := self._get('plex', 'sync', 'libraries')) is not None:
             self.plex_yaml_update_args['filter_libraries'] = value
 
-        if (value := self._get('plex', 'sync', 'exclude')) is not None:
+        if (value := self._get('plex', 'sync', 'exclusions')) is not None:
             self.plex_yaml_update_args['exclusions'] = value
 
         if self._is_specified('sonarr'):
@@ -302,7 +302,7 @@ class PreferenceParser(YamlReader):
         if (value := self._get('sonarr', 'sync', 'required_tags')) is not None:
             self.sonarr_yaml_update_args['required_tags'] = value
 
-        if (value := self._get('sonarr', 'sync', 'exclude')) is not None:
+        if (value := self._get('sonarr', 'sync', 'exclusions')) is not None:
             self.sonarr_yaml_update_args['exclusions'] = value
 
         if (value := self._get('sonarr', 'sync', 'monitored_only',

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -81,13 +81,12 @@ class PreferenceParser(YamlReader):
         self.global_watched_style = 'unique'
         self.global_unwatched_style = 'unique'
         self.plex_yaml_writer = None
-        self.plex_yaml_update_args = {'filter_libraries': []}
+        self.plex_yaml_update_args = {}
         self.use_sonarr = False
         self.sonarr_url = None
         self.sonarr_api_key = None
         self.sonarr_yaml_writer = None
-        self.sonarr_yaml_update_args = {'plex_libraries': {}, 'filter_tags': [],
-                                        'monitored_only': False}
+        self.sonarr_yaml_update_args = {}
         self.use_tmdb = False
         self.tmdb_api_key = None
         self.tmdb_retry_count = TMDbInterface.BLACKLIST_THRESHOLD
@@ -230,20 +229,17 @@ class PreferenceParser(YamlReader):
 
         if (value := self._get('plex', 'watched_style', type_=lower_str))!=None:
             if value not in Show.VALID_STYLES:
-                options = '", "'.join(Show.VALID_STYLES)
-                log.critical(f'Invalid watched style, must be one of "{opts}"')
+                opt = '", "'.join(Show.VALID_STYLES)
+                log.critical(f'Invalid watched style, must be one of "{opt}"')
                 self.valid = False
             else:
                 self.global_watched_style = value
 
         if (value := self._get('plex', 'unwatched_style',
                                type_=lower_str)) != None:
-            if value == 'ignore':
-                log.critical(f'Unwatched style "ignore" is now "unique"')
-                self.valid = False
-            elif value not in Show.VALID_STYLES:
-                opts = '", "'.join(Show.VALID_STYLES)
-                log.critical(f'Invalid unwatched style, must be one of "{opts}"')
+            if value not in Show.VALID_STYLES:
+                opt = '", "'.join(Show.VALID_STYLES)
+                log.critical(f'Invalid unwatched style, must be one of "{opt}"')
                 self.valid = False
             else:
                 self.global_unwatched_style = value
@@ -259,10 +255,12 @@ class PreferenceParser(YamlReader):
                 self._get(*attrs, 'compact_mode', type_=bool, default=True),
                 self._get(*attrs, 'volumes', default={}),
             )
-            self.plex_yaml_update_args = {
-                'filter_libraries': self._get('plex', 'sync', 'libraries',
-                                              default=[]),
-            }
+
+        if (value := self._get('plex', 'sync', 'libraries')) is not None:
+            self.plex_yaml_update_args['filter_libraries'] = value
+
+        if (value := self._get('plex', 'sync', 'exclude')) is not None:
+            self.plex_yaml_update_args['exclusions'] = value
 
         if self._is_specified('sonarr'):
             if (not self._is_specified('sonarr', 'url')
@@ -282,20 +280,29 @@ class PreferenceParser(YamlReader):
                 self._get(*attrs, 'compact_mode', type_=bool, default=True),
                 self._get(*attrs, 'volumes', default={}),
             )
-            self.sonarr_yaml_update_args = {
-                'plex_libraries': self._get('sonarr', 'sync', 'plex_libraries',
-                                            default={}),
-                'filter_tags': self._get('sonarr', 'sync', 'tags', default=[]),
-                'monitored_only': self._get('sonarr', 'sync', 'monitored_only',
-                                            default=False),
-            }
+            
+        if (value := self._get('sonarr', 'sync', 'plex_libraries')) is not None:
+            self.sonarr_yaml_update_args['plex_libraries'] = value
+        
+        if (value := self._get('sonarr', 'sync', 'plex_libraries')) is not None:
+            self.sonarr_yaml_update_args['plex_libraries'] = value
+
+        if (value := self._get('sonarr', 'sync', 'required_tags')) is not None:
+            self.sonarr_yaml_update_args['required_tags'] = value
+
+        if (value := self._get('sonarr', 'sync', 'exclude')) is not None:
+            self.sonarr_yaml_update_args['exclusions'] = value
+
+        if (value := self._get('sonarr', 'sync', 'monitored_only',
+                               type_=bool)) is not None:
+            self.sonarr_yaml_update_args['monitored_only'] = value
         
         if (value := self._get('tmdb', 'api_key', type_=str)) != None:
             self.tmdb_api_key = value
             self.use_tmdb = True
 
         if (value := self._get('tmdb', 'retry_count', type_=int)) != None:
-            self.tmdb_retry_count = int(value)
+            self.tmdb_retry_count = value
 
         if (value := self._get('tmdb', 'minimum_resolution', type_=str)) !=None:
             try:
@@ -310,11 +317,6 @@ class PreferenceParser(YamlReader):
             self.imagemagick_container = value
 
         # Warn for renamed settings
-        if self._is_specified('options', 'source_priority'):
-            log.critical(f'Options "source_priority" setting has been renamed '
-                         f'to "image_source_priority"')
-            self.valid = False
-
         if self._is_specified('options', 'zero_pad_seasons'):
             log.critical(f'Options "zero_pad_seasons" setting has been '
                          f'incorporated into "season_folder_format"')
@@ -330,9 +332,9 @@ class PreferenceParser(YamlReader):
                          f'renamed to "background"')
             self.valid = False
 
-        if self._is_specified('plex', 'unwatched'):
-            log.critical(f'Plex "unwatched" setting has been renamed to '
-                         f'"unwatched_style"')
+        if self._is_specified('sonarr', 'sync', 'tags'):
+            log.critical(f'Sonarr sync "tags" option has been renamed '
+                         f'"required_tags".')
             self.valid = False
 
 

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -254,6 +254,7 @@ class PreferenceParser(YamlReader):
                 self._get(*attrs, 'mode', type_=str, default='append'),
                 self._get(*attrs, 'compact_mode', type_=bool, default=True),
                 self._get(*attrs, 'volumes', default={}),
+                self._get(*attrs, 'add_template', type_=str, default=None),
             )
 
         if (value := self._get('plex', 'sync', 'libraries')) is not None:
@@ -279,6 +280,7 @@ class PreferenceParser(YamlReader):
                 self._get(*attrs, 'mode', type_=str, default='append'),
                 self._get(*attrs, 'compact_mode', type_=bool, default=True),
                 self._get(*attrs, 'volumes', default={}),
+                self._get(*attrs, 'add_template', type_=str, default=None),
             )
             
         if (value := self._get('sonarr', 'sync', 'plex_libraries')) is not None:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -257,6 +257,11 @@ class PreferenceParser(YamlReader):
                 self._get(*attrs, 'add_template', type_=str, default=None),
             )
 
+            if (self._get(*attrs, 'mode', type_=lower_str) == 'sync'
+                and self._get(*attrs, 'add_template', type_=str)):
+                log.warning(f'Adding a template during "sync" mode will do '
+                            f'nothing')
+
         if (value := self._get('plex', 'sync', 'libraries')) is not None:
             self.plex_yaml_update_args['filter_libraries'] = value
 
@@ -282,6 +287,11 @@ class PreferenceParser(YamlReader):
                 self._get(*attrs, 'volumes', default={}),
                 self._get(*attrs, 'add_template', type_=str, default=None),
             )
+
+            if (self._get(*attrs, 'mode', type_=lower_str) == 'sync'
+                and self._get(*attrs, 'add_template', type_=str)):
+                log.warning(f'Adding a template during "sync" mode will do '
+                            f'nothing')
             
         if (value := self._get('sonarr', 'sync', 'plex_libraries')) is not None:
             self.sonarr_yaml_update_args['plex_libraries'] = value

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -85,6 +85,7 @@ class PreferenceParser(YamlReader):
         self.use_sonarr = False
         self.sonarr_url = None
         self.sonarr_api_key = None
+        self.sonarr_verify_ssl = True
         self.sonarr_yaml_writer = None
         self.sonarr_yaml_update_args = {}
         self.use_tmdb = False
@@ -278,6 +279,9 @@ class PreferenceParser(YamlReader):
                 self.sonarr_url = self._get('sonarr', 'url', type_=str)
                 self.sonarr_api_key = self._get('sonarr', 'api_key', type_=str)
                 self.use_sonarr = True
+
+        if (value := self._get('sonarr', 'verify_ssl', type_=bool)) is not None:
+            self.sonarr_verify_ssl = value
 
         if self._is_specified(*(attrs := ('sonarr', 'sync')), 'file'):
             self.sonarr_yaml_writer = SeriesYamlWriter(

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from re import match
+from re import match, compile as re_compile
 from typing import ClassVar
 
 from modules.Debug import log
@@ -12,7 +12,7 @@ class SeriesInfo:
 
     """Initialization fields"""
     name: str
-    year: int
+    year: int=None
     imdb_id: str=None
     sonarr_id: int=None
     tvdb_id: int=None
@@ -34,9 +34,23 @@ class SeriesInfo:
         '*': '-',
     }
 
+    """Regex to match name + year from given full name"""
+    __FULL_NAME_REGEX = re_compile(r'^(.*?)\s+\((\d{4})\)$')
+
 
     def __post_init__(self) -> None:
+        # Try and parse name and year from full name
+        if (self.year is None
+            and (group := match(self.__FULL_NAME_REGEX,self.name)) is not None):
+            self.name = group.group(1)
+            self.year = int(group.group(2))
+        
+        # If year isn't specified still, exit
+        if self.year is None:
+            raise ValueError(f'Year not provided')
+
         self.update_name(self.name)
+
 
     def __str__(self) -> str:
         """Returns a string representation of the object."""

--- a/modules/SeriesYamlWriter.py
+++ b/modules/SeriesYamlWriter.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from re import sub, IGNORECASE
 
-from ruamel.yaml import YAML, round_trip_dump, comments
+from ruamel.yaml import YAML, round_trip_dump, comments, 
+from ruamel.yaml.constructor import DuplicateKeyError
 from yaml import add_representer, dump
 
 from modules.Debug import log
@@ -121,8 +122,17 @@ class SeriesYamlWriter:
             return None
 
         # Read existing lines/YAML for future parsing
-        with self.file.open('r', encoding='utf-8') as file_handle:
-            existing_yaml = YAML().load(file_handle)
+        try:
+            with self.file.open('r', encoding='utf-8') as file_handle:
+                existing_yaml = YAML().load(file_handle)
+        except DuplicateKeyError as e:
+            log.error(f'Cannot sync to file "{self.file.resolve()}"')
+            log.error(f'Invalid YAML encountered {e}')
+            return None
+        except Exception as e:
+            log.error(f'Cannot sync to file "{self.file.resolve()}"')
+            log.error(f'Error occured {e}')
+            return None
         
         # Write if file exists but is blank
         if existing_yaml is None or len(existing_yaml) == 0:

--- a/modules/SeriesYamlWriter.py
+++ b/modules/SeriesYamlWriter.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from re import sub, IGNORECASE
 
-from ruamel.yaml import YAML, round_trip_dump, comments, 
+from ruamel.yaml import YAML, round_trip_dump, comments
 from ruamel.yaml.constructor import DuplicateKeyError
 from yaml import add_representer, dump
 
@@ -10,7 +10,7 @@ from modules.Debug import log
 class SeriesYamlWriter:
     """
     This class describes a SeriesYamlWriter. This is an object that writes
-    formatted series YAML files.
+    formatted series YAML files by syncing with Sonarr or Plex.
     """
 
     """Default arguments for initializing an object"""
@@ -18,11 +18,9 @@ class SeriesYamlWriter:
         'sync_mode': 'append', 'compact_mode': True, 'volume_map': {}
     }
 
-    """Temporary file to read/write YAML from for string conversion"""
-    __TEMPORARY_FILE = Path(__file__).parent / '.objects' / 'tmp.yml'
-
     """Keyword arguments for yaml.dump()"""
     __WRITE_OPTIONS = {'allow_unicode': True, 'width': 200}
+
 
     def __init__(self, file: Path, sync_mode: str='append',
                  compact_mode: bool=True, volume_map: dict[str: str]={}) ->None:
@@ -74,6 +72,17 @@ class SeriesYamlWriter:
 
 
     def __convert_path(self, path: str) -> str:
+        """
+        Convert the given path string to its TCM-equivalent by using this 
+        object's volume map.
+
+        Args:
+            path: Path (as string) to convert.
+
+        Returns:
+            Converted Path (as string). If no conversion was applied, then the 
+            original path is returned.
+        """
 
         # Use volume map to convert Sonarr path to TCM path
         for source_base, tcm_base in self.volume_map.items():
@@ -82,6 +91,51 @@ class SeriesYamlWriter:
                 return adj_path
 
         return path
+
+
+    def __apply_exclusion(self, yaml: dict[str: dict[str: str]],
+                          exclusions: list[dict[str: str]]) -> None:
+        """
+        Apply the given exclusions to the given YAML. This modifies the YAML
+        object in-place.
+
+        Args:
+            yaml: YAML being modified.
+            exclusions: List of labelled exclusions to apply to sync.
+        """
+
+        # No exclusions to apply, exit
+        if len(exclusions) == 0 or len(yaml.get('series', {})) == 0:
+            return None
+
+        # Go through each exclusion in the given list
+        for exclusion in exclusions:
+            # Validate this exclusion is a dictionary
+            if not isinstance(exclusion, dict):
+                log.error(f'Invalid exclusion {exclusion}')
+                continue
+
+            # Get exclusion label and value
+            label, value = list(exclusion.items())[0]
+            
+            # If this exclusion is a YAML file, read and filter each series
+            if (label := label.lower()) == 'yaml':
+                # Attempt to read file, error and skip if invalid
+                try:
+                    with Path(value).open('r', encoding='utf-8') as file_handle:
+                        read_yaml = YAML().load(file_handle)
+                except Exception:
+                    log.error(f'Cannot read "{value}" as exclusion file')
+                    continue
+                
+                # Delete each file's specified series
+                for series in read_yaml.get('series', {}).keys():
+                    if series in yaml.get('series', {}):
+                        del yaml['series'][series]
+            # If this exclusion is a specific series, remove
+            elif label == 'series':
+                if value in yaml.get('series', {}):
+                    del yaml['series'][value]
 
 
     def __write(self, yaml: dict[str: dict[str: str]]) -> None:
@@ -98,7 +152,7 @@ class SeriesYamlWriter:
             # Convert each series dictionary as a Flowmap dictionary
             yaml['series'] = {
                 k: self.__compact_flowmap(x)
-                for k, x in yaml['series'].items()
+                for k, x in yaml.get('series', {}).items()
             }
 
         # Write modified YAML to this writer's file
@@ -173,7 +227,8 @@ class SeriesYamlWriter:
 
     def __get_yaml_from_sonarr(self, sonarr_interface: 'SonarrInterface',
                                plex_libraries: dict[str: str],
-                               filter_tags: list[str],
+                               required_tags: list[str],
+                               exclusions: list[dict[str: str]],
                                monitored_only: bool)->dict[str: dict[str: str]]:
         """
         Get the YAML from Sonarr, as filtered by the given attributes.
@@ -182,7 +237,8 @@ class SeriesYamlWriter:
             sonarr_interface: SonarrInterface to sync from.
             plex_libraries: Dictionary of TCM paths to their corresponding
                 libraries.
-            filter_tags: List of tags to filter the Sonarr sync from.
+            required_tags: List of requried tags to filter the Sonarr sync with.
+            exclusions: List of labelled exclusions to apply to sync.
             monitored_only: Whether to only sync monitored series from Sonarr.
 
         Returns:
@@ -190,9 +246,17 @@ class SeriesYamlWriter:
             contains the YAML for that series, such as the 'name', 'year',
             'media_directory', and 'library'.
         """
+
+        # Get list of excluded tags
+        excluded_tags = [
+               list(exclusion.items())[0][1] for exclusion in exclusions
+            if list(exclusion.items())[0][0] == 'tag'
+        ]
         
         # Get list of SeriesInfo and paths from Sonarr
-        all_series = sonarr_interface.get_all_series(filter_tags,monitored_only)
+        all_series = sonarr_interface.get_all_series(
+            required_tags, excluded_tags, monitored_only
+        )
 
         # Exit if no series were returned
         if len(all_series) == 0:
@@ -212,17 +276,14 @@ class SeriesYamlWriter:
                     break
 
             # Add details to eventual YAML object
-            this_entry = {'year': series_info.year}
+            this_entry = {}
 
-            # Add under key: name > full name > full name (sonarr_id)
-            key = series_info.name
+            # Add under "full name", then "name [sonarr:sonarr_id]""
+            key = series_info.full_name
             if key in series_yaml:
-                if series_info.full_name not in series_yaml:
-                    this_entry['name'] = series_info.name
-                    key = series_info.full_name
-                else:
-                    this_entry['name'] = series_info.name
-                    key = f'{series_info.full_name} ({series_info.sonarr_id})'
+                this_entry['name'] = series_info.name
+                this_entry['year'] = series_info.year
+                key = f'{series_info.name} [sonarr:{series_info.sonarr_id}]'
 
             # Add media directory if path doesn't match default
             if Path(sonarr_path).name != series_info.legal_path:
@@ -241,12 +302,17 @@ class SeriesYamlWriter:
             libraries_yaml[library] = {'path': path}
 
         # Create end-YAML as combination of series and libraries
-        return {'libraries': libraries_yaml, 'series': series_yaml}
+        yaml = {'libraries': libraries_yaml, 'series': series_yaml}
+        
+        # Apply exclusions and return yaml
+        self.__apply_exclusion(yaml, exclusions)
+        return yaml
 
 
     def update_from_sonarr(self, sonarr_interface: 'SonarrInterface',
-                           plex_libraries: dict[str: str],
-                           filter_tags: list[str]=[],
+                           plex_libraries: dict[str: str]={},
+                           required_tags: list[str]=[],
+                           exclusions: list[dict[str: str]]=[],
                            monitored_only: bool=False) -> None:
         """
         Update this object's file from Sonarr.
@@ -255,13 +321,15 @@ class SeriesYamlWriter:
             sonarr_interface: SonarrInterface to sync from.
             plex_libraries: Dictionary of TCM paths to their corresponding
                 libraries.
-            filter_tags: List of tags to filter the Sonarr sync from.
+            required_tags: List of tags to filter the Sonarr sync from.
+            exclusions: List of labelled exclusions to apply to sync.
             monitored_only: Whether to only sync monitored series from Sonarr.
         """
 
         # Get complete file YAML from Sonarr
         yaml = self.__get_yaml_from_sonarr(
-            sonarr_interface, plex_libraries, filter_tags, monitored_only
+            sonarr_interface, plex_libraries, required_tags, exclusions,
+            monitored_only
         )
 
         # Either sync of append this YAML to this object's file
@@ -274,15 +342,16 @@ class SeriesYamlWriter:
 
 
     def __get_yaml_from_plex(self, plex_interface: 'PlexInterface',
-                             filter_libraries: list[str]
+                             filter_libraries: list[str],
+                             exclusions: list[dict[str: str]]=[]
                              ) -> dict[str: dict[str: str]]:
         """
        Get the YAML from Plex, as filtered by the given libraries.
 
         Args:
             plex_interface: PlexInterface to sync from.
-            filter_libraries: List of libraries to filter the returned YAML
-                by.
+            filter_libraries: List of libraries to filter the returned YAML by.
+            exclusions: List of labelled exclusions to apply to sync.
 
         Returns:
             Series YAML as reported by Plex. Keys are series names, and each
@@ -331,17 +400,23 @@ class SeriesYamlWriter:
         }
 
         # Create end-YAML as combination of series and libraries
-        return {'libraries': libraries_yaml, 'series': series_yaml}
+        yaml = {'libraries': libraries_yaml, 'series': series_yaml}
+
+         # Apply exclusions and return yaml
+        self.__apply_exclusion(yaml, exclusions)
+        return yaml
 
 
     def update_from_plex(self, plex_interface: 'PlexInterface',
-                         filter_libraries: list[str]=[]) -> None:
+                         filter_libraries: list[str]=[],
+                         exclusions: list[dict[str: str]]=[]) -> None:
         """
         Update this object's file from Plex.
 
         Args:
             plex_interface: PlexInterface to sync from.
             filter_libraries: List of libraries to filter Plex sync from.
+            exclusions: List of labelled exclusions to apply to sync.
         """
 
         if not isinstance(filter_libraries, (list, tuple)):
@@ -349,7 +424,9 @@ class SeriesYamlWriter:
             exit(1)
 
         # Get complete file YAML from Sonarr
-        yaml = self.__get_yaml_from_plex(plex_interface, filter_libraries)
+        yaml = self.__get_yaml_from_plex(
+            plex_interface, filter_libraries, exclusions
+        )
 
         # Either sync of append this YAML to this object's file
         if self.sync_mode == 'sync':

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -70,7 +70,7 @@ class Show(YamlReader):
 
         # Initialize parent YamlReader object
         super().__init__(yaml_dict, log_function=log.error)
-
+        
         # Get global objects
         self.preferences = preferences
         self.info_set = global_objects.info_set
@@ -79,16 +79,14 @@ class Show(YamlReader):
         self.__library_map = library_map
 
         # Set this show's SeriesInfo object with blank year to start
-        self.series_info = SeriesInfo(name, 0)
-
-        # If year isn't given, skip completely
-        if (year := self._get('year', type_=int)) is None:
+        try:
+            self.series_info = SeriesInfo(name, self._get('year', type_=int))
+        except ValueError:
             log.error(f'Series "{name}" is missing the required "year"')
             self.valid = False
             return None
             
         # Setup default values that may be overwritten by YAML
-        self.series_info = self.info_set.get_series_info(name, year)
         self.card_filename_format = self.preferences.card_filename_format
         self.media_directory = None
         self.card_class = self.preferences.card_class
@@ -185,9 +183,11 @@ class Show(YamlReader):
             modified_base['watched_style'] = value
 
         # Recreate Show object with modified YAML
-        show = Show(self.series_info.name, modified_base, self.__library_map,
-                    self.font._Font__font_map, self.source_directory.parent,
-                    self.preferences)
+        show = Show(
+            self.series_info.full_name, modified_base, self.__library_map,
+            self.font._Font__font_map, self.source_directory.parent,
+            self.preferences
+        )
         show.__is_archive = True
 
         return show

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -596,9 +596,13 @@ class Show(YamlReader):
             # SVG logos need to be converted first
             if url.endswith('.svg'):
                 # Download .svgs to temporary location pre-conversion
-                tmdb_interface.download_image(
+                success = tmdb_interface.download_image(
                     url, self.card_class.TEMPORARY_SVG_FILE
                 )
+
+                # If failed to downlaod, skip
+                if not success:
+                    return None
 
                 # Convert temporary SVG to PNG at logo filepath
                 self.card_class.convert_svg_to_png(
@@ -785,9 +789,9 @@ class Show(YamlReader):
 
                 # If URL was returned by either interface, download
                 if image_url is not None:
-                    WebInterface.download_image(image_url, episode.source)
-                    log.debug(f'Downloaded {episode.source.name} for {self} '
-                              f'from {source_interface}')
+                    if WebInterface.download_image(image_url, episode.source):
+                        log.debug(f'Downloaded {episode.source.name} for {self}'
+                                  f' from {source_interface}')
                     break
         
         # Query TMDb for the backdrop if one does not exist and is needed

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -260,9 +260,9 @@ class SonarrInterface(WebInterface):
 
                 # Skip temporary placeholder names if aired in the last 48 hours
                 if (self.__TEMP_IGNORE_REGEX.match(episode['title'])
-                    and air_datetime > datetime.now() + timedelta(days=2)):
-                    log.debug(f'Temporarily ignoring episode {episode["title"]}'
-                              f' of {series_info} - placeholder title')
+                    and air_datetime < datetime.now() + timedelta(days=2)):
+                    log.debug(f'Temporarily ignoring "{episode["title"]}" of '
+                              f'{series_info} - placeholder title')
                     continue
 
             # Skip permanent placeholder names

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -40,7 +40,7 @@ class SonarrInterface(WebInterface):
         """
 
         # Initialize parent WebInterface 
-        super().__init__(verify_ssl)
+        super().__init__('Sonarr', verify_ssl)
         
         # Get global MediaInfoSet object
         self.info_set = global_objects.info_set
@@ -77,7 +77,7 @@ class SonarrInterface(WebInterface):
 
         # Parse all Sonarr series
         self.__map_all_ids()
-
+        
 
     def __repr__(self) -> str:
         """Returns an unambiguous string representation of the object."""

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -16,7 +16,7 @@ class SonarrInterface(WebInterface):
     """
 
     """Regex to match Sonarr URL's"""
-    __SONARR_URL_REGEX = re_compile(r'^((?:https?:\/\/)?.+?)(?=\/)', IGNORECASE)
+    __SONARR_URL_REGEX = re_compile(r'^((?:https?:\/\/)?.+)(?=\/)', IGNORECASE)
 
     """Episode titles that indicate a placeholder and are to be ignored"""
     __TEMP_IGNORE_REGEX = re_compile(r'^(tba|tbd|episode \d+)$', IGNORECASE)
@@ -45,9 +45,11 @@ class SonarrInterface(WebInterface):
         # Get global MediaInfoSet object
         self.info_set = global_objects.info_set
 
-        # Correct URL to end in /api/v3/
+        # Get correct URL
         url = url if url.endswith('/') else f'{url}/'
-        if (re_match := self.__SONARR_URL_REGEX.match(url)) is None:
+        if url.endswith('/api/v3/'):
+            self.url = url
+        elif (re_match := self.__SONARR_URL_REGEX.match(url)) is None:
             log.critical(f'Invalid Sonarr URL "{url}"')
             exit(1)
         else:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -26,21 +26,22 @@ class SonarrInterface(WebInterface):
     __AIRDATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
-    def __init__(self, url: str, api_key: str) -> None:
+    def __init__(self, url: str, api_key: str, verify_ssl: bool=True) -> None:
         """
         Construct a new instance of an interface to Sonarr.
 
         Args:
-            url (str): The API url communicating with Sonarr.
-            api_key (str): The API key for API requests.
+            url: The API url communicating with Sonarr.
+            api_key: The API key for API requests.
+            verify_ssl: Whether to verify SSL requests to Sonarr.
 
         Raises:
             SystemExit: Invalid Sonarr URL/API key provided.
         """
 
         # Initialize parent WebInterface 
-        super().__init__()
-
+        super().__init__(verify_ssl)
+        
         # Get global MediaInfoSet object
         self.info_set = global_objects.info_set
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -261,7 +261,7 @@ class SonarrInterface(WebInterface):
 
                 # Skip temporary placeholder names if aired in the last 48 hours
                 if (self.__TEMP_IGNORE_REGEX.match(episode['title'])
-                    and air_datetime < datetime.now() + timedelta(days=2)):
+                    and air_datetime + timedelta(days=2) > datetime.now()):
                     log.debug(f'Temporarily ignoring "{episode["title"]}" of '
                               f'{series_info} - placeholder title')
                     continue

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -326,7 +326,11 @@ class TMDbInterface(WebInterface):
                     continue
 
                 # Create either a new EpisodeInfo or get from the MediaInfoSet
-                episode.reload()
+                try:
+                    episode.reload()
+                except NotFound:
+                    continue
+                
                 episode_info = self.info_set.get_episode_info(
                     series_info,
                     episode.name,

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -330,7 +330,7 @@ class TMDbInterface(WebInterface):
                     episode.reload()
                 except NotFound:
                     continue
-                
+
                 episode_info = self.info_set.get_episode_info(
                     series_info,
                     episode.name,

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -25,6 +25,9 @@ class WebInterface:
             verify_ssl: Whether to verify SSL requests with this Interface.
         """
 
+        # Store name of this interface
+        self.name = name
+
         # Create session for persistent requests
         self.session = Session()
 
@@ -32,7 +35,7 @@ class WebInterface:
         self.session.verify = verify_ssl
         if not self.session.verify:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            log.debug(f'Not verifying SSL connections')
+            log.debug(f'Not verifying SSL connections for {name}')
 
         # Cache of the last requests to speed up identical sequential requests
         self.__cache = []

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -15,12 +15,13 @@ class WebInterface:
     CACHE_LENGTH = 10
     
     
-    def __init__(self, verify_ssl: bool=True) -> None:
+    def __init__(self, name: str, verify_ssl: bool=True) -> None:
         """
         Construct a new instance of a WebInterface. This creates creates cached
         request and results lists, and establishes a session for future use.
 
         Args:
+            name: Name (for logging) of this Interface.
             verify_ssl: Whether to verify SSL requests with this Interface.
         """
 

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -86,12 +86,16 @@ class WebInterface:
 
 
     @staticmethod
-    def download_image(image_url: str, destination: 'Path') -> None:
+    def download_image(image_url: str, destination: 'Path') -> bool:
         """
         Download the provided image URL to the destination filepath.
         
-        :param      image_url:      The image url to download.
-        :param      destination:    The destination for the requested image.
+        Args:
+            image_url: URL to the image to download.
+            destination: Destination path to download the image to.
+
+        Returns:
+            Whether the image was successfully downloaded.
         """
 
         # Make parent folder structure
@@ -99,7 +103,11 @@ class WebInterface:
 
         # Attempt to download the image, if an error happens log to user
         try:
+            image = get(image_url).content
             with destination.open('wb') as file_handle:
-                file_handle.write(get(image_url).content)
+                file_handle.write(image)
+
+            return True
         except Exception as e:
             log.error(f'Cannot download image, error: "{e}"')
+            return False

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -1,5 +1,6 @@
 from requests import get
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_exponential
+import urllib3
 
 from modules.Debug import log
 
@@ -13,11 +14,16 @@ class WebInterface:
     CACHE_LENGTH = 10
     
     
-    def __init__(self) -> None:
+    def __init__(self, verify_ssl: bool=True) -> None:
         """
         Constructs a new instance of a WebInterface. This creates creates a 
         cached request and result, but no other attributes.
         """
+
+        # Whether to verify SSL
+        self.__verify_ssl = verify_ssl
+        if not verify_ssl:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         # Cache of the last requests to speed up identical sequential requests
         self.__cache = []
@@ -36,7 +42,10 @@ class WebInterface:
         :retuns:    Dict made from the JSON return of the specified GET request.
         """
 
-        return get(url=url, params=params).json()
+        if self.__verify_ssl:
+            return get(url=url, params=params).json()
+        
+        return get(url=url, params=params, verify=False).json()
 
 
     def _get(self, url: str, params: dict) -> dict:

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -1,4 +1,4 @@
-from requests import Session
+from requests import get, Session
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_exponential
 import urllib3
 
@@ -31,6 +31,7 @@ class WebInterface:
         self.session.verify = verify_ssl
         if not self.session.verify:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            log.debug(f'Not verifying SSL connections')
 
         # Cache of the last requests to speed up identical sequential requests
         self.__cache = []


### PR DESCRIPTION
# Major Changes
- Make `year` attribute _optional_ if a series is given as a _full name_
  - This means the bare minimum of a series changes like so:
     ```yaml
     series:
       # Old Style
       Breaking Bad:
         year: 2008
       # New style
       Breaking Bad (2008): {}
     ```
- Optionally parse exclusions from Sonarr/Plex YAML sync
  - Exclusions can be specified as series YAML file, tag (if syncing from Sonarr), and a specific series - for example:
     ```yaml
     sonarr:
      # ...
      sync:
        file: ./yaml/sonarr_sync.yaml
        exclusions:
        - yaml: ./yaml/other_series_yaml_file.yml
        - tag: sonarr-tag-to-exclude
        - series: Breaking Bad (2008)
        # ...
     ```
  - `yaml` takes a series YAML file to exclude all series of, this can be useful if you've got one file of customized shows to prevent duplicate specification, or just a longer file of exclusions; `tag` takes a Sonarr tag; and `series` take a series _full name_.
  - Rename `tag` attribute to `required_tags`
  - Closes #238
- Optionally add a template to all series during Sonarr/Plex YAML sync
  - A template name can be specified via `add_template` in the `sync` section, like so:
    ```yaml
    sonarr:
      # ...
      sync:
        file: ./yaml/sonarr_sync.yaml
        add_template: standard_template
        # ...
    ```
  - Will result in a sync like:
    ```yaml
    series:
      Series1 (Year): {library: ..., template: standard_template}
      Series2 (Year): {library: ..., template: standard_template}
    ```
  - Closes #239 
# Major Fixes 
- Handle invalid YAML when appending to a synced series YAML file
  - Duplicate keys (and other errors) are now errored and logged, instead of resulting in an exit
- Correctly skip placeholder titles like `TBA`, `TBD`, or `Episode {x}` (were only being skipped specific edge cases)
# Minor Changes
- Change default YAML sync to specify series name by _full name_ to omit `year: xxxx` specification
- - Use a persistent session for interfacing with Sonarr and Plex (minor performance improvement)
# Minor Fixes
- Catch errors on episode reload while sourcing episodes from TMDb
- Handle KeyError during series renaming when manually specifying `name` attribute
- Add ability to disable SSL verification for Sonarr or Plex
  - Enabled via `verify_ssl` option within Sonarr or Plex preferences, like so:
    ```yaml
    sonarr: # Same as Plex
      # ...
      verify_ssl: false # Defaults to true
    ```
  - Closes #241 
- Handle any format of Sonarr URL - for example `http://xx.xx.xx.xx:yyyy/etc/sonarr` style URL's used to silently fail
- Better handling of failed image downloading
   - Only write to file if download was successful (used to write 0-byte images even on failure)
   - Only log image download upon success