### PR TITLE
darken_color and shadow_color extra overrides are being ignored

### DIFF
--- a/modules/cards/LandscapeTitleCard.py
+++ b/modules/cards/LandscapeTitleCard.py
@@ -501,6 +501,8 @@ def get_validator_model() -> type[Base]:
         box_color: str | None = None
         box_width: PositiveInt = LandscapeTitleCard.BOX_WIDTH
         darken: DarkenOption = 'box'
+        darken_color: str = LandscapeTitleCard.DARKEN_COLOR
+        shadow_color: str = LandscapeTitleCard.SHADOW_COLOR
 
         @validator('box_adjustments')
         def parse_box_adjustments(cls, val: str) -> tuple[int, int, int, int]:


### PR DESCRIPTION
When setting a new darken_color or shadow_color the card will just use the default values since the extra colors are not being added to the model.

To reproduce: 
- Set card_type to landscape
- change Darken Color extra to anything other than default
- generate a new preview
- Darken Color will still be hex code: # 00000030

Same for shadow_color