### PR TITLE
Disable tqdm progressbars if no TTY is present

### DIFF
--- a/modules/Debug.py
+++ b/modules/Debug.py
@@ -12,6 +12,8 @@ TQDM_KWARGS = {
                    '[{elapsed}]'),
     # Progress bars should disappear when finished
     'leave': False,
+    # Progress bars can not be used if no TTY is present
+    'disable': None,
 }
 
 """Log file"""


### PR DESCRIPTION
When running without TTY (FreeBSD cron for example) tqdm tries to paint the progress bars, resulting in a non clean exit, and thus TCM does not complete.
By disabling the tqdm progress bar when not attached to a TTY, it does complete.

There will be 0 change for when TCM is run from the CLI.