### PR TITLE
make dockerfile more cacheable

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -44,6 +44,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: python3 build cache for docker
+        uses: actions/cache@v4
+        with:
+          path: python-build-cache
+          key: ${{ runner.os }}-python-build-cache-${{ hashFiles('Pipfile.lock') }}
+
+      - name: inject python-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3 # v2.1.4
+        with:
+          cache-map: | 
+            { 
+              "python-build-cache" : "/root/.cache"
+            }
+
       # Build container
       - name: Build Container
         uses: docker/build-push-action@v5

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,18 +1,5 @@
 # syntax=docker/dockerfile:1
-# Create pipenv image to convert Pipfile to requirements.txt
-FROM python:3.11-slim as pipenv
-
-# Copy Pipfile and Pipfile.lock
-COPY Pipfile Pipfile.lock ./
-
-# Install pipenv and convert to requirements.txt
-RUN pip3 install --no-cache-dir --upgrade pipenv; \
-    pipenv requirements > requirements.txt
-
 FROM python:3.11-slim as python-reqs
-
-# Copy requirements.txt from pipenv stage
-COPY --from=pipenv /requirements.txt requirements.txt
 
 # Install dependencies for building python dependencies; install TCM dependencies
 # cffi: libffi-dev
@@ -27,43 +14,50 @@ RUN apt-get update && \
     apt-get install -y \
         build-essential curl libffi-dev libssl-dev pkg-config python3-dev python3-setuptools \
         libtiff5-dev libjpeg62-turbo-dev libopenjp2-7-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk libharfbuzz-dev libfribidi-dev libxcb1-dev
+RUN curl https://sh.rustup.rs | sh -s -- -y
 
-        RUN curl https://sh.rustup.rs | sh -s -- -y
-# add manual dockerfile cachine
+# Copy Pipfile and Pipfile.lock
+COPY Pipfile Pipfile.lock ./
+# Install pipenv and convert to requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pipenv; \
+    pipenv requirements > requirements.txt
+
+# add manual dockerfile caching
 RUN --mount=type=cache,target=/root/.cache \
     . "$HOME/.cargo/env" && \
     pip3 install -r requirements.txt
 
 # Set base image for running TCM
-FROM python:3.11-slim
+FROM python:3.11-slim AS final
 LABEL maintainer="CollinHeist" \
       description="Automated Title card maker for Emby, Jellyfin, and Plex" \
       version="v2.0-alpha.10.0"
+# Script environment variables
+ENV TCM_IS_DOCKER=TRUE \
+    TZ=UTC
+
+# Install static dependencies
+RUN \
+    # Create user and group to run TCM
+    set -eux && \
+    groupadd -g 314 titlecardmaker && \
+    useradd -u 314 -g 314 titlecardmaker
+# Install imagemagick and curl (for healthcheck)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl imagemagick libmagickcore-6.q16-6-extra && \
+    # Remove apt cache and setup files
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# Copy python packages from python-reqs
+COPY --from=python-reqs /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 
 # Set working directory, copy source into container
 WORKDIR /maker
 COPY . /maker
 
-# Copy python packages from python-reqs
-COPY --from=python-reqs /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-
-# Script environment variables
-ENV TCM_IS_DOCKER=TRUE \
-    TZ=UTC
-
 # Finalize setup
-RUN \
-    # Create user and group to run TCM
-    set -eux && \
+RUN cp modules/ref/policy.xml /etc/ImageMagick-6/policy.xml && \
     rm -f Pipfile Pipfile.lock && \
-    groupadd -g 314 titlecardmaker && \
-    useradd -u 314 -g 314 titlecardmaker && \
-    # Install imagemagick and curl (for healthcheck)
-    apt-get update && \
-    apt-get install -y --no-install-recommends curl imagemagick libmagickcore-6.q16-6-extra && \
-    cp modules/ref/policy.xml /etc/ImageMagick-6/policy.xml && \
-    # Remove apt cache and setup files
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 # Expose TCM Port
 EXPOSE 4242


### PR DESCRIPTION
- move "static" installation steps higher up to cache earlier
  - separate out "dynamic" apt install into a separate layer
  - add files last
- add python cache to non-arm build
- merge pipenv builder with python requirement builder