### PR TITLE
Fix for Windows mapped drive output.

### DIFF
--- a/modules/PreferenceParser.py
+++ b/modules/PreferenceParser.py
@@ -68,7 +68,7 @@ class PreferenceParser(YamlReader):
             log.critical(f'Preference file missing required options/source '
                          f'attribute')
             exit(1)
-        self.source_directory = TitleCard.sanitize_full_directory(value)
+        self.source_directory = TitleCard.sanitize_full_directory(True, value)
         
         # Setup default values that can be overwritten by YAML
         self.series_files = []

--- a/modules/Show.py
+++ b/modules/Show.py
@@ -215,7 +215,7 @@ class Show(YamlReader):
             self.media_directory = self.library / self.series_info.legal_path
 
         if (value := self._get('media_directory', type_=str)) is not None:
-            self.media_directory = TitleCard.sanitize_full_directory(value)
+            self.media_directory = TitleCard.sanitize_full_directory(False, value)
 
         if (value := self._get('filename_format', type_=str)) is not None:
             if TitleCard.validate_card_format_string(value):

--- a/modules/TitleCard.py
+++ b/modules/TitleCard.py
@@ -3,6 +3,7 @@ from re import match, sub, IGNORECASE
 
 from modules.Debug import log
 import modules.global_objects as global_objects
+import os
 
 # Default CardType classes
 from modules.AnimeTitleCard import AnimeTitleCard
@@ -114,7 +115,7 @@ class TitleCard:
 
 
     @staticmethod
-    def sanitize_full_directory(path: str) -> Path:
+    def sanitize_full_directory(prefs, path: str) -> Path:
         """
         Sanitize the entire path and remove all invalid characters. This is
         different to sanitizing a name as '/' and '\' characters aren't
@@ -130,13 +131,17 @@ class TitleCard:
         # Create Path object from this path
         path_ = Path(path)
 
+        # Set windows to true if running on Windows
+        windows = os.name == 'nt'
         # Don't sanitize root (either drive or /)
-        root = path_.resolve().anchor
-
+        root = path_.anchor if windows and not prefs else path_.resolve().anchor
         # Sanitize each part (folder) individually
-        parts = (TitleCard.sanitize_name(part)
+        if windows and not prefs:
+            parts = (TitleCard.sanitize_name(part)
+                 for part in path_.parts[1:])
+        else:
+            parts = (TitleCard.sanitize_name(part)
                  for part in path_.resolve().parts[1:])
-        
         return Path(root, *parts)
 
 


### PR DESCRIPTION
Fix for Windows mapped drive output.

Calling resolve() from pathlib results in converting a mapped drive to a UNC path.  Depending on how permissions are set up, this may cause issues. 