### PR TITLE
Make `anime` and `standard` title cards about 5x faster, replace `sync` sync mode with `match`, set up Tautulli integration automatically, other changes and fixes

### DIFF
--- a/fixer.py
+++ b/fixer.py
@@ -127,7 +127,7 @@ tmdb_group.add_argument(
     help='Add title translations from TMDb to the given datafile')
 
 # Parse given arguments
-args, unknown = parser.parse_known_args()
+args = parser.parse_args()
 
 # Parse preference file for options that might need it
 pp = PreferenceParser(args.preferences)

--- a/fixer.py
+++ b/fixer.py
@@ -234,11 +234,12 @@ if args.sonarr_list_ids and pp.use_sonarr:
 # Execute TMDB related options
 if hasattr(args, 'unblacklist'):
     TMDbInterface.unblacklist(
+        pp.database_directory,
         SeriesInfo(args.unblacklist[0], int(args.unblacklist[1]))
     )
 
 if hasattr(args, 'delete_blacklist') and args.delete_blacklist:
-    TMDbInterface.delete_blacklist()
+    TMDbInterface.delete_blacklist(pp.database_directory)
 
 if hasattr(args, 'tmdb_download_images') and pp.use_tmdb:
     for arg_set in args.tmdb_download_images:
@@ -250,8 +251,8 @@ if hasattr(args, 'tmdb_download_images') and pp.use_tmdb:
                       f'2-10 for episodes 2 through 10')
             continue
 
