### PR TITLE
Remake cards when new title is detected, allow for longer font replacements, better Windows path handling, other changes and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ TitleCardMaker can be automated such that everything can be pulled without manua
 
 <img alt="card unblurring process" src="https://user-images.githubusercontent.com/17693271/185819730-a2c55a3a-63cc-4f0e-8061-891edd8d64d0.gif"/>
   
-The actual image creation is done using the open-source and free image library called [ImageMagick](https://imagemagick.org/).
+All configuration/automation of the TitleCardMaker is done via YAML files, and the actual image creation is done using the open-source and free image library called [ImageMagick](https://imagemagick.org/).
 
 ## Getting Started
 Read the [Getting Started](https://github.com/CollinHeist/TitleCardMaker/wiki) page on the Wiki for the traditional install, or the [Getting Started on Docker](https://github.com/CollinHeist/TitleCardMaker/wiki/Docker-Tutorial) page to install using Docker.
@@ -33,7 +33,7 @@ If you're using Unraid, there is a template available for easy setup - just sear
 Assuming you're using the default preference filename, invoking the Maker is as simple as:
 
 ```console
-$ pipenv run python3 main.py --run
+pipenv run python main.py --run
 ```
 
 For invocation and configuration details, read [here](https://github.com/CollinHeist/TitleCardMaker/wiki/Running-the-TitleCardMaker).
@@ -57,6 +57,13 @@ The TitleCardMaker can also use user-created and maintained card types hosted on
 > The above cards are, in order, `Yozora/BarebonesTitleCard`, `Beedman/GradientLogoTitleCard`, `Yozora/RetroTitleCard`, `Yozora/SlimTitleCard`, `Wdvh/StarWarsTitleOnly`, `Wdvh/WhiteTextAbsolute`, `lyonza/WhiteTextBroadcast`, `Wdvh/WhiteTextStandard`, `Wdvh/WhiteTextTitleOnly`, and `azuravian/TitleColorMatch`
 
 </details>
+
+## Other Features
+In addition to title card creation and management, the TitleCardMaker can also be used for other image-creation functionality. For example, the [mini maker](https://github.com/CollinHeist/TitleCardMaker/wiki/Using-the-Mini-Maker) - a.k.a. `mini_maker.py` - can be used to "manually" create collection posters, genre cards, movie posters, show summaries, and season posters. An example of each is shown below:
+
+<img alt="Example Collection Poster" src="https://user-images.githubusercontent.com/17693271/180630284-57e6d14a-025b-439f-9a84-696749b92c8d.jpg" height="200"/> <img alt="Example Genre Card" src="https://user-images.githubusercontent.com/17693271/166091004-c8cf6afe-7cdf-4ba2-b16d-8a1c13236df8.jpg" height="200"/> <img alt="Example Movie Poster" src="https://user-images.githubusercontent.com/17693271/188292228-c57b7415-63ee-4907-9886-dd94e7d94a6b.jpg" height="200"/> <img alt="Example Genre Card" src="https://user-images.githubusercontent.com/17693271/188784303-a80f0e1c-e1c3-43b0-8591-fa0eb3aafabc.jpg" height="200"/> <img alt="Example Genre Card" src="https://user-images.githubusercontent.com/17693271/172294392-ecababbe-eeef-4e28-b08c-814b7e02f4c7.png" height="200"/>
+
+This is largely done via the command-line, and is described on the wiki [here](https://github.com/CollinHeist/TitleCardMaker/wiki/Using-the-Mini-Maker).
 
 ## Contributing
 If you'd like to contribute - whether that's a suggested feature, a bug fix, or anything else - please do so on GitHub by creating an issue, or [join the Discord](https://discord.gg/bJ3bHtw8wH). The best way for me to manage technical aspects of the project is on GitHub.

--- a/main.py
+++ b/main.py
@@ -253,7 +253,7 @@ if args.sync:
     read_preferences()
     
     # Create Manager, run, and write missing report
-    Manager().sync_series_files()
+    Manager(check_tautulli=False).sync_series_files()
 
 # Schedule first run, which then schedules subsequent runs
 if hasattr(args, 'runtime'):

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ except ImportError as e:
     exit(1)
 
 # Version information
-CURRENT_VERSION = 'v1.11.1'
+CURRENT_VERSION = 'v1.11.2'
 REPO_URL = ('https://api.github.com/repos/'
             'CollinHeist/TitleCardMaker/releases/latest')
 

--- a/main.py
+++ b/main.py
@@ -118,14 +118,14 @@ parser.add_argument(
     action='store_true',
     help='Omit color from all print messages')
 parser.add_argument(
-    '--tautulli-list', '--tautulli-update-list',
+    '-tl', '--tautulli-list', '--tautulli-update-list',
     type=Path,
     default=environ.get(ENV_UPDATE_LIST, SUPPRESS),
     metavar='FILE',
     help=f'File to monitor for Tautulli-driven episode watch-status updates. '
          f'Environment variable {ENV_UPDATE_LIST}.')
 parser.add_argument(
-    '--tautulli-frequency', '--tautulli-update-frequency',
+    '-tf', '--tautulli-frequency', '--tautulli-update-frequency',
     type=frequency,
     default=environ.get(ENV_UPDATE_FREQUENCY, DEFAULT_TAUTULLI_FREQUENCY),
     metavar='FREQUENCY',

--- a/main.py
+++ b/main.py
@@ -230,7 +230,7 @@ def read_update_list():
     # Read update list contents
     try:
         with args.tautulli_list.open('r') as file_handle:
-            update_list = list(map(int, file_handle.readlines()))
+            update_list = set(map(int, file_handle.readlines()))
         log.debug(f'Read update list ({update_list})')
     except ValueError:
         log.error(f'Error reading update list, skipping and deleting')

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -200,6 +200,12 @@ movie_poster_group.add_argument(
     metavar='SUBTITLE',
     help='Subtitle for the movie poster')
 movie_poster_group.add_argument(
+    '--movie-index', '--movie-number',
+    type=str,
+    default='',
+    metavar='INDEX',
+    help='Index number/text to place behind the title text on the movie poster')
+movie_poster_group.add_argument(
     '--movie-font',
     type=Path,
     default=MoviePosterMaker.FONT,
@@ -387,6 +393,7 @@ if hasattr(args, 'movie_poster'):
         title='\n'.join(args.movie_title),
         subtitle=args.movie_subtitle,
         top_subtitle=args.movie_top_subtitle,
+        movie_index=args.movie_index,
         font=args.movie_font,
         font_color=args.movie_font_color,
         font_size=float(args.movie_font_size[:-1])/100.0,

--- a/mini_maker.py
+++ b/mini_maker.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from re import match, IGNORECASE
 
 try:
+    from modules.AspectRatioFixer import AspectRatioFixer
     from modules.CollectionPosterMaker import CollectionPosterMaker
     from modules.Debug import log
     from modules.GenreMaker import GenreMaker
@@ -128,6 +129,30 @@ title_card_group.add_argument(
     metavar='SCALE%',
     help='Specify the font black stroke scale (as percentage)')
     
+# Argument group for aspect ratio fixing
+aspect_ratio_group = parser.add_argument_group(
+    'Aspect Ratio Correction',
+    'Fit images into a 16:9 aspect ratio')
+aspect_ratio_group.add_argument(
+    '--ratio', '--aspect-ratio',
+    type=Path,
+    nargs=2,
+    default=SUPPRESS,
+    metavar=('SOURCE', 'DESTINATION'),
+    help='Correct the aspect ratio of the given image, write to destination')
+aspect_ratio_group.add_argument(
+    '--ratio-batch', '--aspect-ratio-batch',
+    type=Path,
+    default=SUPPRESS,
+    metavar='DIRECTORY',
+    help='Correct the aspect ratios of all images in the given directory')
+aspect_ratio_group.add_argument(
+    '--ratio-style', '--aspect-ratio-style',
+    type=str,
+    default=AspectRatioFixer.DEFAULT_STYLE,
+    choices=AspectRatioFixer.VALID_STYLES,
+    help='Style of the aspect-ratio correction to utilize')
+
 # Argument group for collection posters
 collection_group = parser.add_argument_group(
     'Collection Posters',
@@ -371,6 +396,23 @@ if hasattr(args, 'title_card'):
         **arbitrary_data,
     ).create()
 
+# Correct aspect ration
+if hasattr(args, 'ratio'):
+    AspectRatioFixer(
+        source=args.ratio[0],
+        destination=args.ratio[1],
+        style=args.ratio_style,
+    ).create()
+
+if hasattr(args, 'ratio_batch'):
+    for file in args.ratio_batch.glob('*'):
+        if file.suffix.lower() in AspectRatioFixer.VALID_IMAGE_EXTENSIONS:
+            AspectRatioFixer(
+                source=file,
+                destination=file.with_stem(f'{file.stem}-corrected'),
+                style=args.ratio_style,
+            ).create()
+
 # Create Collection Poster
 if hasattr(args, 'collection_poster'):
     CollectionPosterMaker(
@@ -417,12 +459,13 @@ if hasattr(args, 'genre_card_batch'):
             GenreMaker(
                 source=file,
                 genre=file.stem.upper(),
-                output=Path(file.parent /f'{file.stem}-GenreCard{file.suffix}'),
+                output=file.with_stem(f'{file.stem}-GenreCard'),
                 font_size=float(args.font_size[:-1])/100.0,
                 borderless=args.borderless,
                 omit_gradient=args.no_gradient,
             ).create()
             
+# Create show summaries
 if hasattr(args, 'show_summary'):
     # Temporary classes
     @dataclass
@@ -478,7 +521,7 @@ if hasattr(args, 'show_summary'):
     else:
         log.warning(f'Failed to create "{summary.output.resolve()}"')
 
-
+# Create season posters
 if hasattr(args, 'season_poster'):
     SeasonPoster(
         source=args.season_poster[0],

--- a/modules/AspectRatioFixer.py
+++ b/modules/AspectRatioFixer.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+
+from modules.Debug import log
+from modules.ImageMaker import ImageMaker
+
+class AspectRatioFixer(ImageMaker):
+    """
+    This class describes a type of ImageMaker that corrects the aspect ratio of
+    source images (usually 4x3) to the TitleCard aspect ratio of 16x9.
+    """
+
+    """Valid styles for the fixer"""
+    DEFAULT_STYLE = 'copy'
+    VALID_STYLES = ('copy', 'stretch')
+
+    """Temporary intermediate files"""
+    __RESIZED_TEMP = ImageMaker.TEMP_DIR / 'ar_temp.png'
+
+    __slots__ = ('source', 'destination', 'style')
+
+
+    def __init__(self, source: Path, destination: Path,
+                 style: str=DEFAULT_STYLE) -> None:
+        """
+        Initialize this object. This stores attributes, and initialzies the 
+        parent ImageMaker object.
+
+        Args:
+            source: Path to the source image to use.
+            destination: Path to the desination file to write the image at.
+            style: Aspect ratio correction style. Must be one of VALID_STYLES.
+
+        Raises:
+            AssertionError: If 'style' is invalid.
+        """
+
+        # Initialize parent object for the ImageMagickInterface
+        super().__init__()
+
+        # Store attributes
+        self.source = source
+        self.destination = destination
+        self.style = style.lower()
+
+        assert self.style in self.VALID_STYLES, 'Invalid style'
+
+
+    def create(self) -> None:
+        """
+        Create the aspect-ratio-corrected image for this object's source file.
+        """
+
+        # If source DNE, exit
+        if not self.source.exists():
+            log.error(f'Input file "{self.source.resolve()}" does not exist')
+            return None
+
+        # Copy style command
+        if self.style == 'copy':
+            command = ' '.join([
+                f'convert "{self.source.resolve()}"',
+                # Force resize source to correct size
+                f'-resize "3200x1800!"',
+                # Blur source
+                f'-blur 0x16',
+                f'-gravity center',
+                f'-append',
+                # Add source image over blurred source
+                f'"{self.source.resolve()}"',
+                f'-resize "3200x1800"',
+                f'-composite',
+                f'"{self.destination.resolve()}"',
+            ])
+        # Stretch style command
+        elif self.style == 'stretch':
+            # Resize source image to correct height
+            resize_command = ' '.join([
+                f'convert',
+                f'+profile "*"',
+                f'"{self.source.resolve()}"',
+                f'-resize x1800',
+                f'"{self.__RESIZED_TEMP.resolve()}"',
+            ])
+            self.image_magick.run(resize_command)
+
+            # Get dimensions of resized image, exit if too narrow for stretching
+            dimensions = self.get_image_dimensions(self.__RESIZED_TEMP)
+            if dimensions['width'] < 400 or dimensions['height'] < 1800:
+                log.error(f'Image too narrow for correcting with "stretch" style')
+                return None
+
+            # Stretch sides to fit into 3200px wide
+            side_width = (3200 - dimensions['width'] + 100) // 2
+
+            command = ' '.join([
+                f'convert',
+                # Crop left 50px and stretch
+                f'\( "{self.__RESIZED_TEMP.resolve()}"',
+                f'-crop "50x1800+0+0"',
+                f'-resize "{side_width}!" \)',
+                # Crop middle section
+                f'\(  "{self.__RESIZED_TEMP.resolve()}"',
+                f'-crop "{dimensions["width"]-100}x1800+50+0" \)',
+                # Crop right 50px and stretch
+                f'\(  "{self.__RESIZED_TEMP.resolve()}"',
+                f'-crop "50x1800+{dimensions["width"]-50}+0"',
+                f'-resize "{side_width}!" \)',
+                # Append like [LEFT 50][MIDDLE][RIGHT 50] left-to-right
+                f'+append',
+                f'"{self.destination.resolve()}"',
+            ])
+
+        self.image_magick.run(command)
+
+        # Delete temporary images
+        if self.style == 'stretch':
+            self.image_magick.delete_intermediate_images(self.__RESIZED_TEMP)
+
+        log.debug(f'Created "{self.destination.resolve()}"')

--- a/modules/BaseCardType.py
+++ b/modules/BaseCardType.py
@@ -126,7 +126,7 @@ class BaseCardType(ImageMaker):
         """ImageMagick commands to resize and blur an image."""
 
         return [
-            f'-profile "*"',
+            f'+profile "*"',
             f'-background transparent',
             f'-gravity center',
             f'-resize "{self.TITLE_CARD_SIZE}^"',

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -133,11 +133,16 @@ class Font:
         if (value := self.__yaml.get('replacements')) is not None:
             if not isinstance(value, dict):
                 self.__error('replacements', value, 'must be character set')
-            if not all(isinstance(repl, str) for _, repl in value.items()):
-                self.__error('replacements',value,'can only substitute strings')
             else:
-                self.replacements = value
-
+                # Convert each replacement to string, exit if impossible
+                self.replacements = {}
+                for in_, out_ in value.items():
+                    try:
+                        self.replacements[str(in_)] = str(out_)
+                    except Exception:
+                        self.__error('replacements', value,
+                                     f'bad replacement for "{in_}"')
+        
         # Size
         if (value := self.__yaml.get('size')) is not None:
             if (not isinstance(value, str)

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -118,12 +118,12 @@ class Font:
         if (value := self.__yaml.get('file')) is not None:
             if not isinstance(value, str):
                 self.__error('file', value, 'not a valid path')
+            # If specified as direct path, check for existance
             elif (value := Path(value)).exists():
-                # If specified as direct path, check for existance
                 self.file = str(value.resolve())
                 self.replacements = {}
+            # If specified indirectly (or DNE), glob for any extension
             elif len(matches := tuple(value.parent.glob(f'{value.name}*'))) ==1:
-                # If specified indirectly (or DNE), glob for any extension
                 self.file = str(matches[0].resolve())
                 self.replacements = {}
             else:
@@ -133,10 +133,7 @@ class Font:
         if (value := self.__yaml.get('replacements')) is not None:
             if not isinstance(value, dict):
                 self.__error('replacements', value, 'must be character set')
-            if any(len(key) != 1 for key in value.keys()):
-                self.__error('replacements', value,
-                             'can only specify single character replacements')
-            elif not all(isinstance(repl, str) for _, repl in value.items()):
+            if not all(isinstance(repl, str) for _, repl in value.items()):
                 self.__error('replacements',value,'can only substitute strings')
             else:
                 self.replacements = value

--- a/modules/Font.py
+++ b/modules/Font.py
@@ -57,7 +57,7 @@ class Font:
         self.__validator = global_objects.fv
         
         # Generic font attributes
-        self.set_default()
+        self.reset()
         
         # Parse YAML, update validity
         self.__parse_attributes()
@@ -180,7 +180,7 @@ class Font:
                 self.stroke_width = float(value[:-1]) / 100.0
 
 
-    def set_default(self) -> None:
+    def reset(self) -> None:
         """Reset this object's attributes to its default values."""
 
         # Whether to validate for this font

--- a/modules/FontValidator.py
+++ b/modules/FontValidator.py
@@ -28,28 +28,6 @@ class FontValidator:
         # Create/read font validation database
         self.__db = TinyDB(database_directory / self.CHARACTER_DATABASE)
 
-        # List of missing characters that have already been warned
-        self.__warned = []
-
-
-    def __warn_missing(self, char: str, font_filepath: str) -> None:
-        """
-        Warn a given character is missing from a given font, but only if it 
-        hasn't already been warned.
-        
-        Args:
-            char: The missing character
-            font_filepath: Filepath to the relevant font.
-        """
-
-        # If this character (for this font) has already been warned, return
-        if (key := f'{char}-{font_filepath}') in self.__warned:
-            return None
-
-        # Character (and font) hasn't been warned yet - warn and add to list
-        log.warning(f'Character "{char}" missing from "{font_filepath}"')
-        self.__warned.append(key)
-
 
     def __has_character(self, font_filepath: str, character: str) -> bool:
         """
@@ -83,7 +61,9 @@ class FontValidator:
             if glyph in table.cmap:
                 # Update map for this character, return True
                 self.__db.insert({
-                    'file': font_filepath, 'character': character, 'status':True
+                    'file': font_filepath,
+                    'character': character,
+                    'status': True
                 })
 
                 return True
@@ -119,6 +99,6 @@ class FontValidator:
         # Log all missing characters
         for char, has_character in zip(title, has_characters):
             if not has_character:
-                self.__warn_missing(char, font_filepath)
+                log.warning(f'Character "{char}" missing from "{font_filepath}"')
 
         return all(has_characters)

--- a/modules/LandscapeTitleCard.py
+++ b/modules/LandscapeTitleCard.py
@@ -160,7 +160,7 @@ class LandscapeTitleCard(BaseCardType):
             # Create bounding box
             f'-fill transparent',
             f'-strokewidth 10',
-            f'-stroke {self.title_color}',
+            f'-stroke "{self.title_color}"',
             f'-draw "rectangle {x_start},{y_start},{x_end},{y_end}"',
             # Create shadow of the bounding box
             f'\( +clone',

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -350,7 +350,8 @@ class Manager:
 
     def __run(self, *, serial: bool=False) -> None:
         """
-        Run the Manager.
+        Run the Manager. If serial execution is not indicated, then sync is run
+        and Show/ShowArchive objects are created.
         
         Args:
             serial: (Keyword only) Whether execution is serial.

--- a/modules/Manager.py
+++ b/modules/Manager.py
@@ -1,5 +1,6 @@
 from yaml import dump
 from tqdm import tqdm
+from typing import Iterable
 
 from modules.Debug import log, TQDM_KWARGS
 from modules.PlexInterface import PlexInterface
@@ -411,7 +412,7 @@ class Manager:
             self.__run()
 
 
-    def remake_cards(self, rating_keys: list[int]) -> None:
+    def remake_cards(self, rating_keys: Iterable[int]) -> None:
         """
         Remake the title cards associated with the given list of rating keys.
         These keys are used to identify their corresponding episodes within
@@ -444,12 +445,9 @@ class Manager:
                 break
 
             # Check if this show is one of the entries to update
+            is_found = False
             for index, (series_info, episode_info, library_name) \
                 in enumerate(entry_list):
-                # Skip entries already found
-                if index in found:
-                    continue
-
                 # Match the library and series name
                 full_match_name = show.series_info.full_match_name
                 if (show.valid
@@ -457,7 +455,12 @@ class Manager:
                     and full_match_name == series_info.full_match_name):
                     self.shows = [show]
                     self.__run(serial=True)
-                    found.add(index)
+                    is_found = True
+                    break
+
+            # If an entry was found, delete from list 
+            if is_found:
+                del entry_list[index]
 
         # Warn for all entries not found
         for index, (series_info, episode_info, library_name) \

--- a/modules/MediaInfoSet.py
+++ b/modules/MediaInfoSet.py
@@ -218,7 +218,7 @@ class MediaInfoSet:
                     return set_ids(info)
                 else:
                     log.debug(f'Index match on {series_info} {key}, but title '
-                              f'mismatch ({info.title}) vs ({title})')
+                              f'mismatch ({info.title}) vs ("{title}")')
                     return EpisodeInfo(title, season_number, episode_number,
                                        abs_number, imdb_id=imdb_id,
                                        tvdb_id=tvdb_id, tmdb_id=tmdb_id,

--- a/modules/MoviePosterMaker.py
+++ b/modules/MoviePosterMaker.py
@@ -142,6 +142,43 @@ class MoviePosterMaker(ImageMaker):
             f'-kerning 0.5',
         ]
 
+    @property
+    def title_command(self) -> list[str]:
+        """
+        _summary_
+
+        Returns:
+            _description_
+        """
+
+        # No titles, return empty command
+        if (len(self.top_subtitle.strip()) == 0
+            and len(self.title.strip()) == 0
+            and len(self.subtitle.strip()) == 0):
+            return []
+
+        # At least one title being added, return entire command
+        return [
+            ## Global font attributes
+            f'-font "{self.font.resolve()}"',
+            f'-fill "{self.font_color}"',
+            # Create an image for each title
+            f'\( -background transparent',
+            *self.subtitle_font_attributes,
+            f'label:"{self.top_subtitle}"',
+            *self.title_font_attributes,
+            f'label:"{self.title}"',
+            *self.subtitle_font_attributes,
+            f'label:"{self.subtitle}"',
+            # Combine in order [TOP SUBTITLE] / [TITLE] / [SUBTITLE]
+            f'-smush 30 \)',
+            # Add titles to image
+            f'-gravity south',
+            f'-geometry +0+{182.5 if len(self.subtitle) > 0 else 262.5}',
+            f'-compose atop',
+            f'-composite',
+        ]
+
 
     def create(self) -> None:
         """
@@ -176,24 +213,7 @@ class MoviePosterMaker(ImageMaker):
             # Add index text
             *self.index_command,
             # Add title text
-            ## Global font attributes
-            f'-font "{self.font.resolve()}"',
-            f'-fill "{self.font_color}"',
-            # Create an image for each title
-            f'\( -background transparent',
-            *self.subtitle_font_attributes,
-            f'label:"{self.top_subtitle}"',
-            *self.title_font_attributes,
-            f'label:"{self.title}"',
-            *self.subtitle_font_attributes,
-            f'label:"{self.subtitle}"',
-            # Combine in order [TOP SUBTITLE] / [TITLE] / [SUBTITLE]
-            f'-smush 30 \)',
-            # Add titles to image
-            f'-gravity south',
-            f'-geometry +0+{182.5 if len(self.subtitle) > 0 else 262.5}',
-            f'-compose atop',
-            f'-composite',
+            *self.title_command,
             f'"{self.output.resolve()}"',
         ])
 

--- a/modules/MoviePosterMaker.py
+++ b/modules/MoviePosterMaker.py
@@ -12,6 +12,7 @@ class MoviePosterMaker(ImageMaker):
     """Base font for title text"""
     FONT = REF_DIRECTORY / 'Arial Bold.ttf'
     FONT_COLOR = 'white'
+    INDEX_FONT_COLOR = 'rgb(154,154,154)'
 
     """Paths to reference images to overlay"""
     __FRAME = REF_DIRECTORY / 'frame.png'
@@ -19,7 +20,7 @@ class MoviePosterMaker(ImageMaker):
 
 
     def __init__(self, source: Path, output: Path, title: str, subtitle: str='',
-                 top_subtitle: str='', font: Path=FONT,
+                 top_subtitle: str='', movie_index: str='', font: Path=FONT,
                  font_color: str=FONT_COLOR, font_size: float=1.0,
                  omit_gradient: bool=False) -> None:
         """
@@ -32,6 +33,8 @@ class MoviePosterMaker(ImageMaker):
             subtitle: String to use for smaller title text.
             top_subtitle: String to use for smaller subtitle text that appears
                 above the title text.
+            movie_index: Optional (series) index to place behind the movie
+                title.
             font: Path to the font file of the poster's title.
             font_color: Font color of the poster text.
             font_size: Scalar for the font size of the poster's title.
@@ -44,6 +47,7 @@ class MoviePosterMaker(ImageMaker):
         # Store arguments as attributes
         self.source = source
         self.output = output
+        self.movie_index = movie_index
         self.font = font
         self.font_color = font_color
         self.font_size = font_size
@@ -81,6 +85,28 @@ class MoviePosterMaker(ImageMaker):
 
 
     @property
+    def index_command(self) -> list[str]:
+        """
+        ImageMagick command(s) to add the underlying index text behind the
+        title text.
+
+        Returns:
+            List of ImageMagick commands.
+        """
+
+        # No index, return empty command
+        if len(self.movie_index) == 0:
+            return []
+
+        return [
+            f'-font "{self.FONT.resolve()}"',
+            f'-pointsize 598',
+            f'-fill "{self.INDEX_FONT_COLOR}"',
+            f'-annotate +0+1150 "{self.movie_index}"',
+        ]
+
+
+    @property
     def title_font_attributes(self) -> list[str]:
         """
         Imagemagick commands to define the font attributes of the title text.
@@ -93,8 +119,9 @@ class MoviePosterMaker(ImageMaker):
         
         return [
             f'-pointsize {title_font_size}',
-            f'-interline-spacing -40',
-            f'+kerning',
+            f'-interline-spacing -44.5',
+            f'-interword-spacing 55',
+            f'-kerning 0.70',
         ]
 
 
@@ -111,8 +138,8 @@ class MoviePosterMaker(ImageMaker):
 
         return [
             f'-pointsize {subtitle_font_size}',
-            f'-interword-spacing 15',
-            f'-kerning 7',
+            f'-interword-spacing 18',
+            f'-kerning 0.5',
         ]
 
 
@@ -146,10 +173,12 @@ class MoviePosterMaker(ImageMaker):
             # Swap, putting frame on top of source+gradient
             f'+swap',
             f'-composite',
+            # Add index text
+            *self.index_command,
             # Add title text
             ## Global font attributes
             f'-font "{self.font.resolve()}"',
-            f'-fill {self.font_color}',
+            f'-fill "{self.font_color}"',
             # Create an image for each title
             f'\( -background transparent',
             *self.subtitle_font_attributes,
@@ -162,7 +191,7 @@ class MoviePosterMaker(ImageMaker):
             f'-smush 30 \)',
             # Add titles to image
             f'-gravity south',
-            f'-geometry +0+{185 if len(self.subtitle) > 0 else 265}',
+            f'-geometry +0+{182.5 if len(self.subtitle) > 0 else 262.5}',
             f'-compose atop',
             f'-composite',
             f'"{self.output.resolve()}"',

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -403,7 +403,8 @@ class PlexInterface:
 
             # Skip temporary titles
             airdate = plex_episode.originallyAvailableAt
-            if (self.__TEMP_IGNORE_REGEX.match(plex_episode.title)
+            if (airdate is not None
+                and self.__TEMP_IGNORE_REGEX.match(plex_episode.title)
                 and airdate + timedelta(days=2) > datetime.now()):
                 log.debug(f'Temporarily ignoring '
                           f'{plex_episode.seasonEpisode.upper()} of '

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -427,7 +427,7 @@ class PlexInterface:
                 plex_episode.parentIndex,
                 plex_episode.index,
                 **ids,
-                title_match=False,
+                title_match=True,
                 queried_plex=True,
             )
 

--- a/modules/PlexInterface.py
+++ b/modules/PlexInterface.py
@@ -1,4 +1,6 @@
+from datetime import datetime, timedelta
 from pathlib import Path
+from re import IGNORECASE, compile as re_compile
 
 from plexapi.exceptions import PlexApiException
 from plexapi.server import PlexServer, NotFound, Unauthorized
@@ -27,6 +29,9 @@ class PlexInterface:
 
     """Default filesize limit for all uploaded assets"""
     DEFAULT_FILESIZE_LIMIT = '10 MB'
+
+    """Episode titles that indicate a placeholder and are to be ignored"""
+    __TEMP_IGNORE_REGEX = re_compile(r'^(tba|tbd|episode \d+)$', IGNORECASE)
 
 
     def __init__(self, database_directory: Path, url: str,
@@ -394,6 +399,15 @@ class PlexInterface:
                 or plex_episode.index is None):
                 log.warning(f'Episode {plex_episode} of {series_info} in '
                             f'"{library_name}" has no index - skipping')
+                continue
+
+            # Skip temporary titles
+            airdate = plex_episode.originallyAvailableAt
+            if (self.__TEMP_IGNORE_REGEX.match(plex_episode.title)
+                and airdate + timedelta(days=2) > datetime.now()):
+                log.debug(f'Temporarily ignoring '
+                          f'{plex_episode.seasonEpisode.upper()} of '
+                          f'{series_info} - placeholder title')
                 continue
 
             # Get all ID's for this episode

--- a/modules/PosterTitleCard.py
+++ b/modules/PosterTitleCard.py
@@ -165,18 +165,24 @@ class PosterTitleCard(BaseCardType):
         # Single command to create card
         command = ' '.join([
             f'convert',
-            f'"{self.source_file.resolve()}"',          # Resize source image
             # Resize and optionally blur source image
-            *self.resize_and_blur,
-            f'"{self.__GRADIENT_OVERLAY.resolve()}"',   # Add gradient overlay
-            f'-flatten',                                # Combine images
-            *logo_command,                              # Optionally add logo
-            f'-gravity south',                          # Add episode text
+            f'"{self.source_file.resolve()}"',
+            f'-resize "x1800"',
+            f'-extent "3200x1800"',
+            f'-blur {self.BLUR_PROFILE}' if self.blur else '',
+            # Add gradient overlay
+            f'"{self.__GRADIENT_OVERLAY.resolve()}"',
+            f'-flatten',
+            # Optionally add logo
+            *logo_command,
+            # Add episode text
+            f'-gravity south',
             f'-font "{self.TITLE_FONT}"',
             f'-pointsize 75',
             f'-fill "#FFFFFF"',
             f'-annotate +649+50 "{self.episode_text}"',
-            f'-gravity center',                         # Add title text
+            # Add title text
+            f'-gravity center',                         
             f'-pointsize 165',
             f'-interline-spacing -40', 
             f'-annotate +649+{title_offset} "{self.title}"',

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -63,7 +63,7 @@ class PreferenceParser(YamlReader):
             log.critical(f'Preference file missing required options/source '
                          f'attribute')
             exit(1)
-        self.source_directory = Path(TitleCard.sanitize_full_directory(value))
+        self.source_directory = TitleCard.sanitize_full_directory(value)
 
         # Setup default values that can be overwritten by YAML
         self.series_files = []

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -814,7 +814,7 @@ class PreferenceParser(YamlReader):
                     library_map,
                     font_map,
                 )
-
+                
                 # If returned YAML is None (invalid) skip series
                 if show_yaml is None:
                     log.error(f'Skipping "{show_name}" from "{file_}"')

--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -64,7 +64,7 @@ class PreferenceParser(YamlReader):
                          f'attribute')
             exit(1)
         self.source_directory = TitleCard.sanitize_full_directory(value)
-
+        
         # Setup default values that can be overwritten by YAML
         self.series_files = []
         self.execution_mode = Manager.DEFAULT_EXECUTION_MODE

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -331,8 +331,9 @@ class Profile:
         else:
             cased_title = self.font.case(title_text)
 
-        # Create translation table for this profile's replacements
-        translation = str.maketrans(self.font.replacements)
-
-        # Apply translation table to this text
-        return cased_title.translate(translation)
+        # Apply font replacements
+        replaced_title = cased_title
+        for old, new in self.font.replacements.items():
+            replaced_title = replaced_title.replace(old, new)
+            
+        return replaced_title

--- a/modules/Profile.py
+++ b/modules/Profile.py
@@ -126,7 +126,7 @@ class Profile:
 
         # If the new profile has a generic font, reset font attributes
         if not self.__use_custom_font:
-            self.font.set_default()
+            self.font.reset()
 
         # If the new profile has generic seasons, reset EpisodeMap
         if not self.__use_custom_seasons:

--- a/modules/SeasonPoster.py
+++ b/modules/SeasonPoster.py
@@ -1,4 +1,3 @@
-from cgitb import text
 from pathlib import Path
 
 from modules.Debug import log
@@ -23,9 +22,10 @@ class SeasonPoster(ImageMaker):
     """Paths for the gradient overlay"""
     GRADIENT_OVERLAY = REF_DIRECTORY / 'gradient.png'
 
-    __slots__ = ('source', 'destination', 'logo', 'season_text', 'font',
-                 'font_color', 'font_size', 'font_kerning', 'top_placement',
-                 'omit_gradient')
+    __slots__ = (
+        'source', 'destination', 'logo', 'season_text', 'font', 'font_color',
+        'font_size', 'font_kerning', 'top_placement', 'omit_gradient'
+    )
 
 
     def __init__(self, source: Path, logo: Path, destination: Path, 
@@ -140,19 +140,27 @@ class SeasonPoster(ImageMaker):
         command = ' '.join([
             f'convert',
             f'-density 300',
-            f'"{self.source.resolve()}"',           # Resize input image
-            f'-gravity center',                         # Crop around center
-            f'-resize "{self.SEASON_POSTER_SIZE}^"',    # Force into 2000x3000
+            # Resize input image
+            f'"{self.source.resolve()}"',
+            f'-gravity center',
+            f'-resize "{self.SEASON_POSTER_SIZE}^"',
             f'-extent "{self.SEASON_POSTER_SIZE}"',
-            *gradient_command,                      # Apply gradient
-            f'\( "{self.logo.resolve()}"',          # Add logo
-            f'-resize 1460x',                           # Fit to 1460px wide
-            f'-resize x750\> \)',                       # Limit to 750px tall
-            f'-gravity {merge_gravity}',                # Begin logo merge
+            # Apply gradient
+            *gradient_command,
+            # Overlay logo
+            f'\( "{self.logo.resolve()}"',
+            ## Fit to 1460px wide
+            f'-resize 1460x',
+            ## Limit to 750px tall
+            f'-resize x750\> \)',       
+            # Begin logo merge                
+            f'-gravity {merge_gravity}',
             f'-compose Atop',
-            f'-geometry +0{logo_offset}',               # Offset from top/bottom
-            f'-composite',                              # Merge images
-            f'-font "{self.font.resolve()}"',       # Write season text
+            f'-geometry +0{logo_offset}',
+            # Merge logo and source
+            f'-composite',
+            # Write season text
+            f'-font "{self.font.resolve()}"',
             f'-fill "{self.font_color}"',
             f'-pointsize {font_size}',
             f'-kerning {kerning}',

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -422,7 +422,7 @@ class Show(YamlReader):
             if (existing_ep := self.episodes.get(episode.key)) is not None:
                 if (self.refresh_titles and not
                     existing_ep.episode_info.title.matches(episode.title)):
-                    existing_ep.delete_card(reason='Updating title')
+                    existing_ep.delete_card(reason='updating title')
                     return True
                 return False
             
@@ -436,14 +436,7 @@ class Show(YamlReader):
         
         # If any new episodes remain, add to datafile and create Episode object
         self.file_interface.add_many_entries(new_episodes)
-        for episode_info in new_episodes:
-            self.episodes[episode_info.key] = Episode(
-                base_source=self.source_directory,
-                destination=self.__get_destination(episode_info),
-                card_class=self.card_class,
-                given_keys=set(),
-                episode_info=episode_info,
-            )
+        self.read_source()
 
 
     def set_episode_ids(self, sonarr_interface: 'TMDbInterface'=None,

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -198,7 +198,7 @@ class Show(YamlReader):
             self.media_directory = self.library / self.series_info.legal_path
 
         if (value := self._get('media_directory', type_=str)) is not None:
-            self.media_directory =Path(TitleCard.sanitize_full_directory(value))
+            self.media_directory = TitleCard.sanitize_full_directory(value)
 
         if (value := self._get('filename_format', type_=str)) is not None:
             if TitleCard.validate_card_format_string(value):

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -414,18 +414,20 @@ class Show(YamlReader):
 
         # Inner function to filter episodes
         def filter_ep(episode) -> bool:
-            # Filter out if a special and sync_specials is disabled
+            # Exclude special if special and not syncing specials
             if not self.sync_specials and episode.season_number == 0:
-                return True
+                return False
 
-            # Filter episode if refresh_titles and title doesn't match
-            if (self.refresh_titles
-                and (existing_ep := self.episodes.get(episode.key)) is not None
-                and not existing_ep.episode_info.title.matches(episode.title)):
-                existing_ep.delete_card(reason='Updating title')
-                return True
-
-            return False
+            # If episode is not new, include if title needs refreshed
+            if (existing_ep := self.episodes.get(episode.key)) is not None:
+                if (self.refresh_titles and not
+                    existing_ep.episode_info.title.matches(episode.title)):
+                    existing_ep.delete_card(reason='Updating title')
+                    return True
+                return False
+            
+            # New episode, include
+            return True
         
         # Apply filter formula to list of Episodes from data source
         new_episodes = tuple(filter(filter_ep, all_episodes))

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -713,7 +713,7 @@ class Show(YamlReader):
         download_backdrop = self.__apply_styles(plex_interface,
                                                 select_only=select_only)
 
-        # Don't download source if this card type doesn't use unique images
+        # Don't download sources if this card type doesn't use unique images
         if not self.card_class.USES_UNIQUE_SOURCES:
             return None
 
@@ -745,7 +745,7 @@ class Show(YamlReader):
                 )
                 check_tmdb = not blacklisted
             else:
-                check_tmdb, blacklisted = False, False
+                check_tmdb, blacklisted = False, not self.tmdb_sync
 
             # Check Plex if enabled, provided, and valid relative to TMDb
             if always_check_plex:

--- a/modules/SonarrInterface.py
+++ b/modules/SonarrInterface.py
@@ -236,8 +236,7 @@ class SonarrInterface(WebInterface):
         series_info.set_tvdb_id(ids['tvdb_id'])
 
 
-    def get_all_episodes(self, series_info: SeriesInfo,
-                         title_match: bool=False) -> list[EpisodeInfo]:
+    def get_all_episodes(self, series_info: SeriesInfo) -> list[EpisodeInfo]:
         """
         Gets all episode info for the given series. Only episodes that have 
         already aired are returned.
@@ -291,7 +290,7 @@ class SonarrInterface(WebInterface):
                 episode['episodeNumber'],
                 episode.get('absoluteEpisodeNumber'),
                 tvdb_id=episode.get('tvdbId'),
-                title_match=title_match,
+                title_match=True,
                 queried_sonarr=True,
             )
 
@@ -310,11 +309,11 @@ class SonarrInterface(WebInterface):
         
         Args:
             series_info: SeriesInfo for the entry.
-            infos: List of EpisodeInfo objects to update.
+            infos: List of EpisodeInfo objects to update. Not used.
         """
 
-        # Get all sonarr-created EpisodeInfo objects
-        self.get_all_episodes(series_info, True)
+        # Get all Sonarr-created EpisodeInfo objects
+        self.get_all_episodes(series_info)
 
 
     def list_all_series_id(self) -> None:

--- a/modules/TMDbInterface.py
+++ b/modules/TMDbInterface.py
@@ -784,7 +784,6 @@ class TMDbInterface(WebInterface):
         return None
 
 
-    @staticmethod
     def manually_download_season(self, title: str, year: int,season_number: int,
                                  episode_range: Iterable[int],
                                  directory: Path) -> None:

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -1,3 +1,4 @@
+from pathlib import Path, WindowsPath
 from re import match, sub, IGNORECASE
 
 from modules.Debug import log
@@ -111,7 +112,7 @@ class TitleCard:
 
 
     @staticmethod
-    def sanitize_full_directory(path: str) -> str:
+    def sanitize_full_directory(path: str) -> Path:
         """
         Sanitize the entire path and remove all invalid characters. This is
         different to sanitizing a name as '/' and '\' characters aren't
@@ -121,12 +122,16 @@ class TitleCard:
             path: Directory path (as a string) to sanitize.
 
         Returns:
-            Modified directory.
+            Modified directory instantiated as a Path object.
         """
 
         replacements = TitleCard.__ILLEGAL_CHARACTERS
 
-        return path.translate(str.maketrans(replacements))
+        # On windows don't replace colons
+        if isinstance(Path(path), WindowsPath):
+            replacements.pop(':', None)
+
+        return Path(path.translate(str.maketrans(replacements)))
 
 
     @staticmethod

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -131,11 +131,13 @@ class TitleCard:
         
         # On Windows, sanitize each part individually EXCEPT the root/drive
         if isinstance(path_, WindowsPath):
-            parts = (TitleCard.sanitize_name(part) for part in path_.parts[1:])
+            parts = (TitleCard.sanitize_name(part)
+                     for part in path_.resolve().parts[1:])
             return Path(path_.drive, *parts)
 
         # On Unix, sanitize all parts individually and re-join
-        return Path(*(TitleCard.sanitize_name(part) for part in path_.parts))
+        return Path(*(TitleCard.sanitize_name(part)
+                      for part in path_.resolve().parts))
 
 
     @staticmethod

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -131,8 +131,12 @@ class TitleCard:
         
         # On Windows, sanitize each part individually EXCEPT the root/drive
         if isinstance(path_, WindowsPath):
-            parts = (TitleCard.sanitize_name(part)
-                     for part in path_.resolve().parts[1:])
+            parts = path_.resolve().parts
+            # Skip drive to avoid bad colon replacement
+            if parts[0].startswith(path_.drive):
+                parts = parts[1:]
+
+            parts = (TitleCard.sanitize_name(part) for part in parts)
             return Path(path_.drive, *parts)
 
         # On Unix, sanitize all parts individually and re-join

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -128,11 +128,11 @@ class TitleCard:
 
         # Create Path object from this path
         path_ = Path(path)
-        if isinstance(path_, WindowsPath):
-            root = path_.drive
-        else:
-            root = path_.resolve().root
 
+        # Don't sanitize root (either drive or /)
+        root = path_.resolve().anchor
+
+        # Sanitize each part (folder) individually
         parts = (TitleCard.sanitize_name(part)
                  for part in path_.resolve().parts[1:])
         

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -128,20 +128,15 @@ class TitleCard:
 
         # Create Path object from this path
         path_ = Path(path)
-        
-        # On Windows, sanitize each part individually EXCEPT the root/drive
         if isinstance(path_, WindowsPath):
-            parts = path_.resolve().parts
-            # Skip drive to avoid bad colon replacement
-            if parts[0].startswith(path_.drive):
-                parts = parts[1:]
+            root = path_.drive
+        else:
+            root = path_.resolve().root
 
-            parts = (TitleCard.sanitize_name(part) for part in parts)
-            return Path(path_.drive, *parts)
-
-        # On Unix, sanitize all parts individually and re-join
-        return Path(*(TitleCard.sanitize_name(part)
-                      for part in path_.resolve().parts))
+        parts = (TitleCard.sanitize_name(part)
+                 for part in path_.resolve().parts[1:])
+        
+        return Path(root, *parts)
 
 
     @staticmethod


### PR DESCRIPTION
# Major Changes
- Ignore temporary (`TBA` / `Episode {x}`) titles when sourcing episode data from Plex
- Remake cards when a new title is detected (by default)
  - Manual titles (specified in the datafile) can be utilized if `refresh_titles: false` is added to a series (which disables title matching)
  - Closes #272
- Allow for >1 character replacements in custom fonts
- Add functionality to "correct" images with non-16:9 aspect ratios to `mini_maker.py`
  - Add `--ratio`/`--aspect-ratio`, `--ratio-batch`/`--aspect-ratio-batch`, and `--ratio-style`/`--aspect-ratio-style` arguments
  - Implement two "styles" of ratio correction - `copy` and `stretch`, for example:
    <img src="https://user-images.githubusercontent.com/17693271/193956464-662495eb-ab96-4c26-b637-6d0eb4bfb906.jpg" width="300"/> <img src="https://user-images.githubusercontent.com/17693271/193956512-bc49680b-be12-4489-ac63-21ea5eaf5738.jpg" width="300"/>
  - Closes #206 
# Major Fixes 
- Fix handling relative paths on Windows
- Faster Tautulli quick-updating
- Handle bounding box color with spaces in `LandscapeTitleCard`
- Properly identify and apply templates with keys in sub-lists (keys were being ignored) - for example:
    ```yaml
    test:
      card_type: landscape
      archive_variations:
      - archive_name: <<arch_name>>
         card_type: standard
    ```
- Correct source image resizing in `PosterTitleCard`
# Minor Changes
- Don't integrate with Tautulli during `--sync` run mode
- Create movie posters with index using `--movie-index`/`--movie-number` arguments - for example:
   <img src="https://user-images.githubusercontent.com/17693271/192935088-379842fd-89c8-4850-99bd-316836a1d4e0.jpg" height="350"/>
  - Closes #270 
- Add description of `mini_maker.py` features to main README
- Add `-tl` for shorthand of `--tautulli-list` and `-tf` for shorthand of `--tautulli-frequency`
# Minor Fixes
- Immediately check Plex for images if TMDb is disabled for a series and image source priorty of TMDb is higher than Plex
- Don't replace colons in paths on Windows systems
- Minor multiline-spacing and kerning adjustments on movie posters (better match for musikmann's typical style)
- Allow for movie posters with no titles
- Fix manual source image downloading with `fixer.py`
- Correctly specify wildcard profile in base image resizing