-        TMDbInterface.manually_download_season(
-            api_key=pp.tmdb_api_key,
+        tmdb_interface = TMDbInterface(pp.database_directory, pp.tmdb_api_key)
+        tmdb_interface.manually_download_season(
             title=arg_set[0],
             year=int(arg_set[1]),
             season_number=int(arg_set[2]),

--- a/main.py
+++ b/main.py
@@ -241,7 +241,7 @@ def read_update_list():
     args.tautulli_list.unlink(missing_ok=True)
 
     # Remake all indicated cards
-    Manager().remake_cards(update_list)
+    Manager(check_tautulli=False).remake_cards(update_list)
 
 # Run immediately if specified
 if args.run:

--- a/main.py
+++ b/main.py
@@ -142,6 +142,12 @@ log.handlers[0].setLevel(args.log)
 if args.no_color:
     apply_no_color_formatter(log)
 
+# Log parsed arguments
+log.debug('Runtime arguments:')
+max_width = max(map(len, vars(args).keys()))
+for arg, value in vars(args).items():
+    log.debug(f'{arg:>{max_width}} : {value}')
+
 # Check if preference file exists
 if not args.preferences.exists():
     log.critical(f'Preference file "{args.preferences.resolve()}" does not exist')

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ except ImportError as e:
     exit(1)
 
 # Version information
-CURRENT_VERSION = 'v1.11.0'
+CURRENT_VERSION = 'v1.11.1'
 REPO_URL = ('https://api.github.com/repos/'
             'CollinHeist/TitleCardMaker/releases/latest')
 

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -188,6 +188,12 @@ movie_poster_group.add_argument(
     metavar=('TITLE_LINE'),
     help='Movie title for the movie poster')
 movie_poster_group.add_argument(
+    '--movie-top-subtitle',
+    type=str,
+    default='',
+    metavar='TOP_SUBTITLE',
+    help='Top subtitle line for the movie poster')    
+movie_poster_group.add_argument(
     '--movie-subtitle',
     type=str,
     default='',
@@ -380,6 +386,7 @@ if hasattr(args, 'movie_poster'):
         output=args.movie_poster[1],
         title='\n'.join(args.movie_title),
         subtitle=args.movie_subtitle,
+        top_subtitle=args.movie_top_subtitle,
         font=args.movie_font,
         font_color=args.movie_font_color,
         font_size=float(args.movie_font_size[:-1])/100.0,

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -419,9 +419,13 @@ if hasattr(args, 'genre_card_batch'):
 if hasattr(args, 'show_summary'):
     # Temporary classes
     @dataclass
+    class EpisodeInfo:
+        season_number: int
+        episode_number: int
+    @dataclass
     class Episode:
+        episode_info: EpisodeInfo
         destination: Path
-
     @dataclass
     class Show:
         logo: Path
@@ -436,9 +440,11 @@ if hasattr(args, 'show_summary'):
         # Attempt to get index from filename, if not just increment last number
         if (groups := match(r'.*s(\d+).*e(\d+)', file.name, IGNORECASE)):
             season, episode = map(int, groups.groups())
-            episodes[f'{season}-{episode}'] = Episode(file)
+            info = EpisodeInfo(season, episode)
+            episodes[f'{season}-{episode}'] = Episode(info, file)
         else:
-            episodes[f'{season}-{episode}'] = Episode(file)
+            info = EpisodeInfo(season, episode)
+            episodes[f'{season}-{episode}'] = Episode(info, file)
             episode += 1
     
     # Create pseudo "show" of these episodes

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -367,15 +367,10 @@ class AnimeTitleCard(BaseCardType):
 
         command = ' '.join([
             f'convert "{self.source_file.resolve()}"',
-            f'+profile "*"',
+            # Resize and optionally blur source image
+            *self.resize_and_blur,
             # Increase contrast of source image
             f'-modulate 100,125',
-            # Resize to proper title card dimensions
-            f'-gravity center',
-            f'-resize "{self.TITLE_CARD_SIZE}^"',
-            f'-extent "{self.TITLE_CARD_SIZE}"',
-            # Optionally blur source image
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
             # Overlay gradient
             f'"{self.__GRADIENT_IMAGE.resolve()}"',
             f'-composite',

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from re import findall
 
 from modules.BaseCardType import BaseCardType
 from modules.Debug import log
@@ -350,7 +349,7 @@ class AnimeTitleCard(BaseCardType):
         defined title card.
         """
 
-        # If kanji is required (and not given), error
+        # If kanji is required, and not given, error
         if self.require_kanji and not self.use_kanji:
             log.error(f'Kanji is required and not provided - skipping card '
                       f'"{self.output_file.name}"')
@@ -361,6 +360,7 @@ class AnimeTitleCard(BaseCardType):
             f'+profile "*"',
             # Increase contrast of source image
             f'-modulate 100,125',
+            # Resize to proper title card dimensions
             f'-gravity center',
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -42,18 +42,20 @@ class AnimeTitleCard(BaseCardType):
     SERIES_COUNT_FONT = REF_DIRECTORY / 'Avenir.ttc'
     SERIES_COUNT_TEXT_COLOR = '#CFCFCF'
 
-    __slots__ = ('source_file', 'output_file', 'title', 'kanji', 'use_kanji',
-                 'require_kanji', 'season_text', 'episode_text', 'hide_season',
-                 'separator', 'blur', 'font', 'font_size', 'font_color',
-                 'vertical_shift', 'interline_spacing', 'kerning')
+    __slots__ = (
+        'source_file', 'output_file', 'title', 'kanji', 'use_kanji',
+        'require_kanji', 'kanji_vertical_shift', 'season_text', 'episode_text',
+        'hide_season', 'separator', 'blur', 'font', 'font_size', 'font_color',
+        'vertical_shift', 'interline_spacing', 'kerning'
+    )
 
     
     def __init__(self, source: Path, output_file: Path, title: str, 
                  season_text: str, episode_text: str, font: str,font_size:float,
                  title_color: str, hide_season: bool, vertical_shift: int=0,
                  interline_spacing: int=0, kerning: float=1.0, kanji: str=None,
-                 require_kanji: bool=False, separator: str='·',
-                 blur: bool=False, **kwargs)->None:
+                 require_kanji: bool=False, kanji_vertical_shift: float=0,
+                 separator: str='·', blur: bool=False, **kwargs)->None:
         """
         Construct a new instance.
         
@@ -64,8 +66,12 @@ class AnimeTitleCard(BaseCardType):
             season_text: The season text for this card.
             episode_text: The episode text for this card.
             hide_season: Whether to hide the season text on this card
+            vertical_shift: Vertical shift to apply to the title and kanji
+                text.
+            interline_spacing: Offset to interline spacing of the title text
             kanji: Kanji text to place above the episode title on this card.
             require_kanji: Whether to require kanji for this card.
+            kanji_vertical_shift: Vertical shift to apply to just kanji text.
             separator: Character to use to separate season and episode text.
             blur: Whether to blur the source image.
             font_size: Scalar to apply to the title font size.
@@ -87,6 +93,7 @@ class AnimeTitleCard(BaseCardType):
         self.kanji = self.image_magick.escape_chars(kanji)
         self.use_kanji = (kanji is not None)
         self.require_kanji = require_kanji
+        self.kanji_vertical_shift = kanji_vertical_shift
 
         # Store season and episode text
         self.season_text = self.image_magick.escape_chars(season_text.upper())
@@ -217,9 +224,10 @@ class AnimeTitleCard(BaseCardType):
 
         # If adding kanji, add additional annotate commands for kanji
         if self.use_kanji:
-            variable_offset = 200 + (165 * (len(self.title.split('\n'))-1))
+            linecount = len(self.title.split('\n')) - 1
+            variable_offset = 200 + ((165 + self.interline_spacing) * linecount)
             kanji_offset = base_offset + variable_offset * self.font_size
-            kanji_offset += self.vertical_shift
+            kanji_offset += self.vertical_shift + self.kanji_vertical_shift
             
             return [
                 *self.__title_text_global_effects,

--- a/modules/AnimeTitleCard.py
+++ b/modules/AnimeTitleCard.py
@@ -212,9 +212,11 @@ class AnimeTitleCard(BaseCardType):
             List of ImageMagick commands.
         """
 
+        # Base offset for the title text
+        base_offset = 175 + self.vertical_shift
+
         # If adding kanji, add additional annotate commands for kanji
         if self.use_kanji:
-            base_offset = 175
             variable_offset = 200 + (165 * (len(self.title.split('\n'))-1))
             kanji_offset = base_offset + variable_offset * self.font_size
             kanji_offset += self.vertical_shift
@@ -222,9 +224,9 @@ class AnimeTitleCard(BaseCardType):
             return [
                 *self.__title_text_global_effects,
                 *self.__title_text_black_stroke,
-                f'-annotate +75+175 "{self.title}"',
+                f'-annotate +75+{base_offset} "{self.title}"',
                 *self.__title_text_effects,
-                f'-annotate +75+175 "{self.title}"',
+                f'-annotate +75+{base_offset} "{self.title}"',
                 f'-font "{self.KANJI_FONT.resolve()}"',
                 *self.__title_text_black_stroke,
                 f'-pointsize {85 * self.font_size}',
@@ -237,9 +239,9 @@ class AnimeTitleCard(BaseCardType):
         return [
             *self.__title_text_global_effects,
             *self.__title_text_black_stroke,
-            f'-annotate +75+175 "{self.title}"',
+            f'-annotate +75+{base_offset} "{self.title}"',
             *self.__title_text_effects,
-            f'-annotate +75+175 "{self.title}"',
+            f'-annotate +75+{base_offset} "{self.title}"',
         ]
 
 

--- a/modules/BaseCardType.py
+++ b/modules/BaseCardType.py
@@ -120,6 +120,20 @@ class BaseCardType(ImageMaker):
         """
         raise NotImplementedError(f'All CardType objects must implement this')
 
+    
+    @property
+    def resize_and_blur(self) -> list[str]:
+        """ImageMagick commands to resize and blur an image."""
+
+        return [
+            f'-profile "*"',
+            f'-background transparent',
+            f'-gravity center',
+            f'-resize "{self.TITLE_CARD_SIZE}^"',
+            f'-extent "{self.TITLE_CARD_SIZE}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+        ]
+
 
     @abstractmethod
     def create(self) -> None:

--- a/modules/BaseSummary.py
+++ b/modules/BaseSummary.py
@@ -69,6 +69,9 @@ class BaseSummary(ImageMaker):
         Select the images that are to be incorporated into the show summary.
         This updates the object's inputs and number_rows attributes.
 
+        Args:
+            maximum_images: maximum number of images to select. Defaults to 9.
+
         Returns:
             Whether the ShowSummary should/can be created.
         """
@@ -78,6 +81,13 @@ class BaseSummary(ImageMaker):
             lambda e: self.show.episodes[e].destination.exists(),
             self.show.episodes
         ))
+
+        # Filter specials if indicated
+        if self.preferences.summary_ignore_specials:
+            available_episodes = list(filter(
+                lambda e: self.show.episodes[e].episode_info.season_number != 0,
+                self.show.episodes
+            ))
 
         # Warn if this show has no episodes to work with
         if (episode_count := len(available_episodes)) == 0:
@@ -99,9 +109,7 @@ class BaseSummary(ImageMaker):
 
         # Get the full filepath for each of the selected images
         get_destination = lambda e_key: self.show.episodes[e_key].destination
-        self.inputs = [
-            str(get_destination(e).resolve()) for e in episode_keys
-        ]
+        self.inputs = [str(get_destination(e).resolve()) for e in episode_keys]
 
         # The number of rows is necessary to determine how to scale y-values
         self.number_rows = ceil(len(episode_keys) / 3)
@@ -133,7 +141,7 @@ class BaseSummary(ImageMaker):
             f'\( "{self.__TCM_LOGO.resolve()}"',
             f'-resize x100 \)',
             f'-fill "#5493D7"',
-            f'label:TitleCardMaker',
+            f'label:"TitleCardMaker"',
             f'+smush 30',
             f'"{self.__CREATED_BY_TEMPORARY_PATH.resolve()}"'
         ])

--- a/modules/DataFileInterface.py
+++ b/modules/DataFileInterface.py
@@ -214,12 +214,10 @@ class DataFileInterface:
                 yaml[season_key][episode_info.episode_number]['abs_number'] =\
                     episode_info.abs_number
 
-        # If nothing was added, exit
+        # If nothing was added, exit - otherwise log to user
         if (count := added['count']) == 0:
             return None
-        
-        # Log add operations to user
-        if count > 1:
+        elif count > 1:
             log.info(f'Added {count} episodes to "{self.file.parent.name}"')
         else:
             log.info(f'Added {added["info"]} to "{self.file.parent.name}"')

--- a/modules/Episode.py
+++ b/modules/Episode.py
@@ -51,7 +51,7 @@ class Episode:
         self.extra_characteristics = extras
 
         # Episodes are watched, not blurred, and spoiled - until updated
-        self.watched = True
+        self.watched = False
         self.blur = False
         self.spoil_type = 'spoiled'
 

--- a/modules/EpisodeInfo.py
+++ b/modules/EpisodeInfo.py
@@ -152,6 +152,13 @@ class EpisodeInfo:
         }
 
 
+    @property
+    def index(self) -> str:
+        """This object's index - i.e. s{season}e{episode}"""
+
+        return f's{self.season_number}e{self.episode_number}'
+
+
     def set_tvdb_id(self, tvdb_id: int) -> None:
         """
         Sets the TVDb ID for this object.

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -56,6 +56,7 @@ class EpisodeMap:
             return None
 
         # If both mappings are provided, invalidate 
+        seasons.pop('hide', None)
         if seasons and episode_ranges:
             log.error(f'Cannot specify both seasons and episode ranges')
             self.valid = False
@@ -65,8 +66,8 @@ class EpisodeMap:
         if seasons and len(seasons) > 0:
             self.__index_by = 'season'
             self.__parse_seasons(seasons)
-        elif (episode_ranges and len(episode_ranges) > 0
-            and 's' in list(episode_ranges)[0]):
+        if (episode_ranges and len(episode_ranges) > 0
+            and list(episode_ranges.keys())[0][0] == 's'):
             self.__index_by = 'index'
             self.__parse_index_episode_range(episode_ranges)
         elif episode_ranges and len(episode_ranges) > 0:
@@ -186,9 +187,10 @@ class EpisodeMap:
         for episode_range, mapping in episode_ranges.items():
             try:
                 start, end = map(int, episode_range.split('-'))
-            except Exception:
+            except Exception as e:
                 self.valid = False
                 log.error(f'Invalid episode range "{episode_range}"')
+                log.debug(e)
                 continue
             
             # Assign attributes for every episode in this range

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -55,8 +55,11 @@ class EpisodeMap:
             self.valid = False
             return None
 
+        # Remove hide key from seasons if indicated
+        if isinstance(seasons, dict):
+            seasons.pop('hide', None)
+
         # If both mappings are provided, invalidate 
-        seasons.pop('hide', None)
         if seasons and episode_ranges:
             log.error(f'Cannot specify both seasons and episode ranges')
             self.valid = False

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -1,3 +1,5 @@
+from re import compile as re_compile, IGNORECASE
+
 from modules.Debug import log
 
 class EpisodeMap:
@@ -10,6 +12,9 @@ class EpisodeMap:
     
     """How to apply manual source if not explicitly stated"""
     DEFAULT_APPLIES_TO = 'all'
+
+    """Regex to match season/episode number from index range text"""
+    INDEX_RANGE_REGEX = re_compile('s(\d+)e(\d+)', IGNORECASE)
 
     __slots__ = ('valid', 'is_custom', '__index_by', '__titles', '__sources',
                  '__applies')
@@ -57,12 +62,16 @@ class EpisodeMap:
             return None
         
         # Specify how to index this Episode Map, parse that YAML
-        if seasons:
+        if seasons and len(seasons) > 0:
             self.__index_by = 'season'
             self.__parse_seasons(seasons)
-        elif episode_ranges:
+        elif (episode_ranges and len(episode_ranges) > 0
+            and 's' in list(episode_ranges)[0]):
+            self.__index_by = 'index'
+            self.__parse_index_episode_range(episode_ranges)
+        elif episode_ranges and len(episode_ranges) > 0:
             self.__index_by = 'episode'
-            self.__parse_episode_ranges(episode_ranges)
+            self.__parse_absolute_episode_ranges(episode_ranges)
 
 
     def __repr__(self) -> str:
@@ -96,7 +105,7 @@ class EpisodeMap:
             if not isinstance(season_number, int):
                 log.warning(f'Invalid season number "{season_number}"')
                 self.valid = False
-                return None
+                continue
             
             # Parse title/source mapping
             if isinstance(mapping, dict):
@@ -111,14 +120,60 @@ class EpisodeMap:
                         log.error(f'Source applies to "{value}" of season '
                                   f'{season_number} is invalid')
                         self.valid = False
-                        return None
+                        continue
                     self.__applies[season_number] = value
             else:
                 self.__titles[season_number] = str(mapping)
                 self.is_custom = True
+
+
+    def __parse_index_episode_range(self, episode_ranges: dict) -> None:
+        """
+        Parse the given episode range map, filling this object's title, source,
+        and applies dictionaries. Also update's object validity.
+
+        Args:
+            episode_ranges: 'episode_ranges' key from series YAML to parse.
+        """
+
+        # Go through each index range of mapping
+        for episode_range, mapping in episode_ranges.items():
+            try:
+                start, end = episode_range.split('-')
+                start_season, start_episode =\
+                    map(int, self.INDEX_RANGE_REGEX.match(start).groups())
+                end_season, end_episode =\
+                    map(int, self.INDEX_RANGE_REGEX.match(end).groups())
+                assert start_season == end_season, 'Cannot span multiple seasons'
+            except Exception as e:
+                self.valid = False
+                log.error(f'Invalid episode range "{episode_range}"')
+                log.debug(e)
+                continue
+
+            # Assign attributes for each index in this range
+            for episode_number in range(start_episode, end_episode+1):
+                key = f's{start_season}e{episode_number}'
+                if isinstance(mapping, str):
+                    self.__titles[key] = mapping
+                    self.is_custom = True
+                elif isinstance(mapping, dict):
+                    if (value := mapping.get('title')):
+                        self.__titles[key] = value
+                        self.is_custom = True
+                    if (value := mapping.get('source')):
+                        self.__sources[key] = value
+                    if (value := mapping.get('source_applies_to', '').lower()):
+                        if value not in ('all', 'unwatched'):
+                            # Invalid applies, error and exit
+                            log.error(f'Source applies to "{value}" of episodes '
+                                        f'{episode_range} is invalid')
+                            self.valid = False
+                            continue
+                        self.__applies[key] = value
         
         
-    def __parse_episode_ranges(self, episode_ranges: dict) -> None:
+    def __parse_absolute_episode_ranges(self, episode_ranges: dict) -> None:
         """
         Parse the given episode range map, filling this object's title, source,
         and applies dictionaries. Also update's object validity.
@@ -134,9 +189,9 @@ class EpisodeMap:
             except Exception:
                 self.valid = False
                 log.error(f'Invalid episode range "{episode_range}"')
-                return None
+                continue
             
-            # Assign title for every episode in this range
+            # Assign attributes for every episode in this range
             for episode_number in range(start, end+1):
                 if isinstance(mapping, str):
                     self.__titles[episode_number] = mapping
@@ -153,7 +208,7 @@ class EpisodeMap:
                             log.error(f'Source applies to "{value}" of episodes '
                                       f'{episode_range} is invalid')
                             self.valid = False
-                            return None
+                            continue
                         self.__applies[episode_number] = value
     
     
@@ -220,32 +275,34 @@ class EpisodeMap:
         """
 
         # Get target to look through
-        if which == 'season_title':
-            target = self.__titles
-        elif which == 'source':
-            target = self.__sources
-        else:
-            target = self.__applies
-
+        target = {'season_title':   self.__titles,
+                  'source':         self.__sources,
+                  'applies_to':     self.__applies}[which]
+        
         # Index by season
         if self.__index_by == 'season':
             if episode_info.season_number in target:
                 return target[episode_info.season_number]
 
             return default(episode_info=episode_info)
-        
+        # Index by index
+        elif self.__index_by == 'index':
+            if episode_info.index in target:
+                return target[episode_info.index]
+
+            return default(episode_info=episode_info)
         # Index by absolute episode number
-        index_number = episode_info.abs_number
-        if index_number is None:
-            # No absolute number, use episode number instead
-            index_number = episode_info.episode_number
+        else:
+            # If there's no absolute number, use episode number instead
+            if (index_number := episode_info.abs_number) is None:
+                index_number = episode_info.episode_number
 
-        # Return custom from target
-        if index_number in target:
-            return target[index_number]
+            # Return custom from target
+            if index_number in target:
+                return target[index_number]
 
-        # Use default if index doesn't fall into specified target
-        return default(episode_info=episode_info)
+            # Use default if index doesn't fall into specified target
+            return default(episode_info=episode_info)
     
     
     def get_season_title(self, episode_info: 'EpisodeInfo') -> str:
@@ -258,10 +315,12 @@ class EpisodeMap:
         Returns:
             Season title defined by this map for this Episode.
         """
-
+        
+        # Get season title for this episode
         season_title = self.__get_value(episode_info, 'season_title',
                                         self.get_generic_season_title)
 
+        # Warn if default value was returned and indexing by absolute number
         if self.__index_by == 'episode':
             if (episode_info.abs_number is None
                 and episode_info.season_number != 0):
@@ -270,6 +329,10 @@ class EpisodeMap:
             elif episode_info.abs_number not in self.__titles:
                 log.warning(f'{episode_info} does not fall into given episode '
                             f'ranges')
+        # Warn if default was returned and indexing by index
+        elif (self.__index_by == 'index'
+            and episode_info.index not in self.__titles):
+            log.warning(f'{episode_info} does not fall into given episode ranges')
 
         return season_title
 

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -213,9 +213,14 @@ class EpisodeMap:
     
     
     def reset(self) -> None:
-        # Reset all mappings
-        self.__index_by = 'season'
-        self.__titles, self.__sources, self.__applies = {}, {}, {}
+        """Reset this object go have generic titles."""
+
+        # Always reset titles/applies - never reset sources
+        self.__titles, self.__applies = {}, {}
+
+        # If no manual sources have been specified, reset index by flag
+        if len(self.__sources) == 0:
+            self.__index_by = 'season'
 
     
     def get_generic_season_title(self, *, season_number: int=None,

--- a/modules/EpisodeMap.py
+++ b/modules/EpisodeMap.py
@@ -268,8 +268,8 @@ class EpisodeMap:
                 log.warning(f'Episode range specified, but {episode_info} has '
                             f'no absolute episode number')
             elif episode_info.abs_number not in self.__titles:
-                log.warning(f'{episode_info} does not fall into specified '
-                            f'episode range')
+                log.warning(f'{episode_info} does not fall into given episode '
+                            f'ranges')
 
         return season_title
 

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -124,16 +124,12 @@ class ImageMagickInterface:
             log.error(f'ImageMagick command timed out')
             log.debug(command)
         except FileNotFoundError as e:
-            if 'docker' in str(e):
-                log.critical(f'ImageMagick docker container not found')
-                exit(1)
-            else:
-                log.error(f'Command error "{e}"')
-                return b'', b''
-        else:
-            # Add command to history and return results
-            self.__history.append((command, stdout, stderr))
-            return stdout, stderr
+            log.error(f'Command error "{e}"')
+            log.debug(command)
+            
+        # Add command to history and return results
+        self.__history.append((command, stdout, stderr))
+        return stdout, stderr
 
 
     def run_get_output(self, command: str) -> str:

--- a/modules/ImageMagickInterface.py
+++ b/modules/ImageMagickInterface.py
@@ -117,8 +117,8 @@ class ImageMagickInterface:
 
         # Execute, capturing stdout and stderr
         stdout, stderr = b'', b''
-        process = Popen(cmd, stdout=PIPE, stderr=PIPE)
         try:
+            process = Popen(cmd, stdout=PIPE, stderr=PIPE)
             stdout, stderr = process.communicate(timeout=self.timeout)
         except TimeoutExpired:
             log.error(f'ImageMagick command timed out')

--- a/modules/LandscapeTitleCard.py
+++ b/modules/LandscapeTitleCard.py
@@ -151,13 +151,16 @@ class LandscapeTitleCard(BaseCardType):
  
         # Generate command to create card
         command = ' '.join([
-            f'convert "{self.source.resolve()}"',       # Resize source
+            f'convert "{self.source.resolve()}"',
             f'+profile "*"',
             f'-gravity center',
+            # Resize source image
             f'-resize "{self.TITLE_CARD_SIZE}^"',
             f'-extent "{self.TITLE_CARD_SIZE}"',
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '', # Optional blur
-            f'\( -background None',                     # Add title
+            # Optionally blur
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            # Add title text
+            f'\( -background None',
             f'-font "{self.font}"',
             f'-pointsize {font_size}',
             f'-gravity center',
@@ -166,14 +169,17 @@ class LandscapeTitleCard(BaseCardType):
             f'-interword-spacing 40',
             f'-fill "{self.title_color}"',
             f'label:"{self.title}"',
-            f'\( +clone',                               # Add drop shadow
+            # Create drop shadow of title text
+            f'\( +clone',
             f'-background None',
             f'-shadow 80x3+10+10 \)',
-            f'+swap',                                   # Underlay drop shadow
+            # Underlay drop shadow 
+            f'+swap',
             f'-background None',
             f'-layers merge',
             f'+repage \)',
-            f'-composite',                              # Add text to source
+            # Add title image(s) to source
+            f'-composite',
             f'"{self.output_file.resolve()}"',
         ])
         

--- a/modules/LandscapeTitleCard.py
+++ b/modules/LandscapeTitleCard.py
@@ -233,13 +233,8 @@ class LandscapeTitleCard(BaseCardType):
         # Generate command to create card
         command = ' '.join([
             f'convert "{self.source.resolve()}"',
-            f'+profile "*"',
-            f'-gravity center',
-            # Resize source image
-            f'-resize "{self.TITLE_CARD_SIZE}^"',
-            f'-extent "{self.TITLE_CARD_SIZE}"',
-            # Optionally blur
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            # Resize and optionally blur source image
+            *self.resize_and_blur,
             # Add title text
             f'\( -background None',
             f'-font "{self.font}"',

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -7,6 +7,7 @@ import modules.global_objects as global_objects
 from modules.Show import Show
 from modules.ShowArchive import ShowArchive
 from modules.SonarrInterface import SonarrInterface
+from modules.TautulliInterface import TautulliInterface
 from modules.TMDbInterface import TMDbInterface
 
 class Manager:
@@ -33,6 +34,12 @@ class Manager:
         # Get the global preferences
         self.preferences = global_objects.pp
 
+        # Optionally integrate with Tautulli
+        if self.preferences.use_tautulli:
+            TautulliInterface(
+                **self.preferences.tautulli_interface_args
+            ).integrate()
+            
         # Optionally assign PlexInterface
         self.plex_interface = None
         if self.preferences.use_plex:

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -24,18 +24,22 @@ class Manager:
     VALID_EXECUTION_MODES = ('serial', 'batch')
 
 
-    def __init__(self) -> None:
+    def __init__(self, check_tautulli: bool=True) -> None:
         """
         Constructs a new instance of the Manager. This uses the global
         PreferenceParser object in preferences, and optionally creates
         interfaces as indicated by that parser.
+
+        Args:
+            check_tautulli: Whether to check Tautulli integration (for fast
+                start).
         """
 
         # Get the global preferences
         self.preferences = global_objects.pp
 
         # Optionally integrate with Tautulli
-        if self.preferences.use_tautulli:
+        if check_tautulli and self.preferences.use_tautulli:
             TautulliInterface(
                 **self.preferences.tautulli_interface_args
             ).integrate()
@@ -426,10 +430,11 @@ class Manager:
         # Get details for each rating key from Plex
         entry_list = []
         for key in rating_keys:
-            if (details := self.plex_interface.get_episode_details(key)) is None:
-                log.error(f'Cannot remake card, episode not found')
+            if len(details := self.plex_interface.get_episode_details(key)) ==0:
+                log.error(f'Cannot remake cards, no episodes found')
             else:
-                entry_list.append(details)
+                log.debug(f'{len(details)} items associated with rating key {key}')
+                entry_list += details
 
         # Go through every series in all series YAML files
         found = set()

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -452,6 +452,7 @@ class Manager:
                     and full_match_name == series_info.full_match_name):
                     self.shows = [show]
                     self.__run(serial=True)
+                    found.add(index)
 
         # Warn for all entries not found
         for index, (series_info, episode_info, library_name) \

--- a/modules/OlivierTitleCard.py
+++ b/modules/OlivierTitleCard.py
@@ -215,7 +215,7 @@ class OlivierTitleCard(BaseCardType):
             offset = text_offset[self.episode_prefix]
         else:
             offset_per_char = text_offset['EPISODE'] / len('EPISODE')
-            offset = offset_per_char * len(self.episode_prefix)
+            offset = offset_per_char * len(self.episode_prefix) * 1.10
 
         return [
             f'-gravity west',

--- a/modules/OlivierTitleCard.py
+++ b/modules/OlivierTitleCard.py
@@ -128,11 +128,7 @@ class OlivierTitleCard(BaseCardType):
 
         command = ' '.join([
             f'convert "{source.resolve()}"',
-            f'+profile "*"',
-            f'-gravity center',
-            f'-resize "{self.TITLE_CARD_SIZE}^"',
-            f'-extent "{self.TITLE_CARD_SIZE}"',
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            *self.resize_and_blur,
             f'"{self.__RESIZED_SOURCE.resolve()}"',
         ])
 

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -340,6 +340,11 @@ class PlexInterface:
                 if show.year is None:
                     log.warning(f'Series {show.title} has no year - skipping')
                     continue
+                    
+                # Skip show if has no locations.. somehow..
+                if len(show.locations) == 0:
+                    log.warning(f'Series {show.title} has no files - skipping')
+                    continue
 
                 # Get all ID's for this series
                 ids = {}
@@ -350,11 +355,7 @@ class PlexInterface:
                             break
 
                 # Create SeriesInfo object for this show
-                series_info = SeriesInfo(
-                    show.title,
-                    show.year,
-                    **ids,
-                )
+                series_info = SeriesInfo(show.title, show.year, **ids)
 
                 # Add to returned list
                 all_series.append((series_info,show.locations[0],library.title))

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -25,6 +25,9 @@ class PlexInterface:
     """How many failed episodes result in skipping a series"""
     SKIP_SERIES_THRESHOLD = 3
 
+    """Default filesize limit for all uploaded assets"""
+    DEFAULT_FILESIZE_LIMIT = '10 MB'
+
 
     def __init__(self, database_directory: Path, url: str,
                  x_plex_token: str=None, verify_ssl: bool=True) -> None:

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -275,7 +275,8 @@ class PlexInterface:
 
 
     @catch_and_log('Error getting library paths', default={})
-    def get_library_paths(self, filter_libraries: list[str]=[]) ->dict[str:str]:
+    def get_library_paths(self, filter_libraries: list[str]=[]
+                          ) -> dict[str: list[str]]:
         """
         Get all libraries and their associated base directories.
 
@@ -284,8 +285,7 @@ class PlexInterface:
 
         Returns:
             Dictionary whose keys are the library names, and whose values are
-            the paths to that library's base directory. If the library has
-            multiple directories, the first one is returned.
+            the list of paths to that library's base directories.
         """
 
         # Go through every library in this server
@@ -300,8 +300,8 @@ class PlexInterface:
                 and library.title not in filter_libraries):
                 continue
 
-            # Add library's corresponding (first) path to the dictionary
-            all_libraries[library.title] = library.locations[0]
+            # Add library's paths to the dictionary under the library name
+            all_libraries[library.title] = library.locations
 
         return all_libraries
     
@@ -555,7 +555,7 @@ class PlexInterface:
                 continue
 
 
-    @catch_and_log('Error getting source image', default=None)
+    @catch_and_log('Error getting source image')
     def get_source_image(self, library_name: str, series_info: 'SeriesInfo',
                          episode_info: EpisodeInfo) -> str:
         """
@@ -795,7 +795,7 @@ class PlexInterface:
             log.info(f'Loaded {loaded_count} season posters for "{series_info}"')
 
 
-    @catch_and_log('Error getting episode details', default=None)
+    @catch_and_log('Error getting episode details')
     def get_episode_details(self, rating_key: int) -> tuple[SeriesInfo,
                                                             EpisodeInfo, str]:
         """

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -340,7 +340,7 @@ class PlexInterface:
                 if show.year is None:
                     log.warning(f'Series {show.title} has no year - skipping')
                     continue
-                    
+
                 # Skip show if has no locations.. somehow..
                 if len(show.locations) == 0:
                     log.warning(f'Series {show.title} has no files - skipping')
@@ -395,7 +395,7 @@ class PlexInterface:
                 log.warning(f'Episode {plex_episode} of {series_info} in '
                             f'"{library_name}" has no index - skipping')
                 continue
-            
+
             # Get all ID's for this episode
             ids = {}
             for guid in plex_episode.guids:

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -389,6 +389,13 @@ class PlexInterface:
         # Create list of all episodes in Plex
         all_episodes = []
         for plex_episode in series.episodes():
+            # Skip if episode has no season or episode number
+            if (plex_episode.parentIndex is None
+                or plex_episode.index is None):
+                log.warning(f'Episode {plex_episode} of {series_info} in '
+                            f'"{library_name}" has no index - skipping')
+                continue
+            
             # Get all ID's for this episode
             ids = {}
             for guid in plex_episode.guids:

--- a/modules/PosterTitleCard.py
+++ b/modules/PosterTitleCard.py
@@ -166,9 +166,8 @@ class PosterTitleCard(BaseCardType):
         command = ' '.join([
             f'convert',
             f'"{self.source_file.resolve()}"',          # Resize source image
-            f'-resize "x1800"',
-            f'-extent "3200x1800"',
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            # Resize and optionally blur source image
+            *self.resize_and_blur,
             f'"{self.__GRADIENT_OVERLAY.resolve()}"',   # Add gradient overlay
             f'-flatten',                                # Combine images
             *logo_command,                              # Optionally add logo

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -184,19 +184,24 @@ class PreferenceParser(YamlReader):
                 log.error(f'Cannot sync to "{file.resolve()}" - invalid sync')
                 return None
 
-            # Parse update args
+            # Parse args applicable to Plex and Sonarr
             update_args = {}
-            if (value := sync_yaml._get('libraries', type_=list)) is not None:
-                update_args['filter_libraries'] = value
             if (value := sync_yaml._get('exclusions', type_=list)) is not None:
                 update_args['exclusions'] = value
-            if (value := sync_yaml._get('plex_libraries', type_=dict)) != None:
-                update_args['plex_libraries'] = value
-            if (value := sync_yaml._get('required_tags', type_=list)) != None:
-                update_args['required_tags'] = value
-            if (value := sync_yaml._get('monitored_only', 
-                                        type_=bool)) is not None:
-                update_args['monitored_only'] = value
+
+            # Parse args applicable only to Plex or Sonarr
+            if sync_type == 'plex':
+                if (value := sync_yaml._get('libraries', type_=list)) != None:
+                    update_args['filter_libraries'] = value
+            elif sync_type == 'sonarr':
+                if (value := sync_yaml._get('plex_libraries', type_=dict)) != None:
+                    update_args['plex_libraries'] = value
+                if (value := sync_yaml._get('required_tags', type_=list)) != None:
+                    update_args['required_tags'] = value
+                if (value := sync_yaml._get('monitored_only', type_=bool)) != None:
+                    update_args['monitored_only'] = value
+                if (value := sync_yaml._get('downloaded_only', type_=bool)) != None:
+                    update_args['downloaded_only'] = value
 
             # Skip if YAML was invalidated at any point
             if not sync_yaml.valid:
@@ -216,7 +221,7 @@ class PreferenceParser(YamlReader):
             # Singular sync specification
             if isinstance(plex_sync, dict):
                 append_writer_and_args('plex', plex_sync, {})
-            # List of syncs, no globals
+            # List of syncs
             elif isinstance(plex_sync, list) and len(plex_sync) > 0:
                 base_sync = plex_sync[0]
                 for sync in plex_sync:
@@ -229,7 +234,7 @@ class PreferenceParser(YamlReader):
             # Singular sync specification
             if isinstance(sonarr_sync, dict):
                 append_writer_and_args('sonarr', sonarr_sync, {})
-            # List of syncs, no globals
+            # List of syncs
             elif isinstance(sonarr_sync, list) and len(sonarr_sync) > 0:
                 base_sync = sonarr_sync[0]
                 for sync in sonarr_sync:

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -719,7 +719,7 @@ class PreferenceParser(YamlReader):
                 if show_yaml is None:
                     log.error(f'Skipping "{show_name}" from "{file_}"')
                     continue
-
+                
                 yield Show(show_name, show_yaml, self.source_directory, self)
 
                 # If archiving is disabled, skip

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -736,7 +736,8 @@ class PreferenceParser(YamlReader):
                     # Skip if finalization failed
                     if variation is None:
                         log.error(f'Skipping archive variation of "{show_name}"'
-                                  f'from "{file_}"')
+                                  f' from "{file_}"')
+                        continue
 
                     # Get priority union of variation and base series
                     Template.recurse_priority_union(variation, show_yaml)

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -83,6 +83,7 @@ class PreferenceParser(YamlReader):
         self.summary_background = self.summary_class.BACKGROUND_COLOR
         self.summary_minimum_episode_count = 3
         self.summary_created_by = None
+        self.summary_ignore_specials = False
         self.use_plex = False
         self.plex_url = None
         self.plex_token = 'NA'
@@ -309,7 +310,7 @@ class PreferenceParser(YamlReader):
         if (value := self._get('options', 'sync_specials', type_=bool)) != None:
             self.sync_specials = value
 
-        if (value := self._get('archive', 'path', type_=Path)) != None:
+        if (value := self._get('archive', 'path', type_=Path)) is not None:
             self.archive_directory = value
             self.create_archive = True
 
@@ -317,7 +318,7 @@ class PreferenceParser(YamlReader):
             self.archive_all_variations = value
 
         if (value := self._get('archive', 'summary', 'create',
-                               type_=bool)) != None:
+                               type_=bool)) is not None:
             self.create_summaries = value
 
         if (value := self._get('archive', 'summary', 'type',
@@ -338,18 +339,22 @@ class PreferenceParser(YamlReader):
             self.summary_created_by = value
 
         if (value := self._get('archive', 'summary', 'background',
-                               type_=str)) != None:
+                               type_=str)) is not None:
             self.summary_background = value
 
-        if ((value := self._get('archive', 'summary', 'minimum_episodes',
-                               type_=int)) != None):
+        if (value := self._get('archive', 'summary', 'minimum_episodes',
+                               type_=int)) is not None:
             self.summary_minimum_episode_count = value
 
-        if (value := self._get('plex', 'url', type_=str)) != None:
+        if (value := self._get('archive', 'summary', 'ignore_specials',
+                               type_=bool)) is not None:
+            self.summary_ignore_specials = value
+
+        if (value := self._get('plex', 'url', type_=str)) is not None:
             self.plex_url = value
             self.use_plex = True
 
-        if (value := self._get('plex', 'token', type_=str)) != None:
+        if (value := self._get('plex', 'token', type_=str)) is not None:
             self.plex_token = value
 
         if (value := self._get('plex', 'verify_ssl', type_=bool)) is not None:
@@ -364,7 +369,7 @@ class PreferenceParser(YamlReader):
                 self.global_watched_style = value
 
         if (value := self._get('plex', 'unwatched_style',
-                               type_=lower_str)) != None:
+                               type_=lower_str)) is not None:
             if value not in Show.VALID_STYLES:
                 opt = '", "'.join(Show.VALID_STYLES)
                 log.critical(f'Invalid unwatched style, must be one of "{opt}"')
@@ -397,11 +402,11 @@ class PreferenceParser(YamlReader):
         if (value := self._get('sonarr', 'verify_ssl', type_=bool)) is not None:
             self.sonarr_verify_ssl = value
         
-        if (value := self._get('tmdb', 'api_key', type_=str)) != None:
+        if (value := self._get('tmdb', 'api_key', type_=str)) is not None:
             self.tmdb_api_key = value
             self.use_tmdb = True
 
-        if (value := self._get('tmdb', 'retry_count', type_=int)) != None:
+        if (value := self._get('tmdb', 'retry_count', type_=int)) is not None:
             self.tmdb_retry_count = value
 
         if (value := self._get('tmdb', 'minimum_resolution', type_=str)) !=None:
@@ -432,11 +437,6 @@ class PreferenceParser(YamlReader):
         if self._is_specified('options', 'hide_season_folders'):
             log.critical(f'Options "hide_season_folders" setting has been '
                          f'incorporated into "season_folder_format"')
-            self.valid = False
-
-        if self._is_specified('archive', 'summary', 'background_color'):
-            log.critical(f'Archive summary "background_color" option has been '
-                         f'renamed to "background"')
             self.valid = False
 
         if self._is_specified('sonarr', 'sync', 'tags'):

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -84,7 +84,7 @@ class Profile:
                 seasons = 'hidden'
             elif has_custom_season_titles:
                 seasons = 'custom'
-
+                
             return [{
                 'seasons': seasons,
                 'font': 'custom' if has_custom_font else 'generic'
@@ -120,7 +120,7 @@ class Profile:
         """
 
         # Update this object's data
-        self.__use_custom_seasons = (seasons == 'custom')
+        self.__use_custom_seasons = (seasons in ('custom', 'hidden'))
         self.hide_season_title = (seasons == 'hidden')
         self.__use_custom_font = (font == 'custom')
 

--- a/modules/RomanNumeralTitleCard.py
+++ b/modules/RomanNumeralTitleCard.py
@@ -193,22 +193,22 @@ class RomanNumeralTitleCard(BaseCardType):
         """
 
         # Scale font size and interline spacing of roman text
-        font_size = int(1250 * self.__roman_text_scalar)
-        interline_spacing = int(-400 * self.__roman_text_scalar) # -700
+        font_size = 1250 * self.__roman_text_scalar
+        interline_spacing = -400 * self.__roman_text_scalar
         
         # Generate command to create card
         command = ' '.join([
             f'convert',
             f'-size "{self.TITLE_CARD_SIZE}"',
-            f'xc:"{self.background}"',
-            f'-font "{self.ROMAN_NUMERAL_FONT.resolve()}"',
+            f'xc:"{self.background}"',                      # Create background
+            f'-font "{self.ROMAN_NUMERAL_FONT.resolve()}"', # Add roman numerals
             f'-fill "{self.roman_numeral_color}"',
             f'-pointsize {font_size}',
             f'-gravity center',
             f'-interline-spacing {interline_spacing}',
-            f'-annotate +0+0 "{self.roman_numeral}"',     # +0-175
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
-            f'-font "{self.TITLE_FONT}"',
+            f'-annotate +0+0 "{self.roman_numeral}"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',  # Optional blur
+            f'-font "{self.TITLE_FONT}"',                   # Add title
             f'-pointsize 150',
             f'-interword-spacing 40',
             f'-interline-spacing 0',

--- a/modules/SeriesInfo.py
+++ b/modules/SeriesInfo.py
@@ -3,6 +3,7 @@ from re import match, compile as re_compile
 from typing import ClassVar
 
 from modules.Debug import log
+from modules.TitleCard import TitleCard
 
 @dataclass(eq=False, order=False)
 class SeriesInfo:
@@ -90,8 +91,7 @@ class SeriesInfo:
         self.full_match_name = self.get_matching_title(self.full_name)
 
         # Set folder-safe name
-        translation = str.maketrans(self.__ILLEGAL_CHARACTERS)
-        self.legal_path = self.full_name.translate(translation)
+        self.legal_path = TitleCard.sanitize_name(self.full_name)
 
 
     def has_id(self, id_: str) -> bool:

--- a/modules/SeriesYamlWriter.py
+++ b/modules/SeriesYamlWriter.py
@@ -12,11 +12,6 @@ class SeriesYamlWriter:
     formatted series YAML files by syncing with Sonarr or Plex.
     """
 
-    """Default arguments for initializing an object"""
-    DEFAULT_ARGUMENTS = {
-        'sync_mode': 'append', 'compact_mode': True, 'volume_map': {}
-    }
-
     """Keyword arguments for yaml.dump()"""
     __WRITE_OPTIONS = {'allow_unicode': True, 'width': 200}
 
@@ -33,7 +28,7 @@ class SeriesYamlWriter:
                 'append' or 'match'.
             compact_mode: Whether to write this YAML in compact mode or not.
             volume_map: Mapping of interface paths to corresponding TCM paths.
-            template: Template to add to all synced series.
+            template: Template name to add to all synced series.
         """
 
         # Start as valid, Store base attributes
@@ -64,8 +59,6 @@ class SeriesYamlWriter:
         # Add representer for compact YAML writing
         # Pseudo-class for a flow map - i.e. dictionary
         class flowmap(dict): pass
-
-        # Representor using flow style
         def flowmap_rep(dumper, data):
             return dumper.represent_mapping(
                 u'tag:yaml.org,2002:map', data, flow_style=True
@@ -394,7 +387,8 @@ class SeriesYamlWriter:
                            plex_libraries: dict[str: str]={},
                            required_tags: list[str]=[],
                            exclusions: list[dict[str: str]]=[],
-                           monitored_only: bool=False) -> None:
+                           monitored_only: bool=False,
+                           downloaded_only: bool=False) -> None:
         """
         Update this object's file from Sonarr.
 
@@ -405,12 +399,13 @@ class SeriesYamlWriter:
             required_tags: List of tags to filter the Sonarr sync from.
             exclusions: List of labelled exclusions to apply to sync.
             monitored_only: Whether to only sync monitored series from Sonarr.
+            downloaded_only: Whether to only sync downloaded series from Sonarr.
         """
 
         # Get complete file YAML from Sonarr
         yaml = self.__get_yaml_from_sonarr(
             sonarr_interface, plex_libraries, required_tags, exclusions,
-            monitored_only
+            monitored_only, downloaded_only
         )
 
         # Either sync of append this YAML to this object's file
@@ -419,7 +414,7 @@ class SeriesYamlWriter:
         elif self.sync_mode == 'append':
             self.__append(yaml)
 
-        log.info(f'Updated {self.file.resolve()} from Sonarr')
+        log.info(f'Synced {self.file.resolve()} from Sonarr')
 
 
     def __get_yaml_from_plex(self, plex_interface: 'PlexInterface',
@@ -514,7 +509,7 @@ class SeriesYamlWriter:
         Args:
             plex_interface: PlexInterface to sync from.
             filter_libraries: List of libraries to filter Plex sync from.
-            exclusions: List of labelled exclusions to apply to sync.
+            exclusions: List of labeled exclusions to apply to sync.
         """
 
         if not isinstance(filter_libraries, (list, tuple)):
@@ -532,4 +527,4 @@ class SeriesYamlWriter:
         elif self.sync_mode == 'append':
             self.__append(yaml)
 
-        log.info(f'Updated {self.file.resolve()} from Plex')
+        log.info(f'Synced {self.file.resolve()} from Plex')

--- a/modules/SeriesYamlWriter.py
+++ b/modules/SeriesYamlWriter.py
@@ -304,7 +304,8 @@ class SeriesYamlWriter:
                                plex_libraries: dict[str: str],
                                required_tags: list[str],
                                exclusions: list[dict[str: str]],
-                               monitored_only: bool)->dict[str: dict[str: str]]:
+                               monitored_only: bool, downloaded_only: bool
+                               )->dict[str: dict[str: str]]:
         """
         Get the YAML from Sonarr, as filtered by the given attributes.
 
@@ -315,6 +316,7 @@ class SeriesYamlWriter:
             required_tags: List of requried tags to filter the Sonarr sync with.
             exclusions: List of labelled exclusions to apply to sync.
             monitored_only: Whether to only sync monitored series from Sonarr.
+            downloaded_only: Whether to only sync downloaded series from Sonarr.
 
         Returns:
             Series YAML as reported by Sonarr. Keys are series names, and each
@@ -330,7 +332,7 @@ class SeriesYamlWriter:
         
         # Get list of SeriesInfo and paths from Sonarr
         all_series = sonarr_interface.get_all_series(
-            required_tags, excluded_tags, monitored_only
+            required_tags, excluded_tags, monitored_only, downloaded_only,
         )
 
         # Exit if no series were returned

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -905,7 +905,7 @@ class Show(YamlReader):
 
     def create_missing_title_cards(self) ->None:
         """Create any missing title cards for each episode of this show."""
-
+        
         # If the media directory is unspecified, exit
         if self.media_directory is None:
             return False

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -133,7 +133,7 @@ class Show(YamlReader):
             self.media_directory,
             self._get('season_posters'),
         )
-
+        
         # Episode dictionary to be filled
         self.episodes = {}
         self.__is_archive = False
@@ -197,8 +197,8 @@ class Show(YamlReader):
             self.library = value['path']
             self.media_directory = self.library / self.series_info.legal_path
 
-        if (value := self._get('media_directory', type_=Path)) is not None:
-            self.media_directory = value
+        if (value := self._get('media_directory', type_=str)) is not None:
+            self.media_directory =Path(TitleCard.sanitize_full_directory(value))
 
         if (value := self._get('filename_format', type_=str)) is not None:
             if TitleCard.validate_card_format_string(value):

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -792,13 +792,9 @@ class Show(YamlReader):
         MultiEpisode objects to this Show's episodes dictionary.
         """
 
-        # Set of episodes already mapped
-        matched = set()
-
-        # List of multipart episodes
-        multiparts = []
-
         # Go through each episode to check if it can be made into a MultiEpisode
+        matched = set()
+        multiparts = []
         for _, episode in self.episodes.items():
             # If this episode has already been used in MultiEpisode, skip
             if episode in matched:

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -637,11 +637,8 @@ class Show(YamlReader):
                 episode_map = {select_only.episode_info.key: select_only}
             
             plex_interface.update_watched_statuses(
-                self.library_name,
-                self.series_info,
-                episode_map,
-                self.watched_style,
-                self.unwatched_style,
+                self.library_name, self.series_info, episode_map,
+                self.watched_style, self.unwatched_style,
             )
             
         # Get show styles
@@ -918,7 +915,7 @@ class Show(YamlReader):
             log.info(f'Detected new YAML for {self} - deleting old cards')
             for episode in self.episodes.values():
                 episode.delete_card(reason='new config')
-
+        
         # Go through each episode for this show
         for _, episode in (pbar := tqdm(self.episodes.items(), **TQDM_KWARGS)):
             # Skip episodes without a destination or that already exist

--- a/modules/ShowArchive.py
+++ b/modules/ShowArchive.py
@@ -1,5 +1,3 @@
-from copy import copy
-
 from modules.Debug import log
 import modules.global_objects as global_objects
 

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -279,7 +279,7 @@ class SonarrInterface(WebInterface):
             # Skip permanent placeholder names
             if self.__ALWAYS_IGNORE_REGEX.match(episode['title']):
                 continue
-
+            
             # Create EpisodeInfo object for this entry
             episode_info = self.info_set.get_episode_info(
                 series_info,

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from pathlib import Path
 from re import IGNORECASE, compile as re_compile
 
 from modules.Debug import log
@@ -13,10 +12,7 @@ class SonarrInterface(WebInterface):
     This class describes a Sonarr interface, which is a type of WebInterface.
     The primary purpose of this class is to get episode titles, as well as
     database ID's for episodes.
-    """
-
-    """Regex to match Sonarr URL's"""
-    __SONARR_URL_REGEX = re_compile(r'^((?:https?:\/\/)?.+)(?=\/)', IGNORECASE)
+    """    
 
     """Episode titles that indicate a placeholder and are to be ignored"""
     __TEMP_IGNORE_REGEX = re_compile(r'^(tba|tbd|episode \d+)$', IGNORECASE)
@@ -49,7 +45,7 @@ class SonarrInterface(WebInterface):
         url = url if url.endswith('/') else f'{url}/'
         if url.endswith('/api/v3/'):
             self.url = url
-        elif (re_match := self.__SONARR_URL_REGEX.match(url)) is None:
+        elif (re_match := self._URL_REGEX.match(url)) is None:
             log.critical(f'Invalid Sonarr URL "{url}"')
             exit(1)
         else:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -181,7 +181,8 @@ class SonarrInterface(WebInterface):
                 continue
 
             # Skip if downloaded only and filesize is 0
-            if downloaded_only and show['sizeOnDisk'] == 0:
+            if (downloaded_only
+                and show.get('statistics', {}).get('sizeOnDisk') == 0):
                 continue
 
             # Skip show if tag is in exclude list

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -138,8 +138,8 @@ class SonarrInterface(WebInterface):
 
 
     def get_all_series(self, required_tags: list[str]=[], 
-                       excluded_tags: list[str]=[],
-                       monitored_only: bool=False)->list[tuple[SeriesInfo,str]]:
+                       excluded_tags: list[str]=[], monitored_only: bool=False,
+                       downloaded_only:bool=False)->list[tuple[SeriesInfo,str]]:
         """
         Get all the series within Sonarr, filtered by the given parameters.
 
@@ -148,8 +148,10 @@ class SonarrInterface(WebInterface):
                 series that have all of the given tags are returned.
             excluded_tags: List of tags to filter return by. If provided, series
                 with any of the given tags are excluded from return.
-            monitored_only: Whether to filter return by onyl series that are
-                monitored within Sonarr.
+            monitored_only: Whether to filter return to exclude series that are
+                unmonitored within Sonarr.
+            downloaded_only: Whether to filter return to exclude series that do
+                not have any downloaded episodes.
 
         Returns:
             List of tuples. Tuple contains the SeriesInfo object for the series,
@@ -176,6 +178,10 @@ class SonarrInterface(WebInterface):
         for show in all_series:
             # Skip if monitored only and show isn't monitored
             if monitored_only and not show['monitored']:
+                continue
+
+            # Skip if downloaded only and filesize is 0
+            if downloaded_only and show['sizeOnDisk'] == 0:
                 continue
 
             # Skip show if tag is in exclude list

--- a/modules/StandardSummary.py
+++ b/modules/StandardSummary.py
@@ -278,7 +278,7 @@ class StandardSummary(BaseSummary):
             return None
 
         # Select images for montaging
-        if not self._select_images() or len(self.inputs) == 0:
+        if not self._select_images(9) or len(self.inputs) == 0:
             return None
             
         # Create montage of title cards

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -219,6 +219,7 @@ class StandardTitleCard(BaseCardType):
                 f'-font "{self.EPISODE_COUNT_FONT.resolve()}"',
                 f'label:"{self.episode_text}"',
                 f'+smush 30 \)',
+                # Add text to source image
                 f'-geometry +0+697.2',
                 f'-composite',
             ]

--- a/modules/StandardTitleCard.py
+++ b/modules/StandardTitleCard.py
@@ -226,13 +226,8 @@ class StandardTitleCard(BaseCardType):
 
         command = ' '.join([
             f'convert "{self.source_file.resolve()}"',
-            # Resize source image
-            f'+profile "*"',    
-            f'-gravity center',
-            f'-resize "{self.TITLE_CARD_SIZE}^"',
-            f'-extent "{self.TITLE_CARD_SIZE}"',
-            # Optionally blur source image
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            # Resize and optionally blur source image
+            *self.resize_and_blur,
             # Overlay gradient
             *gradient_command,
             # Global title text options

--- a/modules/StarWarsTitleCard.py
+++ b/modules/StarWarsTitleCard.py
@@ -146,11 +146,7 @@ class StarWarsTitleCard(BaseCardType):
 
         command = ' '.join([
             f'convert "{source.resolve()}"',
-            f'+profile "*"',
-            f'-gravity center',
-            f'-resize "{self.TITLE_CARD_SIZE}^"',
-            f'-extent "{self.TITLE_CARD_SIZE}"',
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            *self.resize_and_blur,
             f'"{self.__STAR_GRADIENT_IMAGE.resolve()}"',
             f'-background None',
             f'-layers Flatten',

--- a/modules/TautulliInterface.py
+++ b/modules/TautulliInterface.py
@@ -7,11 +7,13 @@ from modules.WebInterface import WebInterface
 
 class TautulliInterface(WebInterface):
     """
-    This class describes an interface to Tautulli
+    This class describes an interface to Tautulli. This interface can configure
+    notification agents within Tautulli to enable fast card updating/creation.
     """
 
+    """Default configurations for the notification agent(s)"""
     DEFAULT_AGENT_NAME = 'Update TitleCardMaker'
-    DEFAULT_SCRIPT_TIMEOUT = 120
+    DEFAULT_SCRIPT_TIMEOUT = 30
 
     """Agent ID for a custom Script"""
     AGENT_ID = 15
@@ -159,9 +161,12 @@ class TautulliInterface(WebInterface):
             # Conditions for watched agent
             # Always add condition for the episode
             conditions = [{
-                'parameter': 'media_type', 'operator': 'is','value':['episode'],
+                'parameter': 'media_type',
+                'operator':  'is',
+                'value':     ['episode'],
+                'type':      'str',
             }]
-            # Optionally add condition for username (if provided)
+            # If provided, add condition for username
             if self.username is not None:
                 conditions.append({
                     'parameter': 'username',

--- a/modules/TautulliInterface.py
+++ b/modules/TautulliInterface.py
@@ -1,0 +1,164 @@
+from json import dumps
+from pathlib import Path
+
+from modules.Debug import log
+import modules.global_objects as global_objects
+from modules.WebInterface import WebInterface
+
+class TautulliInterface(WebInterface):
+    """
+    This class describes an interface to Tautulli
+    """
+
+    DEFAULT_AGENT_NAME = 'Update TitleCardMaker'
+    DEFAULT_SCRIPT_TIMEOUT = 60
+
+    """Agent ID for a custom Script"""
+    AGENT_ID = 15
+
+    """Only cache one request at a time"""
+    CACHE_LENGTH = 1
+
+
+    def __init__(self, url: str, api_key: str, verify_ssl: bool,
+                 update_script: Path, agent_name: str=DEFAULT_AGENT_NAME,
+                 script_timeout: int=DEFAULT_SCRIPT_TIMEOUT,
+                 username: str=None) -> None:
+        """
+        Construct a new instance of an interface to Sonarr.
+
+        Args:
+            url: The API url communicating with Tautulli.
+            api_key: The API key for API requests.
+            verify_ssl: Whether to verify SSL requests.
+
+        Raises:
+            SystemExit: Invalid Sonarr URL/API key provided.
+        """
+
+        # Initialize parent WebInterface 
+        super().__init__('Tautulli', verify_ssl)
+
+        # Get correct URL
+        url = url if url.endswith('/') else f'{url}/'
+        if url.endswith('/api/v2/'):
+            self.url = url
+        elif (re_match := self._URL_REGEX.match(url)) is None:
+            log.critical(f'Invalid Tautulli URL "{url}"')
+            exit(1)
+        else:
+            self.url = f'{re_match.group(1)}/api/v2/'
+
+        # Base parameters for sending requests to Sonarr
+        self.__params = {'apikey': api_key}
+
+        # Query system status to verify connection to Tautulli
+        try:
+            status = self._get(self.url, self.__params | {'cmd': 'status'})
+            if status.get('response', {}).get('result') != 'success':
+                log.critical(f'Cannot get Tautulli status - invalid URL/API key')
+                exit(1)
+        except Exception as e:
+            log.critical(f'Cannot connect to Tautulli - returned error: "{e}"')
+            exit(1)
+
+        # Store attributes
+        self.update_script = update_script
+        self.agent_name = agent_name
+        self.script_timeout = script_timeout
+        self.username = username
+        
+
+    def is_integrated(self) -> bool:
+        """
+        Check if this interface's Tautulli instance already has integration set
+        up.
+
+        Returns:
+            True if Tautulli has integration is already set up, False otherwise.
+        """
+
+        # Get all notifiers
+        response = self._get(self.url, self.__params | {'cmd': 'get_notifiers'})
+        notifiers = response['response']['data']
+
+        # Check each agent's name 
+        for agent in notifiers:
+            name = agent['friendly_name'].lower()
+            if (agent['agent_label'] == 'Script'
+                and ('tcm' in name or 'titlecardmaker' in name)):
+                log.debug(f'Tautulli already integrated in agent '
+                          f'{agent["id"]} ("{agent["friendly_name"]}")')
+                return True
+
+        log.debug(f'Tautulli not integrated')
+        return False
+
+
+    def integrate(self) -> None:
+        """
+        Integrate this interface's instance of Tautulli with TCM. This
+        configures a new notification agent if a valid one does not exist or
+        cannot be identified.
+        """
+
+        # If already integrated, skip
+        if self.is_integrated():
+            return None
+        
+        # Get all existing notifier ID's
+        response = self._get(self.url, self.__params | {'cmd': 'get_notifiers'})
+        existing_ids = {agent['id'] for agent in response['response']['data']}
+
+        # Create new notifier
+        params = {'cmd': 'add_notifier_config', 'agent_id': self.AGENT_ID}
+        self._get(self.url,  self.__params | params)
+
+        # Get notifier ID's after adding new one
+        response = self._get(self.url, self.__params | {'cmd': 'get_notifiers'})
+        new_ids = {agent['id'] for agent in response['response']['data']}
+
+        # If no new ID's are returned
+        if len(new_ids - existing_ids) == 0:
+            log.error(f'Failed to create new notification agent on Tautulli')
+            return None
+        
+        # Get ID of created notifier
+        notifier_id = list(new_ids - existing_ids)[0]
+        log.info(f'Created Tautulli notification agent {notifier_id}')
+
+        # Determine condition(s)
+        # Always add condition for the episode
+        conditions = [{
+            'parameter': 'media_type', 'operator': 'is', 'value': ['episode'],
+        }]
+        # Optionally add condition for username (if provided)
+        if self.username is not None:
+            conditions.append({
+                'parameter': 'username',
+                'operator':  'is',
+                'value':     [self.username],
+            })
+
+        # Configure this notifier
+        params = self.__params | {
+            # API arguments
+            'cmd': 'set_notifier_config',
+            'notifier_id': notifier_id,
+            'agent_id': self.AGENT_ID,
+            # Configuration
+            'friendly_name': self.agent_name,
+            'scripts_script_folder': str(self.update_script.parent.resolve()),
+            'scripts_script': str(self.update_script.resolve()),
+            'scripts_timeout': self.script_timeout,
+            # Triggers
+            'on_watched': 1,
+            'on_created': 1,
+            # Conditions
+            'custom_conditions': dumps(conditions),
+            # Arguments
+            'on_watched_subject': '{rating_key}',
+            'on_created_subject': '{rating_key}',
+        }
+        self._get(self.url, params)
+        log.info(f'Configured Tautulli notification agent {notifier_id}')

--- a/modules/TautulliInterface.py
+++ b/modules/TautulliInterface.py
@@ -167,6 +167,7 @@ class TautulliInterface(WebInterface):
                     'parameter': 'username',
                     'operator':  'is',
                     'value':     [self.username],
+                    'type':      'str',
                 })
 
             # Configure this agent
@@ -200,6 +201,7 @@ class TautulliInterface(WebInterface):
                 'parameter': 'media_type',
                 'operator':  'is',
                 'value':     ['show', 'season', 'episode'],
+                'type':      'str',
             }]
 
             # Configure this agent

--- a/modules/TextlessTitleCard.py
+++ b/modules/TextlessTitleCard.py
@@ -71,11 +71,7 @@ class TextlessTitleCard(BaseCardType):
 
         command = ' '.join([
             f'convert "{self.source_file.resolve()}"',
-            f'+profile "*"',
-            f'-gravity center',
-            f'-resize "{self.TITLE_CARD_SIZE}^"',
-            f'-extent "{self.TITLE_CARD_SIZE}"',
-            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            *self.resize_and_blur,
             f'"{self.output_file.resolve()}"',
         ])
 

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -34,6 +34,7 @@ class TitleCard:
     DEFAULT_FILENAME_FORMAT = '{full_name} - S{season:02}E{episode:02}'
 
     """Mapping of card type identifiers to CardType classes"""
+    DEFAULT_CARD_TYPE = 'standard'
     CARD_TYPES = {
         'anime': AnimeTitleCard,
         'generic': StandardTitleCard,
@@ -58,11 +59,10 @@ class TitleCard:
         '>': '',
         ':':' -',
         '"': '',
-        '/': '+',
-        '\\': '+',
         '|': '',
         '*': '-',
     }
+    __ILLEGAL_NAME_CHARACTERS = {'/': '+', '\\': '+'}
 
     __slots__ = ('episode', 'profile', 'converted_title', 'maker', 'file')
     
@@ -111,19 +111,41 @@ class TitleCard:
 
 
     @staticmethod
-    def __replace_illegal_characters(filename: str) -> str:
+    def sanitize_full_directory(path: str) -> str:
         """
-        Replace the given filename's illegal characters with their legal
-        counterparts.
-        
+        Sanitize the entire path and remove all invalid characters. This is
+        different to sanitizing a name as '/' and '\' characters aren't
+        sanitized in names.
+
         Args:
-            filename: The filename (as a string) to modify.
-        
-        returns:
-            The modified filename.
+            path: Directory path (as a string) to sanitize.
+
+        Returns:
+            Modified directory.
         """
 
-        return filename.translate(str.maketrans(TitleCard.__ILLEGAL_CHARACTERS))
+        replacements = TitleCard.__ILLEGAL_CHARACTERS
+
+        return path.translate(str.maketrans(replacements))
+
+
+    @staticmethod
+    def sanitize_name(filename: str) -> str:
+        """
+        Sanitize the filename and remove all invalid characters.
+
+        Args:
+            path: Filename (as a string) to sanitize.
+
+        Returns:
+            Modified filename.
+        """
+
+        # Replace all characters (including / and \)
+        replacements =\
+            TitleCard.__ILLEGAL_CHARACTERS | TitleCard.__ILLEGAL_NAME_CHARACTERS
+
+        return filename.translate(str.maketrans(replacements))
 
         
     @staticmethod
@@ -151,7 +173,7 @@ class TitleCard:
         
         # Get filename from the given format string, with illegals removed
         abs_number = episode_info.abs_number
-        filename = TitleCard.__replace_illegal_characters(
+        filename = TitleCard.sanitize_name(
             format_string.format(
                 name=series_info.name,
                 full_name=series_info.full_name,
@@ -220,7 +242,7 @@ class TitleCard:
 
         # Get filename from the modified format string
         abs_number = multi_episode.episode_info.abs_number
-        filename = TitleCard.__replace_illegal_characters(
+        filename = TitleCard.sanitize_name(
             modified_format_string.format(
                 name=series_info.name,
                 full_name=series_info.full_name,

--- a/modules/WebInterface.py
+++ b/modules/WebInterface.py
@@ -1,3 +1,4 @@
+from re import IGNORECASE, compile as re_compile
 from requests import get, Session
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_exponential
 import urllib3
@@ -14,6 +15,9 @@ class WebInterface:
     """How many requests to cache"""
     CACHE_LENGTH = 10
     
+    """Regex to match URL's"""
+    _URL_REGEX = re_compile(r'^((?:https?:\/\/)?.+)(?=\/)', IGNORECASE)
+
     
     def __init__(self, name: str, verify_ssl: bool=True) -> None:
         """
@@ -40,6 +44,12 @@ class WebInterface:
         # Cache of the last requests to speed up identical sequential requests
         self.__cache = []
         self.__cached_results = []
+
+
+    def __repr__(self) -> str:
+        """Returns an unambiguous string representation of the object."""
+        
+        return f'<WebInterface to {self.name}>'
 
 
     @retry(stop=stop_after_attempt(10),


### PR DESCRIPTION
# Major Changes
- Make `sync` sync mode actually useful
  - Replace `sync` sync mode with `match` (so the naming is more clear)
  - No longer overwrites all change to the file, actually keeps edits/some comments
  - Differs from `append` mode by allowing for entries to be _removed_ from the file if not in the sync
  - Closes #262 
- Optimize `StandardTitleCard` and `AnimeTitleCard` to be ~5x faster
- Modify `episode_ranges` to take non-absolute indices, like so:
     ```yaml
     episode_ranges:
       s1e1-s1e4: # title or sources
       s1e5-s1e10: # title or sources
       # ...
     ```
   - Closes #264 
- Add optional `add_bounding_box` extra to `LandscapeTitleCard` to add a text-colored bounding box around title text
   <img src="https://user-images.githubusercontent.com/17693271/190925206-37dcff21-f547-4dcb-bd23-0d824cca8ab1.jpg" width="250"/> <img src="https://user-images.githubusercontent.com/17693271/190925268-1ab09dd4-5de5-495b-9651-4c3c11531af0.jpg" width="250"/> <img src="https://user-images.githubusercontent.com/17693271/190926356-1ea1fd45-25b6-4bb3-9b2e-4cf0d4f7d460.jpg" width="250"/> 
   - Closes #265
- Add ability to create movie posters with a top-line subtitle - for example (comparison with/without):
   <img src="https://user-images.githubusercontent.com/17693271/192154720-150ae35c-ba8b-41b5-9e0f-51fcecde4ac9.jpg" height="300"> <img src="https://user-images.githubusercontent.com/17693271/192154758-cbc5b9b3-a4c6-48ed-80c7-039cfae270f3.jpg" height="300"/>
  - Specified via `--movie-top-subtitle` argument for `mini_maker.py`
  - Closes #266 
- Add ability to set up Tautulli integration automatically
   - Options are specified in new global preferences - for example:
      ```yaml
      tautulli:
        url: # ...
        api_key: # ...
        update_script: /config/update_card.sh
        verify_ssl: true
        username: CollinHeist
        agent_name: Update TitleCardMaker
        script_timeout: 30
      ```
  - Closes #268 
# Major Fixes 
- Windows paths in `sync` `volumes` specification are now handled with their fully-resolved POSIX equivalent path
- Handle libraries with multiple asset directories in plex sync
- Maintain custom/manually specified sources in derived archive variations
- Allow season hiding and custom source specification via `episode_ranges`
- Fix manual show summary creation to work with new `StylizedShowSummary` style
# Minor Changes
- Assume episodes not present in Plex are _unwatched_ (was _watched_) so that if an `unwatched_style` is indicated, the cards are made correctly upon first import
- Add optional `omit_gradient` extra to `StandardTitleCard` to optionally not apply the gradient to the card
- Optionally omit specials from summary creation by parsing `ignore_specials` option under `archive` `summary` global option
- Add optional extra `kanji_vertical_shift` to `AnimeTitleCard` to offset kanji separately from title text
- Added 10% margin on unrecognized episode text formats in `OlivierTitleCard`
- Log runtime arguments with `main.py` is run
- Optionally only filter downloaded series in sonarr sync via `downloaded_only` option
  - Closes #267 
- Allow for completely transparent title cards in all card types (if a completely transparent source image is provided)
   <img src="https://user-images.githubusercontent.com/17693271/192155037-86b0b607-dbb6-4120-80d6-b0e69dd89069.jpg" width="400"/>
- Change Tautulli integration to handle entire series or seasons (not just episodes) to remake card - mostly relevant for newly added series/seasons
# Minor Fixes
- Actually skip invalid archive variations
- No longer reset custom episode text formats in seasonless archive variations
- Handle more bad ImageMagick installations during setup
- Handle bad characters in manual `media_directory` specifications
- Apply font `vertical_shift` to title text in `AnimeTitleCard` (was just applying to kanji)
- Handle series without files in plex sync
- Handle episodes without season or episode numbers in plex sync
- Fix `fixer.py`  TMDb blacklist arguments to work with variable database directories